### PR TITLE
stabilize jit closure capture and gc cadence

### DIFF
--- a/examples/spec/eventsource.js
+++ b/examples/spec/eventsource.js
@@ -1,30 +1,17 @@
 import { test, summary } from './helpers.js';
-import { spawn } from 'child_process';
+import { startServer } from './fixtures/server_ready.mjs';
 
 console.log('EventSource Tests\n');
 
 const port = 32188;
 const serverPath = new URL('./fixtures/eventsource_server.mjs', import.meta.url).pathname;
 
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function startServer(path) {
-  const child = spawn(process.execPath, [path, String(port)]);
-  child.on('stderr', data => {
-    if (String(data).trim()) console.log(String(data).trim());
-  });
-  return child;
-}
-
 test('EventSource global exists', typeof EventSource, 'function');
 test('EventSource CONNECTING constant', EventSource.CONNECTING, 0);
 test('EventSource OPEN constant', EventSource.OPEN, 1);
 test('EventSource CLOSED constant', EventSource.CLOSED, 2);
 
-const server = startServer(serverPath);
-await sleep(150);
+const server = await startServer(serverPath, port);
 
 const result = await new Promise(resolve => {
   const source = new EventSource(`http://127.0.0.1:${port}/events`, { withCredentials: true });

--- a/examples/spec/fixtures/server_ready.mjs
+++ b/examples/spec/fixtures/server_ready.mjs
@@ -1,0 +1,39 @@
+import { spawn } from 'child_process';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForHttpServer(port, { host = '127.0.0.1', timeoutMs = 1000, intervalMs = 5 } = {}) {
+  const deadline = performance.now() + timeoutMs;
+  let lastError = null;
+
+  while (performance.now() < deadline) {
+    try {
+      const response = await fetch(`http://${host}:${port}/__ant_spec_ready__`);
+      await response.text();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(intervalMs);
+    }
+  }
+
+  const detail = lastError && lastError.message ? `: ${lastError.message}` : '';
+  throw new Error(`Timed out waiting for fixture server on ${host}:${port}${detail}`);
+}
+
+export async function startServer(path, port, options) {
+  const child = spawn(process.execPath, [path, String(port)]);
+  child.on('stderr', data => {
+    if (String(data).trim()) console.log(String(data).trim());
+  });
+
+  try {
+    await waitForHttpServer(port, options);
+    return child;
+  } catch (error) {
+    child.kill('SIGTERM');
+    throw error;
+  }
+}

--- a/examples/spec/websocket.js
+++ b/examples/spec/websocket.js
@@ -1,22 +1,10 @@
 import { test, summary } from './helpers.js';
-import { spawn } from 'child_process';
+import { startServer } from './fixtures/server_ready.mjs';
 
 console.log('WebSocket Tests\n');
 
 const port = 32187;
 const serverPath = new URL('./fixtures/websocket_server.mjs', import.meta.url).pathname;
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function startServer(path) {
-  const child = spawn(process.execPath, [path, String(port)]);
-  child.on('stderr', data => {
-    if (String(data).trim()) console.log(String(data).trim());
-  });
-  return child;
-}
 
 test('WebSocket global exists', typeof WebSocket, 'function');
 test('WebSocket CONNECTING constant', WebSocket.CONNECTING, 0);
@@ -24,8 +12,7 @@ test('WebSocket OPEN constant', WebSocket.OPEN, 1);
 test('MessageEvent global exists', typeof MessageEvent, 'function');
 test('CloseEvent global exists', typeof CloseEvent, 'function');
 
-const server = startServer(serverPath);
-await sleep(150);
+const server = await startServer(serverPath, port);
 
 const result = await new Promise(resolve => {
   const seen = [];

--- a/include/gc.h
+++ b/include/gc.h
@@ -39,12 +39,12 @@ extern bool gc_disabled;
 gc_func_mark_profile_t gc_func_mark_profile_get(void);
 
 static inline void gc_write_barrier(ant_t *js, ant_object_t *writer_obj, ant_value_t new_val) {
-  if (writer_obj->generation != 1 || new_val <= NANBOX_PREFIX) return;
+  if (writer_obj->flags.generation != 1 || new_val <= NANBOX_PREFIX) return;
   uint8_t type = (new_val >> NANBOX_TYPE_SHIFT) & NANBOX_TYPE_MASK;
   if (type == T_FUNC) gc_remember_add(js, writer_obj);
   else if ((1u << type) & GC_OBJ_TYPE_MASK) {
     ant_object_t *ref = (ant_object_t *)(uintptr_t)(new_val & NANBOX_DATA_MASK);
-    if (ref && ref->generation == 0) gc_remember_add(js, writer_obj);
+    if (ref && ref->flags.generation == 0) gc_remember_add(js, writer_obj);
   }
 }
 

--- a/include/gc.h
+++ b/include/gc.h
@@ -28,7 +28,9 @@ typedef struct gc_func_mark_profile {
 void gc_run(ant_t *js);
 void gc_run_minor(ant_t *js);
 void gc_maybe(ant_t *js);
+
 void gc_remember_add(ant_t *js, ant_object_t *obj);
+void gc_remember_func_const(ant_t *js, sv_func_t *func, uint32_t slot, ant_value_t value);
 
 size_t gc_live_major_threshold(ant_t *js);
 size_t gc_pool_major_threshold(ant_t *js);

--- a/include/gc.h
+++ b/include/gc.h
@@ -9,6 +9,7 @@
 #define GC_NURSERY_THRESHOLD   32768
 #define GC_FORCE_INTERVAL_MS   50
 #define GC_MAJOR_EVERY_N_MINOR 8
+#define GC_POOL_PRESSURE_FLOOR (8u * 1024u * 1024u)
 
 #define GC_OBJ_TYPE_MASK (JS_TPFLG(T_OBJ) \
   | JS_TPFLG(T_ARR)                       \

--- a/include/internal.h
+++ b/include/internal.h
@@ -233,6 +233,14 @@ struct ant_isolate_t {
   size_t remember_set_len;
   size_t remember_set_cap;
 
+  struct {
+    sv_func_t *func;
+    uint32_t slot;
+  } *remembered_func_consts;
+  
+  size_t remembered_func_const_len;
+  size_t remembered_func_const_cap;
+
   #ifdef ANT_JIT
   uint32_t jit_active_depth;
   #endif

--- a/include/object.h
+++ b/include/object.h
@@ -93,6 +93,28 @@ _Static_assert(
   "object sidecar pointer uses low-bit tag"
 );
 
+typedef union ant_object_flags {
+  struct {
+    uint8_t extensible: 1;
+    uint8_t frozen: 1;
+    uint8_t sealed: 1;
+    uint8_t is_exotic: 1;
+    uint8_t is_constructor: 1;
+    uint8_t fast_array: 1;
+    uint8_t may_have_holes: 1;
+    uint8_t may_have_dense_elements: 1;
+    uint8_t gc_permanent: 1;
+    uint8_t generation: 1;
+    uint8_t in_remember_set: 1;
+  };
+  uint8_t bytes[2];
+} ant_object_flags_t;
+
+_Static_assert(
+  sizeof(ant_object_flags_t) == 2,
+  "ant_object_flags_t must cover the packed object bitfields"
+);
+
 typedef struct ant_prop_ref {
   ant_object_t *obj;
   uint32_t slot;
@@ -131,17 +153,7 @@ typedef struct ant_object {
   uint8_t extra_count;
   uint8_t overflow_cap;
 
-  uint8_t extensible: 1;
-  uint8_t frozen: 1;
-  uint8_t sealed: 1;
-  uint8_t is_exotic: 1;
-  uint8_t is_constructor: 1;
-  uint8_t fast_array: 1;
-  uint8_t may_have_holes: 1;
-  uint8_t may_have_dense_elements: 1;
-  uint8_t gc_permanent: 1;
-  uint8_t generation: 1;
-  uint8_t in_remember_set: 1;
+  ant_object_flags_t flags;
 } ant_object_t;
 
 static inline bool ant_object_has_sidecar(const ant_object_t *obj) {

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -386,6 +386,8 @@ struct sv_vm {
   struct {
     bool active;
     int64_t ip_offset;
+    ant_value_t *params;
+    int64_t n_params;
     ant_value_t *locals;
     int64_t n_locals;
     ant_value_t *vstack;
@@ -1255,7 +1257,7 @@ static inline ant_value_t sv_call_resolve_closure(
       uint32_t cc = ++fn->call_count;
       if (__builtin_expect(cc == SV_TFB_ALLOC_THRESHOLD, 0))
         sv_tfb_ensure(fn);
-      if (cc > SV_JIT_THRESHOLD) {
+      if (!fn->jit_compile_failed && cc > SV_JIT_THRESHOLD) {
         ant_value_t result = sv_jit_try_compile_and_call(vm, js, closure, callee_func, ctx, out_this);
         if (result != SV_JIT_RETRY_INTERP) return result;
       }

--- a/include/silver/glue.h
+++ b/include/silver/glue.h
@@ -101,20 +101,29 @@ ant_value_t jit_helper_get_field(
 ant_value_t jit_helper_closure(
   sv_vm_t *vm, ant_t *js, sv_closure_t *parent_closure,
   ant_value_t this_val, ant_value_t *slots,
-  int slot_base, int slot_count, uint32_t const_idx
+  int slot_base, int slot_count, uint32_t const_idx,
+  const char *name, uint32_t name_len,
+  sv_upvalue_t **open_upvalues
 );
 
 ant_value_t jit_helper_bailout_resume(
   sv_vm_t *vm, sv_closure_t *closure,
   ant_value_t this_val, ant_value_t *args, int argc,
   ant_value_t *vstack, int64_t vstack_sp,
+  ant_value_t *params, int64_t n_params,
   ant_value_t *locals, int64_t n_locals,
   int64_t bc_offset
 );
 
 void jit_helper_close_upval(
   sv_vm_t *vm, uint16_t slot_idx,
-  ant_value_t *locals, int n_locals
+  ant_value_t *locals, int n_locals,
+  sv_upvalue_t **open_upvalues
+);
+
+void jit_helper_adopt_open_upvalues(
+  sv_vm_t *vm,
+  sv_upvalue_t **open_upvalues
 );
 
 void jit_helper_define_field(

--- a/src/ant.c
+++ b/src/ant.c
@@ -17131,6 +17131,10 @@ void js_destroy(ant_t *js) {
   free(js->c_roots);
   js->c_roots = NULL;
   js->c_root_count = js->c_root_cap = 0;
+
+  free(js->remembered_func_consts);
+  js->remembered_func_consts = NULL;
+  js->remembered_func_const_len = js->remembered_func_const_cap = 0;
   
   free(js->pending_rejections.items);
   js->pending_rejections.items = NULL;

--- a/src/ant.c
+++ b/src/ant.c
@@ -3,7 +3,6 @@
 #endif
 
 #include <limits.h>
-
 #include <compat.h> // IWYU pragma: keep
 
 #include "ant.h"
@@ -241,7 +240,7 @@ ant_value_t js_obj_from_ptr(ant_object_t *obj) {
 
 void js_mark_constructor(ant_value_t value, bool is_constructor) {
   ant_object_t *obj = js_obj_ptr(value);
-  if (obj) obj->is_constructor = is_constructor ? 1u : 0u;
+  if (obj) obj->flags.is_constructor = is_constructor ? 1u : 0u;
 }
 
 static ant_value_t obj_extra_get(ant_object_t *obj, internal_slot_t slot) {
@@ -403,7 +402,7 @@ static ant_exotic_ops_t *obj_ensure_exotic_ops(ant_object_t *obj) {
 
 static ant_object_t *obj_alloc(ant_t *js, uint8_t type_tag, uint8_t inobj_limit) {
   size_t threshold = gc_live_major_threshold(js);
-  if (js->obj_arena.live_count >= threshold) gc_run(js);
+  if (js->obj_arena.live_count >= threshold) gc_maybe(js);
 
   ant_object_t *obj = (ant_object_t *)fixed_arena_alloc(&js->obj_arena);
   if (!obj) return NULL;
@@ -439,17 +438,17 @@ static ant_object_t *obj_alloc(ant_t *js, uint8_t type_tag, uint8_t inobj_limit)
   obj->native.tag = 0;
   
   obj->mark_epoch = 0;
-  obj->extensible = 1;
-  obj->frozen = 0;
-  obj->sealed = 0;
-  obj->is_exotic = 0;
-  obj->is_constructor = 0;
-  obj->fast_array = 0;
-  obj->may_have_holes = 0;
-  obj->may_have_dense_elements = 0;
-  obj->gc_permanent = 0;
-  obj->generation = 0;
-  obj->in_remember_set = 0;
+  obj->flags.extensible = 1;
+  obj->flags.frozen = 0;
+  obj->flags.sealed = 0;
+  obj->flags.is_exotic = 0;
+  obj->flags.is_constructor = 0;
+  obj->flags.fast_array = 0;
+  obj->flags.may_have_holes = 0;
+  obj->flags.may_have_dense_elements = 0;
+  obj->flags.gc_permanent = 0;
+  obj->flags.generation = 0;
+  obj->flags.in_remember_set = 0;
 
   obj->next = js->objects;
   js->objects = obj;
@@ -502,24 +501,28 @@ ant_value_t js_obj_to_func_ex(ant_value_t obj, uint8_t flags) {
   sv_closure_t *closure = js_closure_alloc(js);
   if (!closure) return mkval(T_ERR, 0);
   
+  closure->func = NULL;
+  closure->upvalues = NULL;
   closure->func_obj = (vtype(obj) == T_OBJ) ? obj : mkval(T_OBJ, vdata(obj));
   closure->bound_this = js_mkundef();
+  closure->bound_argv = NULL;
+  closure->bound_argc = 0;
   closure->bound_args = js_mkundef();
   closure->super_val = js_mkundef();
   closure->call_flags = flags;
   
   ant_object_t *func_obj = js_obj_ptr(closure->func_obj);
   if (func_obj) {
-    if (flags & SV_CALL_IS_DEFAULT_CTOR) func_obj->is_constructor = 1;
+    if (flags & SV_CALL_IS_DEFAULT_CTOR) func_obj->flags.is_constructor = 1;
     // mark native function objects as constructors when they are
     // created with an explicit .prototype own property.
     else if (
-      !func_obj->is_constructor &&
+      !func_obj->flags.is_constructor &&
       func_obj->shape &&
       js->intern.prototype &&
       vtype(obj_extra_get(func_obj, SLOT_CFUNC)) == T_CFUNC
     ) if (ant_shape_lookup_interned(func_obj->shape, js->intern.prototype) >= 0
-    ) func_obj->is_constructor = 1;
+    ) func_obj->flags.is_constructor = 1;
   }
   
   return mkval(T_FUNC, (uintptr_t)closure);
@@ -960,17 +963,17 @@ static inline ant_object_t *array_obj_ptr(ant_value_t obj) {
 
 static inline bool array_may_have_holes(ant_value_t obj) {
   ant_object_t *ptr = array_obj_ptr(obj);
-  return ptr ? ptr->may_have_holes : true;
+  return ptr ? ptr->flags.may_have_holes : true;
 }
 
 static inline bool array_may_have_dense_elements(ant_value_t obj) {
   ant_object_t *ptr = array_obj_ptr(obj);
-  return ptr ? ptr->may_have_dense_elements : true;
+  return ptr ? ptr->flags.may_have_dense_elements : true;
 }
 
 static inline void array_mark_may_have_holes(ant_value_t obj) {
   ant_object_t *ptr = array_obj_ptr(obj);
-  if (ptr) ptr->may_have_holes = 1;
+  if (ptr) ptr->flags.may_have_holes = 1;
 }
 
 static inline void array_define_or_set_index(ant_t *js, ant_value_t obj, const char *key, size_t klen) {
@@ -1221,7 +1224,7 @@ static bool is_small_object(ant_t *js, ant_value_t obj, int *prop_count) {
     }
   }
   
-  if (ptr && ptr->is_exotic) {
+  if (ptr && ptr->flags.is_exotic) {
     descriptor_entry_t *desc, *tmp;
     HASH_ITER(hh, desc_registry, desc, tmp) {
       if (desc->obj_off != obj_off) continue;
@@ -1578,7 +1581,7 @@ bool js_inspect_object_body(js_inspect_builder_t *builder, ant_value_t obj) {
       ant_offset_t sym_off = prop->key.sym_off;
       if (vtype(tag_sym) == T_SYMBOL && sym_off == (ant_offset_t)vdata(tag_sym)) continue;
       
-      if (ptr && ptr->is_exotic) {
+      if (ptr && ptr->flags.is_exotic) {
         prop_meta_t meta;
         if (lookup_symbol_prop_meta(as_obj, sym_off, &meta) && !meta.enumerable) continue;
       }
@@ -1597,7 +1600,7 @@ bool js_inspect_object_body(js_inspect_builder_t *builder, ant_value_t obj) {
 
     const char *key = prop->key.interned;
     ant_offset_t klen = (ant_offset_t)strlen(key);
-    if (ptr && ptr->is_exotic) {
+    if (ptr && ptr->flags.is_exotic) {
       prop_meta_t meta;
       if (lookup_string_prop_meta(js, as_obj, key, (size_t)klen, &meta) && !meta.enumerable) continue;
     }
@@ -1641,7 +1644,7 @@ bool js_inspect_object_body(js_inspect_builder_t *builder, ant_value_t obj) {
     }
   }
 
-  if (ptr && ptr->is_exotic) {
+  if (ptr && ptr->flags.is_exotic) {
     descriptor_entry_t *desc, *tmp;
     HASH_ITER(hh, desc_registry, desc, tmp) {
       if (desc->obj_off != obj_off) continue;
@@ -2622,14 +2625,14 @@ const char *js_str(ant_t *js, ant_value_t value) {
 
 static inline ant_offset_t get_dense_buf(ant_value_t arr) {
   ant_object_t *ptr = js_obj_ptr(js_as_obj(arr));
-  if (!ptr || !ptr->fast_array || !ptr->u.array.data || ptr->u.array.cap == 0) return 0;
+  if (!ptr || !ptr->flags.fast_array || !ptr->u.array.data || ptr->u.array.cap == 0) return 0;
   return (ant_offset_t)(uintptr_t)ptr;
 }
 
 static inline ant_object_t *dense_obj(ant_offset_t doff) {
   if (!doff) return NULL;
   ant_object_t *ptr = (ant_object_t *)(uintptr_t)doff;
-  if (!ptr || !ptr->fast_array || !ptr->u.array.data || ptr->u.array.cap == 0) return NULL;
+  if (!ptr || !ptr->flags.fast_array || !ptr->u.array.data || ptr->u.array.cap == 0) return NULL;
   return ptr;
 }
 
@@ -2653,7 +2656,7 @@ static inline void dense_set(ant_t *js, ant_offset_t doff, ant_offset_t idx, ant
   ant_object_t *ptr = dense_obj(doff);
   if (!ptr || idx >= ptr->u.array.cap) return;
   ptr->u.array.data[idx] = val;
-  if (!is_empty_slot(val)) ptr->may_have_dense_elements = 1;
+  if (!is_empty_slot(val)) ptr->flags.may_have_dense_elements = 1;
   gc_write_barrier(js, ptr, val);
 }
 
@@ -2672,7 +2675,7 @@ static ant_offset_t dense_grow(ant_t *js, ant_value_t arr, ant_offset_t needed) 
 
   obj->u.array.data = next;
   obj->u.array.cap = (uint32_t)new_cap;
-  obj->fast_array = 1;
+  obj->flags.fast_array = 1;
   return (ant_offset_t)(uintptr_t)obj;
 }
 
@@ -3067,15 +3070,15 @@ static ant_value_t alloc_array_with_proto(ant_t *js, ant_value_t proto) {
   
   if (obj->u.array.data) {
     for (uint32_t i = 0; i < obj->u.array.cap; i++) obj->u.array.data[i] = T_EMPTY;
-    obj->fast_array = 1;
-    obj->may_have_holes = 0;
-    obj->may_have_dense_elements = 0;
+    obj->flags.fast_array = 1;
+    obj->flags.may_have_holes = 0;
+    obj->flags.may_have_dense_elements = 0;
   } else {
     obj->u.array.cap = 0;
     obj->u.array.len = 0;
-    obj->fast_array = 0;
-    obj->may_have_holes = 1;
-    obj->may_have_dense_elements = 1;
+    obj->flags.fast_array = 0;
+    obj->flags.may_have_holes = 1;
+    obj->flags.may_have_dense_elements = 1;
   }
 
   return arr;
@@ -3673,19 +3676,19 @@ static inline ant_value_t check_object_extensibility(ant_t *js, ant_value_t obj)
   ant_object_t *ptr = js_obj_ptr(obj);
   if (!ptr) return js_mkundef();
 
-  if (ptr->frozen) {
+  if (ptr->flags.frozen) {
     return sv_is_strict_context(js)
       ? js_mkerr(js, "cannot add property to frozen object")
       : js_false;
   }
 
-  if (ptr->sealed) {
+  if (ptr->flags.sealed) {
     return sv_is_strict_context(js)
       ? js_mkerr(js, "cannot add property to sealed object")
       : js_false;
   }
 
-  if (!ptr->extensible) {
+  if (!ptr->flags.extensible) {
     return sv_is_strict_context(js)
       ? js_mkerr(js, "cannot add property to non-extensible object")
       : js_false;
@@ -3821,7 +3824,7 @@ bool lookup_prop_meta(
     }
   }
 
-  if (!cur_ptr->is_exotic) return false;
+  if (!cur_ptr->flags.is_exotic) return false;
 
   descriptor_entry_t *desc = NULL;
   if (key_kind == PROP_META_SYMBOL) {
@@ -4058,7 +4061,7 @@ ant_value_t js_setprop(ant_t *js, ant_value_t obj, ant_value_t k, ant_value_t v)
         }
       }
 
-      if (!found_here && cur_ptr->is_exotic) {
+      if (!found_here && cur_ptr->flags.is_exotic) {
         descriptor_entry_t *desc = lookup_descriptor(cur_obj, key, klen);
         if (desc) {
           found_here = true;
@@ -4174,7 +4177,7 @@ ant_value_t js_define_own_prop(ant_t *js, ant_value_t obj, const char *key, size
       }
     }
 
-    if (!has_desc && ptr && ptr->is_exotic) {
+    if (!has_desc && ptr && ptr->flags.is_exotic) {
       descriptor_entry_t *desc = lookup_descriptor(as_obj, key, klen);
       if (desc) {
         has_desc = true;
@@ -4464,7 +4467,7 @@ static uintptr_t lkp_with_getter(ant_t *js, ant_value_t obj, const char *buf, si
       }
     }
 
-    if (ptr && ptr->is_exotic) {
+    if (ptr && ptr->flags.is_exotic) {
       descriptor_entry_t *desc = lookup_descriptor(current, buf, len);
       if (desc && desc->has_getter) {
         *getter_out = desc->getter;
@@ -4508,7 +4511,7 @@ static uintptr_t lkp_with_setter(ant_t *js, ant_value_t obj, const char *buf, si
       }
     }
 
-    if (ptr && ptr->is_exotic) {
+    if (ptr && ptr->flags.is_exotic) {
       descriptor_entry_t *desc = lookup_descriptor(current, buf, len);
       if (desc && desc->has_setter) {
         *setter_out = desc->setter;
@@ -4708,21 +4711,21 @@ static ant_value_t getprop_any(ant_t *js, ant_value_t obj, const char *key, size
 
 static ant_value_t try_dynamic_getter(ant_t *js, ant_value_t obj, const char *key, size_t key_len) {
   ant_object_t *ptr = js_obj_ptr(js_as_obj(obj));
-  if (!ptr || !ptr->is_exotic) return js_mkundef();
+  if (!ptr || !ptr->flags.is_exotic) return js_mkundef();
   if (!ptr->exotic_ops || !ptr->exotic_ops->getter) return js_mkundef();
   return ptr->exotic_ops->getter(js, obj, key, key_len);
 }
 
 static bool try_dynamic_setter(ant_t *js, ant_value_t obj, const char *key, size_t key_len, ant_value_t value) {
   ant_object_t *ptr = js_obj_ptr(js_as_obj(obj));
-  if (!ptr || !ptr->is_exotic) return false;
+  if (!ptr || !ptr->flags.is_exotic) return false;
   if (!ptr->exotic_ops || !ptr->exotic_ops->setter) return false;
   return ptr->exotic_ops->setter(js, obj, key, key_len, value);
 }
 
 static bool try_dynamic_deleter(ant_t *js, ant_value_t obj, const char *key, size_t key_len) {
   ant_object_t *ptr = js_obj_ptr(js_as_obj(obj));
-  if (!ptr || !ptr->is_exotic) return false;
+  if (!ptr || !ptr->flags.is_exotic) return false;
   if (!ptr->exotic_ops || !ptr->exotic_ops->deleter) return false;
   return ptr->exotic_ops->deleter(js, obj, key, key_len);
 }
@@ -5136,11 +5139,11 @@ static ant_value_t check_frozen_sealed(ant_t *js, ant_value_t obj, const char *a
   ant_object_t *ptr = js_obj_ptr(js_as_obj(obj));
   if (!ptr) return js_mkundef();
 
-  if (ptr->frozen) {
+  if (ptr->flags.frozen) {
     if (sv_is_strict_context(js)) return js_mkerr(js, "cannot %s property of frozen object", action);
     return js_false;
   }
-  if (ptr->sealed) {
+  if (ptr->flags.sealed) {
     if (sv_is_strict_context(js)) return js_mkerr(js, "cannot %s property of sealed object", action);
     return js_false;
   }
@@ -5198,7 +5201,7 @@ ant_value_t js_delete_prop(ant_t *js, ant_value_t obj, const char *key, size_t l
     return js_false;
   }
 
-  if (ptr->is_exotic) {
+  if (ptr->flags.is_exotic) {
     descriptor_entry_t *desc = lookup_descriptor(obj, key, len);
     if (desc && !desc->configurable) {
       if (sv_is_strict_context(js)) return js_mkerr_typed(js, JS_ERR_TYPE, "cannot delete non-configurable property");
@@ -6674,7 +6677,7 @@ static ant_value_t object_enum(ant_t *js, ant_value_t obj, enum obj_enum_mode mo
 
   ant_object_t *ptr = js_obj_ptr(obj);
   if (!ptr || !ptr->shape) return mkarr(js);
-  if (ptr->is_exotic && ptr->exotic_keys) {
+  if (ptr->flags.is_exotic && ptr->exotic_keys) {
     if (mode == OBJ_ENUM_KEYS) return ptr->exotic_keys(js, obj);
     if (ptr->exotic_ops && ptr->exotic_ops->getter) {
       dynamic_kv_mapper_fn mapper = (mode == OBJ_ENUM_ENTRIES) ? map_to_entry : NULL;
@@ -6722,7 +6725,7 @@ static ant_value_t object_enum(ant_t *js, ant_value_t obj, enum obj_enum_mode mo
     }}
     
     bool should_include = (ant_shape_get_attrs(ptr->shape, i) & ANT_PROP_ATTR_ENUMERABLE) != 0;
-    if (should_include && ptr->is_exotic) {
+    if (should_include && ptr->flags.is_exotic) {
       descriptor_entry_t *desc = lookup_descriptor(js_as_obj(obj), key, (size_t)klen);
       if (desc) should_include = desc->enumerable;
     }
@@ -6806,7 +6809,7 @@ static bool own_key_is_enumerable(ant_t *js, ant_value_t obj, ant_object_t *ptr,
     return enumerable;
   }
 
-  if (ptr->is_exotic) {
+  if (ptr->flags.is_exotic) {
     descriptor_entry_t *desc = lookup_descriptor(js_as_obj(obj), prop->key.interned, strlen(prop->key.interned));
     if (desc) enumerable = desc->enumerable;
   }
@@ -6831,7 +6834,7 @@ ant_value_t js_own_property_keys(ant_t *js, ant_value_t obj, bool include_symbol
   ant_object_t *ptr = js_obj_ptr(obj);
   if (!ptr || !ptr->shape) goto done;
 
-  if (ptr->is_exotic && ptr->exotic_keys && !include_symbols) {
+  if (ptr->flags.is_exotic && ptr->exotic_keys && !include_symbols) {
     ant_value_t keys = ptr->exotic_keys(js, obj);
     GC_ROOT_RESTORE(js, root_mark);
     return keys;
@@ -7542,7 +7545,7 @@ static inline ant_value_t for_in_keys_collect_chain(
     ant_value_t key, r, proto;
     
     if (!cur_ptr) goto next_proto;
-    if (!cur_ptr->is_exotic || !cur_ptr->exotic_keys) goto shape_props;
+    if (!cur_ptr->flags.is_exotic || !cur_ptr->exotic_keys) goto shape_props;
 
     {
       ant_value_t ekeys = cur_ptr->exotic_keys(js, as_cur);
@@ -8314,11 +8317,11 @@ static ant_value_t builtin_object_defineProperty(ant_t *js, ant_value_t *args, i
   ant_object_t *obj_ptr = js_obj_ptr(as_obj);
   
   if (!has_existing_prop) {
-    if (obj_ptr && obj_ptr->frozen)
+    if (obj_ptr && obj_ptr->flags.frozen)
       return js_mkerr(js, "Cannot define property %.*s, object is not extensible", (int)prop_len, prop_str);
-    if (obj_ptr && obj_ptr->sealed)
+    if (obj_ptr && obj_ptr->flags.sealed)
       return js_mkerr(js, "Cannot define property %.*s, object is not extensible", (int)prop_len, prop_str);
-    if (obj_ptr && !obj_ptr->extensible)
+    if (obj_ptr && !obj_ptr->flags.extensible)
       return js_mkerr(js, "Cannot define property %.*s, object is not extensible", (int)prop_len, prop_str);
   }
   
@@ -8335,11 +8338,11 @@ static ant_value_t builtin_object_defineProperty(ant_t *js, ant_value_t *args, i
     bool existing_nonconfig =
       (has_existing_meta && !existing_meta.configurable) ||
       (existing_off > 0 && is_nonconfig_prop(js, existing_off)) ||
-      (obj_ptr && (obj_ptr->sealed || obj_ptr->frozen));
+      (obj_ptr && (obj_ptr->flags.sealed || obj_ptr->flags.frozen));
     bool existing_readonly =
       (has_existing_meta && !existing_accessor && !existing_meta.writable) ||
       (existing_off > 0 && is_const_prop(js, existing_off)) ||
-      (obj_ptr && obj_ptr->frozen);
+      (obj_ptr && obj_ptr->flags.frozen);
     if (existing_nonconfig) {
       if (has_configurable && configurable) return js_mkerr(js,
         "Cannot redefine property %.*s: cannot change configurable from false to true",
@@ -8456,7 +8459,7 @@ static ant_value_t builtin_object_defineProperty(ant_t *js, ant_value_t *args, i
     if (configurable) attrs |= ANT_PROP_ATTR_CONFIGURABLE;
 
     if (existing_off > 0) {
-      bool is_frozen = obj_ptr ? obj_ptr->frozen : false;
+      bool is_frozen = obj_ptr ? obj_ptr->flags.frozen : false;
       bool is_nonconfig = is_nonconfig_prop(js, existing_off) || is_frozen;
       bool is_readonly = is_const_prop(js, existing_off) || is_frozen;
       
@@ -8662,7 +8665,7 @@ bool js_is_own_enumerable_prop(
   if (!key) return false;
 
   if (key->is_symbol) {
-    if (!source_ptr || source_ptr->is_exotic) {
+    if (!source_ptr || source_ptr->flags.is_exotic) {
       prop_meta_t meta;
       return !lookup_symbol_prop_meta(js_as_obj(source), key->sym_off, &meta) || meta.enumerable;
     }
@@ -8671,7 +8674,7 @@ bool js_is_own_enumerable_prop(
 
   if (!key->str) return false;
 
-  if (!source_ptr || source_ptr->is_exotic) {
+  if (!source_ptr || source_ptr->flags.is_exotic) {
     descriptor_entry_t *desc = lookup_descriptor(js_as_obj(source), key->str, key->key_len);
     return !desc || desc->enumerable;
   }
@@ -8704,7 +8707,7 @@ static ant_value_t object_assign_copy_slot(
     ant_object_t *target_ptr = js_obj_ptr(js_as_obj(target));
     if (
       existing == 0 && !has_setter && target_ptr &&
-      target_ptr->extensible && !target_ptr->frozen && !target_ptr->sealed && !target_ptr->is_exotic
+      target_ptr->flags.extensible && !target_ptr->flags.frozen && !target_ptr->flags.sealed && !target_ptr->flags.is_exotic
     ) {
       const char *interned = intern_string(key, key_len);
       ant_value_t result = interned
@@ -8734,7 +8737,7 @@ static ant_value_t object_assign_fast_ordinary_source(
     *handled = true;
     return js_mkundef();
   }
-  if (source_ptr->is_exotic) return js_mkundef();
+  if (source_ptr->flags.is_exotic) return js_mkundef();
 
   uint32_t count = ant_shape_count(source_ptr->shape);
   own_index_key_t stack_indices[32];
@@ -8974,7 +8977,7 @@ ant_value_t builtin_object_freeze(ant_t *js, ant_value_t *args, int nargs) {
     } else ant_shape_set_attrs_symbol(ptr->shape, prop->key.sym_off, attrs);
   }
   
-  ptr->frozen = 1;
+  ptr->flags.frozen = 1;
   return obj;
 }
 
@@ -8989,7 +8992,7 @@ static ant_value_t builtin_object_isFrozen(ant_t *js, ant_value_t *args, int nar
   if (is_proxy(as_obj)) return proxy_test_integrity_level(js, as_obj, true);
   
   ant_object_t *ptr = js_obj_ptr(as_obj);
-  return js_bool(ptr && ptr->frozen);
+  return js_bool(ptr && ptr->flags.frozen);
 }
 
 static ant_value_t builtin_object_seal(ant_t *js, ant_value_t *args, int nargs) {
@@ -9005,7 +9008,7 @@ static ant_value_t builtin_object_seal(ant_t *js, ant_value_t *args, int nargs) 
   ant_object_t *ptr = js_obj_ptr(as_obj);
   if (!ptr || !ptr->shape) return obj;
   if (!js_obj_ensure_unique_shape(ptr)) return js_mkerr(js, "oom");
-  ptr->sealed = 1;
+  ptr->flags.sealed = 1;
 
   uint32_t count = ant_shape_count(ptr->shape);
   for (uint32_t i = 0; i < count; i++) {
@@ -9037,7 +9040,7 @@ static ant_value_t builtin_object_isSealed(ant_t *js, ant_value_t *args, int nar
   if (is_proxy(as_obj)) return proxy_test_integrity_level(js, as_obj, false);
   
   ant_object_t *ptr = js_obj_ptr(as_obj);
-  if (ptr && (ptr->sealed || ptr->frozen)) return js_true;
+  if (ptr && (ptr->flags.sealed || ptr->flags.frozen)) return js_true;
   
   return js_false;
 }
@@ -9450,8 +9453,8 @@ static ant_value_t builtin_object_isExtensible(ant_t *js, ant_value_t *args, int
   
   ant_object_t *ptr = js_obj_ptr(as_obj);
   if (!ptr) return js_true;
-  if (ptr->frozen || ptr->sealed) return js_false;
-  return js_bool(ptr->extensible);
+  if (ptr->flags.frozen || ptr->flags.sealed) return js_false;
+  return js_bool(ptr->flags.extensible);
 }
 
 static ant_value_t builtin_object_preventExtensions(ant_t *js, ant_value_t *args, int nargs) {
@@ -9471,7 +9474,7 @@ static ant_value_t builtin_object_preventExtensions(ant_t *js, ant_value_t *args
   }
   
   ant_object_t *ptr = js_obj_ptr(as_obj);
-  if (ptr) ptr->extensible = 0;
+  if (ptr) ptr->flags.extensible = 0;
   return obj;
 }
 
@@ -9537,7 +9540,7 @@ static ant_value_t builtin_object_hasOwnProperty(ant_t *js, ant_value_t *args, i
   ant_offset_t off = lkp(js, as_obj, key_str, key_len);
   if (off != 0) return mkval(T_BOOL, 1);
   ant_object_t *ptr = js_obj_ptr(as_obj);
-  if (ptr && ptr->is_exotic) {
+  if (ptr && ptr->flags.is_exotic) {
     descriptor_entry_t *desc = lookup_descriptor(as_obj, key_str, key_len);
     return mkval(T_BOOL, (desc && (desc->has_getter || desc->has_setter)) ? 1 : 0);
   }
@@ -9607,13 +9610,13 @@ static ant_value_t builtin_object_propertyIsEnumerable(ant_t *js, ant_value_t *a
   if (off == 0) return mkval(T_BOOL, 0);
 
   const ant_shape_prop_t *prop_meta = prop_shape_meta(js, off);
-  if (prop_meta && !js_obj_ptr(as_obj)->is_exotic) {
+  if (prop_meta && !js_obj_ptr(as_obj)->flags.is_exotic) {
     bool enumerable = (prop_meta->attrs & ANT_PROP_ATTR_ENUMERABLE) != 0;
     return mkval(T_BOOL, enumerable ? 1 : 0);
   }
 
   ant_object_t *ptr = js_obj_ptr(as_obj);
-  if (ptr && ptr->is_exotic) {
+  if (ptr && ptr->flags.is_exotic) {
     prop_meta_t meta;
     if (lookup_string_prop_meta(js, as_obj, key_str, (size_t)key_len, &meta))
       return mkval(T_BOOL, meta.enumerable ? 1 : 0);
@@ -10168,7 +10171,7 @@ static bool array_includes_object_may_have_indexed_props(
   ant_value_t as_obj = (vtype(obj) == T_FUNC) ? js_func_obj(obj) : obj;
   ant_object_t *ptr = js_obj_ptr(as_obj);
   if (!ptr) return false;
-  if (ptr->is_exotic) return true;
+  if (ptr->flags.is_exotic) return true;
 
   if (include_dense && vtype(as_obj) == T_ARR) {
     ant_offset_t doff = get_dense_buf(as_obj);
@@ -15227,7 +15230,7 @@ ant_value_t do_instanceof(ant_t *js, ant_value_t l, ant_value_t r) {
     if (func_proto_ptr && func_proto_ptr->shape &&
         ant_shape_lookup_symbol(func_proto_ptr->shape, has_instance_sym_off) >= 0) {
       use_slow_has_instance = true;
-    } else if (func_proto_ptr && func_proto_ptr->is_exotic) {
+    } else if (func_proto_ptr && func_proto_ptr->flags.is_exotic) {
       ant_value_t func_proto_obj = mkval(T_OBJ, (uintptr_t)func_proto_ptr);
       if (lookup_sym_descriptor(func_proto_obj, has_instance_sym_off))
         use_slow_has_instance = true;
@@ -15664,7 +15667,7 @@ static ant_proxy_state_t *get_proxy_data(ant_value_t obj) {
 
 bool is_proxy(ant_value_t obj) {
   ant_object_t *ptr = js_obj_ptr(obj);
-  if (!ptr || !ptr->is_exotic) return false;
+  if (!ptr || !ptr->flags.is_exotic) return false;
   return get_proxy_data(obj) != NULL;
 }
 
@@ -15696,14 +15699,14 @@ bool js_is_constructor(ant_value_t value) {
     uint8_t t = vtype(slow);
     if (t == T_FUNC) {
       ant_object_t *obj = js_obj_ptr(js_func_obj(slow));
-      return obj && obj->is_constructor;
+      return obj && obj->flags.is_constructor;
     }
     if (t != T_OBJ) return false;
 
     ant_object_t *obj = js_obj_ptr(slow);
     if (!obj) return false;
-    if (obj->is_constructor) return true;
-    if (!obj->is_exotic) return false;
+    if (obj->flags.is_constructor) return true;
+    if (!obj->flags.is_exotic) return false;
 
     ant_proxy_state_t *data = get_proxy_data(slow);
     if (!data) return false;
@@ -15712,7 +15715,7 @@ bool js_is_constructor(ant_value_t value) {
     for (int i = 0; i < 2; i++) {
       if (vtype(fast) != T_OBJ) { fast = js_mknull(); break; }
       ant_object_t *fobj = js_obj_ptr(fast);
-      if (!fobj || !fobj->is_exotic) { fast = js_mknull(); break; }
+      if (!fobj || !fobj->flags.is_exotic) { fast = js_mknull(); break; }
       ant_proxy_state_t *fdata = get_proxy_data(fast);
       if (!fdata) { fast = js_mknull(); break; }
       fast = fdata->target;
@@ -15795,8 +15798,8 @@ static bool proxy_target_is_extensible(ant_value_t obj) {
 
   ant_object_t *ptr = js_obj_ptr(js_as_obj(obj));
   if (!ptr) return false;
-  if (ptr->frozen || ptr->sealed) return false;
-  return ptr->extensible != 0;
+  if (ptr->flags.frozen || ptr->flags.sealed) return false;
+  return ptr->flags.extensible != 0;
 }
 
 static bool proxy_target_prop_is_nonconfig(ant_t *js, ant_value_t target, ant_offset_t prop_off) {
@@ -16218,7 +16221,7 @@ static ant_value_t proxy_prevent_extensions(ant_t *js, ant_value_t proxy) {
   }
 
   ant_object_t *ptr = js_obj_ptr(js_as_obj(target));
-  if (ptr) ptr->extensible = 0;
+  if (ptr) ptr->flags.extensible = 0;
   return js_true;
 }
 
@@ -16485,7 +16488,7 @@ static ant_value_t mkproxy(ant_t *js, ant_value_t target, ant_value_t handler) {
   data->handler = handler;
   data->revoked = false;
 
-  proxy_ptr->is_exotic = 1;
+  proxy_ptr->flags.is_exotic = 1;
   js_mark_constructor(proxy_obj, js_is_constructor(target));
   
   ant_object_sidecar_t *sidecar = ant_object_ensure_sidecar(proxy_ptr);
@@ -17969,7 +17972,7 @@ ant_value_t js_getprop_super(ant_t *js, ant_value_t super_obj, ant_value_t recei
       }
     }
 
-    if (!handled && cur_ptr && cur_ptr->is_exotic) {
+    if (!handled && cur_ptr && cur_ptr->flags.is_exotic) {
       descriptor_entry_t *desc = lookup_descriptor(cur_obj, name, key_len);
       if (desc) {
         if (desc->has_getter) {
@@ -18290,7 +18293,7 @@ void js_set_getter(ant_value_t obj, js_getter_fn getter) {
   if (vtype(obj) != T_OBJ) obj = js_as_obj(obj);
   ant_object_t *ptr = js_obj_ptr(obj);
   if (!ptr) return;
-  ptr->is_exotic = 1;
+  ptr->flags.is_exotic = 1;
   ant_exotic_ops_t *ops = obj_ensure_exotic_ops(ptr);
   if (!ops) return;
   ops->getter = getter;
@@ -18301,7 +18304,7 @@ void js_set_setter(ant_value_t obj, js_setter_fn setter) {
   if (vtype(obj) != T_OBJ) obj = js_as_obj(obj);
   ant_object_t *ptr = js_obj_ptr(obj);
   if (!ptr) return;
-  ptr->is_exotic = 1;
+  ptr->flags.is_exotic = 1;
   ant_exotic_ops_t *ops = obj_ensure_exotic_ops(ptr);
   if (!ops) return;
   ops->setter = setter;
@@ -18312,7 +18315,7 @@ void js_set_deleter(ant_value_t obj, js_deleter_fn deleter) {
   if (vtype(obj) != T_OBJ) obj = js_as_obj(obj);
   ant_object_t *ptr = js_obj_ptr(obj);
   if (!ptr) return;
-  ptr->is_exotic = 1;
+  ptr->flags.is_exotic = 1;
   ant_exotic_ops_t *ops = obj_ensure_exotic_ops(ptr);
   if (!ops) return;
   ops->deleter = deleter;
@@ -18331,6 +18334,6 @@ void js_set_keys(ant_value_t obj, js_keys_fn keys) {
   if (vtype(obj) != T_OBJ) obj = js_as_obj(obj);
   ant_object_t *ptr = js_obj_ptr(obj);
   if (!ptr) return;
-  ptr->is_exotic = 1;
+  ptr->flags.is_exotic = 1;
   ptr->exotic_keys = keys;
 }

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -30,7 +30,7 @@ static inline bool is_canonical_desc_obj(ant_value_t obj) {
 
 static inline bool is_exotic_desc_obj(ant_value_t obj) {
   ant_object_t *ptr = js_obj_ptr(obj);
-  return ptr && ptr->is_exotic;
+  return ptr && ptr->flags.is_exotic;
 }
 
 static inline bool desc_registry_allowed(ant_value_t obj) {

--- a/src/gc/gc.c
+++ b/src/gc/gc.c
@@ -35,6 +35,18 @@ static size_t gc_scaled_threshold(size_t base_live, uint32_t growth_x256, size_t
   return scaled;
 }
 
+static size_t gc_pool_live_bytes(ant_t *js) {
+  ant_pool_stats_t rope_stats = js_pool_stats(&js->pool.rope);
+  ant_pool_stats_t symbol_stats = js_pool_stats(&js->pool.symbol);
+  ant_pool_stats_t bigint_stats = js_class_pool_stats(&js->pool.bigint);
+  ant_string_pool_stats_t string_stats = js_string_pool_stats(&js->pool.string);
+
+  return rope_stats.used
+    + symbol_stats.used
+    + bigint_stats.used
+    + string_stats.total.used;
+}
+
 // TODO: inline
 size_t gc_live_major_threshold(ant_t *js) {
   size_t threshold = gc_scaled_threshold(js->gc_last_live, gc_major_live_growth_x256, 2048u);
@@ -45,7 +57,7 @@ size_t gc_live_major_threshold(ant_t *js) {
 
 // TODO: reduce magic
 size_t gc_pool_major_threshold(ant_t *js) {
-  return gc_scaled_threshold(js->gc_pool_last_live, gc_major_pool_growth_x256, 64u * 1024u * 1024u);
+  return gc_scaled_threshold(js->gc_pool_last_live, gc_major_pool_growth_x256, GC_POOL_PRESSURE_FLOOR);
 }
 
 static void gc_adapt_nursery(size_t young_before, size_t survivors) {
@@ -152,8 +164,7 @@ void gc_run(ant_t *js) {
   js->old_live_count = js->obj_arena.live_count;
   js->minor_gc_count = 0;
 
-  ant_string_pool_stats_t pool_stats = js_string_pool_stats(&js->pool.string);
-  js->gc_pool_last_live = pool_stats.total.used;
+  js->gc_pool_last_live = gc_pool_live_bytes(js);
   js->gc_pool_alloc = 0;
 
   gc_adapt_major_interval(live_before, js->obj_arena.live_count);

--- a/src/gc/gc.c
+++ b/src/gc/gc.c
@@ -201,15 +201,15 @@ void gc_maybe(ant_t *js) {
   
   if (young_count >= gc_nursery_threshold) {
     gc_tick = 0;
+    size_t live_before_minor = js->obj_arena.live_count;
+    size_t major_threshold = gc_live_major_threshold(js);
+    size_t pool_threshold = gc_pool_major_threshold(js);
+
     gc_run_minor(js);
     
     if (js->minor_gc_count >= gc_major_every_n) {
-      size_t live_after_minor = js->obj_arena.live_count;
-      size_t major_threshold = gc_live_major_threshold(js);
-      size_t pool_threshold = gc_pool_major_threshold(js);
-      
       bool major_due = 
-        live_after_minor >= major_threshold || 
+        live_before_minor >= major_threshold ||
         js->gc_pool_alloc >= pool_threshold;
       
       js->minor_gc_count = 0;

--- a/src/gc/gc.c
+++ b/src/gc/gc.c
@@ -1,5 +1,6 @@
 #include <gc.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <time.h>
 #include "shapes.h"
 
@@ -34,14 +35,17 @@ static size_t gc_scaled_threshold(size_t base_live, uint32_t growth_x256, size_t
   return scaled;
 }
 
+// TODO: inline
 size_t gc_live_major_threshold(ant_t *js) {
-  size_t base_live = js ? js->gc_last_live : 0;
-  return gc_scaled_threshold(base_live, gc_major_live_growth_x256, 2048u);
+  size_t threshold = gc_scaled_threshold(js->gc_last_live, gc_major_live_growth_x256, 2048u);
+  size_t nursery_floor = js->old_live_count + gc_nursery_threshold;
+  if (threshold < nursery_floor) threshold = nursery_floor;
+  return threshold;
 }
 
+// TODO: reduce magic
 size_t gc_pool_major_threshold(ant_t *js) {
-  size_t base_live = js ? js->gc_pool_last_live : 0;
-  return gc_scaled_threshold(base_live, gc_major_pool_growth_x256, 4u * 1024u * 1024u);
+  return gc_scaled_threshold(js->gc_pool_last_live, gc_major_pool_growth_x256, 64u * 1024u * 1024u);
 }
 
 static void gc_adapt_nursery(size_t young_before, size_t survivors) {
@@ -187,10 +191,20 @@ void gc_maybe(ant_t *js) {
   if (young_count >= gc_nursery_threshold) {
     gc_tick = 0;
     gc_run_minor(js);
+    
     if (js->minor_gc_count >= gc_major_every_n) {
+      size_t live_after_minor = js->obj_arena.live_count;
+      size_t major_threshold = gc_live_major_threshold(js);
+      size_t pool_threshold = gc_pool_major_threshold(js);
+      
+      bool major_due = 
+        live_after_minor >= major_threshold || 
+        js->gc_pool_alloc >= pool_threshold;
+      
       js->minor_gc_count = 0;
-      gc_run(js);
+      if (major_due) gc_run(js);
     }
+    
     return;
   }
 

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -121,7 +121,7 @@ void gc_unroot_pending_promise(ant_object_t *obj) {
 }
 
 void gc_remember_add(ant_t *js, ant_object_t *obj) {
-  if (!obj || obj->in_remember_set) return;
+  if (!obj || obj->flags.in_remember_set) return;
   if (js->remember_set_len >= js->remember_set_cap) {
     size_t new_cap = js->remember_set_cap ? js->remember_set_cap * 2 : 64;
     ant_object_t **ns = realloc(js->remember_set, new_cap * sizeof(*ns));
@@ -129,7 +129,7 @@ void gc_remember_add(ant_t *js, ant_object_t *obj) {
     js->remember_set = ns;
     js->remember_set_cap = new_cap;
   }
-  obj->in_remember_set = 1;
+  obj->flags.in_remember_set = 1;
   js->remember_set[js->remember_set_len++] = obj;
 }
 
@@ -155,7 +155,7 @@ static void gc_mark_stack_push(ant_object_t *obj) {
 static inline void gc_grey_obj(ant_t *js, ant_object_t *obj) {
   if (!obj || !fixed_arena_contains(&js->obj_arena, obj)) return;
   if (obj->mark_epoch == gc_obj_epoch || obj->mark_epoch == ANT_GC_DEAD) return;
-  if (g_minor_gc && obj->generation == 1) return;
+  if (g_minor_gc && obj->flags.generation == 1) return;
   obj->mark_epoch = gc_obj_epoch;
   gc_mark_stack_push(obj);
 }
@@ -679,7 +679,7 @@ static void gc_promote_survivors(ant_t *js) {
   ant_object_t *obj = js->objects;
   while (obj) {
     ant_object_t *next = obj->next;
-    obj->generation = 1;
+    obj->flags.generation = 1;
     obj->next = js->objects_old;
     js->objects_old = obj;
     obj = next;
@@ -710,8 +710,8 @@ void gc_pin_existing_objects(ant_t *js) {
 
   ant_object_t *tail = NULL;
   for (ant_object_t *obj = js->objects; obj; obj = obj->next) {
-    obj->gc_permanent = 1;
-    obj->generation = 1;
+    obj->flags.gc_permanent = 1;
+    obj->flags.generation = 1;
     tail = obj;
   }
   
@@ -723,7 +723,7 @@ void gc_pin_existing_objects(ant_t *js) {
   
   tail = NULL;
   for (ant_object_t *obj = js->objects_old; obj; obj = obj->next) {
-    obj->gc_permanent = 1;
+    obj->flags.gc_permanent = 1;
     tail = obj;
   }
   
@@ -748,7 +748,7 @@ void gc_objects_run(ant_t *js, gc_str_mark_fn str_mark) {
 
   ant_gc_shapes_begin();
   for (size_t i = 0; i < js->remember_set_len; i++)
-    js->remember_set[i]->in_remember_set = 0;
+    js->remember_set[i]->flags.in_remember_set = 0;
   js->remember_set_len = 0;
 
   if (js->remember_set_cap > 512) {
@@ -845,7 +845,7 @@ void gc_objects_run_minor(ant_t *js, gc_str_mark_fn str_mark) {
   g_minor_gc = true;
 
   for (size_t i = 0; i < js->remember_set_len; i++) gc_scan_obj(js, js->remember_set[i]);
-  for (size_t i = 0; i < js->remember_set_len; i++) js->remember_set[i]->in_remember_set = 0;
+  for (size_t i = 0; i < js->remember_set_len; i++) js->remember_set[i]->flags.in_remember_set = 0;
   
   js->remember_set_len = 0;
   gc_mark_roots(js);

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -133,6 +133,32 @@ void gc_remember_add(ant_t *js, ant_object_t *obj) {
   js->remember_set[js->remember_set_len++] = obj;
 }
 
+void gc_remember_func_const(ant_t *js, sv_func_t *func, uint32_t slot, ant_value_t value) {
+  if (!js || !func || value <= NANBOX_PREFIX) return;
+  uint8_t type = (value >> NANBOX_TYPE_SHIFT) & NANBOX_TYPE_MASK;
+  
+  if (type != T_FUNC) {
+    if (((1u << type) & GC_OBJ_TYPE_MASK) == 0) return;
+    ant_object_t *obj = (ant_object_t *)(uintptr_t)(value & NANBOX_DATA_MASK);
+    if (!obj || obj->flags.generation != 0) return;
+  }
+
+  for (size_t i = 0; i < js->remembered_func_const_len; i++) 
+    if (js->remembered_func_consts[i].func == func && js->remembered_func_consts[i].slot == slot) return;
+
+  if (js->remembered_func_const_len >= js->remembered_func_const_cap) {
+    size_t new_cap = js->remembered_func_const_cap ? js->remembered_func_const_cap * 2 : 64;
+    void *entries = realloc(js->remembered_func_consts, new_cap * sizeof(*js->remembered_func_consts));
+    if (!entries) return;
+    js->remembered_func_consts = entries;
+    js->remembered_func_const_cap = new_cap;
+  }
+
+  js->remembered_func_consts[js->remembered_func_const_len].func = func;
+  js->remembered_func_consts[js->remembered_func_const_len].slot = slot;
+  js->remembered_func_const_len++;
+}
+
 #define GC_MARK_STACK_INIT 4096
 
 static ant_object_t **gc_mark_stack = NULL;
@@ -189,6 +215,30 @@ static void gc_mark_func(ant_t *js, sv_func_t *func) {
 
   if (prof && --g_gc_func_mark_profile_depth == 0)
     g_gc_func_mark_profile.time_ns += gc_now_ns() - g_gc_func_mark_profile_start_ns;
+}
+
+static void gc_mark_remembered_func_consts(ant_t *js) {
+for (size_t i = 0; i < js->remembered_func_const_len; i++) {
+  sv_func_t *func = js->remembered_func_consts[i].func;
+  uint32_t slot = js->remembered_func_consts[i].slot;
+  if (!func || !func->constants || slot >= (uint32_t)func->const_count) continue;
+  gc_mark_value(js, func->constants[slot]);
+}}
+
+static void gc_clear_remembered_func_consts(ant_t *js) {
+  js->remembered_func_const_len = 0;
+
+  if (js->remembered_func_const_cap > 512) {
+  size_t target = 256;
+  void *entries = realloc(
+    js->remembered_func_consts,
+    target * sizeof(*js->remembered_func_consts)
+  );
+  
+  if (entries) {
+    js->remembered_func_consts = entries;
+    js->remembered_func_const_cap = target;
+  }}
 }
 
 static void gc_mark_closure(ant_t *js, sv_closure_t *c) {
@@ -750,6 +800,7 @@ void gc_objects_run(ant_t *js, gc_str_mark_fn str_mark) {
   for (size_t i = 0; i < js->remember_set_len; i++)
     js->remember_set[i]->flags.in_remember_set = 0;
   js->remember_set_len = 0;
+  gc_clear_remembered_func_consts(js);
 
   if (js->remember_set_cap > 512) {
     ant_object_t **ns = realloc(js->remember_set, 256 * sizeof(*ns));
@@ -844,8 +895,13 @@ void gc_objects_run_minor(ant_t *js, gc_str_mark_fn str_mark) {
   if (gc_obj_epoch == 0 || gc_obj_epoch == ANT_GC_DEAD) gc_obj_epoch = 1;
   g_minor_gc = true;
 
-  for (size_t i = 0; i < js->remember_set_len; i++) gc_scan_obj(js, js->remember_set[i]);
-  for (size_t i = 0; i < js->remember_set_len; i++) js->remember_set[i]->flags.in_remember_set = 0;
+  for (size_t i = 0; i < js->remember_set_len; i++) 
+    gc_scan_obj(js, js->remember_set[i]);
+  
+  gc_mark_remembered_func_consts(js);
+  
+  for (size_t i = 0; i < js->remember_set_len; i++) 
+    js->remember_set[i]->flags.in_remember_set = 0;
   
   js->remember_set_len = 0;
   gc_mark_roots(js);
@@ -855,6 +911,7 @@ void gc_objects_run_minor(ant_t *js, gc_str_mark_fn str_mark) {
   gc_sweep_regex_cache();
   gc_sweep_young(js);
   gc_promote_survivors(js);
+  gc_clear_remembered_func_consts(js);
   
   // will NOT sweep closure/upvalue arenas here. old closures stored as T_FUNC
   // property values on old objects are not scanned during minor GC (old objects

--- a/src/modules/events.c
+++ b/src/modules/events.c
@@ -253,6 +253,9 @@ static bool is_eventemitter_like(ant_t *js, ant_value_t target) {
     ? js_getprop_fallback(js, proto, "constructor")
     : js_mkundef();
 
+  if (proto == g_eventemitter_proto || proto == g_eventtarget_proto)
+    return false;
+
   if (
     eventemitter_like_cache_has(proto) || 
     eventemitter_like_cache_has(ctor)

--- a/src/modules/napi.c
+++ b/src/modules/napi.c
@@ -334,7 +334,7 @@ void gc_clear_napi_weak_refs(ant_t *js, bool minor) {
     if (r->refcount > 0 || !r->value) continue;
     ant_value_t value = (ant_value_t)r->value;
     ant_object_t *obj = is_object_type(value) ? js_obj_ptr(value) : NULL;
-    if (obj && (!minor || obj->generation == 0) && !gc_obj_is_marked(obj)) r->value = 0;
+    if (obj && (!minor || obj->flags.generation == 0) && !gc_obj_is_marked(obj)) r->value = 0;
   }
 }
 

--- a/src/modules/reflect.c
+++ b/src/modules/reflect.c
@@ -273,13 +273,13 @@ static ant_value_t reflect_is_extensible(ant_t *js, ant_value_t *args, int nargs
   
   ant_value_t target = args[0];
   int t = vtype(target);
-  
   if (t != T_OBJ && t != T_FUNC) return js_false;
 
   ant_object_t *obj = js_obj_ptr(js_as_obj(target));
   if (!obj) return js_false;
-  if (obj->frozen || obj->sealed) return js_false;
-  return js_bool(obj->extensible);
+  if (obj->flags.frozen || obj->flags.sealed) return js_false;
+  
+  return js_bool(obj->flags.extensible);
 }
 
 static ant_value_t reflect_prevent_extensions(ant_t *js, ant_value_t *args, int nargs) {
@@ -287,12 +287,12 @@ static ant_value_t reflect_prevent_extensions(ant_t *js, ant_value_t *args, int 
   
   ant_value_t target = args[0];
   int t = vtype(target);
-  
   if (t != T_OBJ && t != T_FUNC) return js_false;
 
   ant_object_t *obj = js_obj_ptr(js_as_obj(target));
   if (!obj) return js_false;
-  obj->extensible = 0;
+  obj->flags.extensible = 0;
+  
   return js_true;
 }
 

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -1921,7 +1921,14 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
 
   L_SPECIAL_OBJ:  { sv_op_special_obj(vm, js, frame, ip);                       NEXT(2); }
   L_EMPTY:        { vm->stack[vm->sp++] = T_EMPTY;                              NEXT(1); }
-  L_PUT_CONST:    { func->constants[sv_get_u32(ip + 1)] = vm->stack[--vm->sp];  NEXT(5); }
+  
+  L_PUT_CONST: {
+    uint32_t idx = sv_get_u32(ip + 1);
+    ant_value_t cached = vm->stack[--vm->sp];
+    func->constants[idx] = cached;
+    gc_remember_func_const(js, func, idx, cached);
+    NEXT(5);
+  }
   
   L_DEBUGGER:  { NEXT(1); }
   L_NOP:       { NEXT(1); }

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -709,6 +709,7 @@ static inline ant_value_t sv_try_direct_closure_jit(
   }
 
   if (callee->is_generator) return SV_JIT_RETRY_INTERP;
+  if (callee->jit_compile_failed) return SV_JIT_RETRY_INTERP;
 
   uint32_t cc = ++callee->call_count;
   if (__builtin_expect(cc == SV_TFB_ALLOC_THRESHOLD, 0))
@@ -814,14 +815,26 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
   if (!resuming && vm->jit_resume.active) {
     ip = func->code + vm->jit_resume.ip_offset;
     frame->ip = ip;
+    int64_t rp =
+      vm->jit_resume.n_params < func->param_count
+      ? vm->jit_resume.n_params : func->param_count;
+    for (int64_t i = 0; i < rp; i++)
+      entry_bp[i] = vm->jit_resume.params[i];
     int64_t rl = 
       vm->jit_resume.n_locals < func->max_locals
       ? vm->jit_resume.n_locals : func->max_locals;
     for (int64_t i = 0; i < rl; i++)
       entry_lp[i] = vm->jit_resume.locals[i];
-      
+
+    ant_value_t *old_bp = vm->jit_resume.params;
+    for (sv_upvalue_t *uv = vm->open_upvalues; old_bp && uv; uv = uv->next) {
+    if (uv->location >= old_bp && uv->location < old_bp + rp) {
+      ptrdiff_t slot = uv->location - old_bp;
+      uv->location = &entry_bp[slot];
+    }}
+
     ant_value_t *old_lp = vm->jit_resume.locals;
-    for (sv_upvalue_t *uv = vm->open_upvalues; uv; uv = uv->next) {
+    for (sv_upvalue_t *uv = vm->open_upvalues; old_lp && uv; uv = uv->next) {
     if (uv->location >= old_lp && uv->location < old_lp + rl) {
       ptrdiff_t slot = uv->location - old_lp;
       uv->location = &entry_lp[slot];

--- a/src/silver/glue.c
+++ b/src/silver/glue.c
@@ -1,18 +1,20 @@
 #ifdef ANT_JIT
 
 #include <math.h>
-#include "silver/glue.h"
+#include <stdlib.h>
 
 #include "utf8.h"
 #include "internal.h"
 #include "errors.h"
+#include "tokens.h"
+#include "silver/glue.h"
 
+#include "ops/calls.h"
 #include "ops/globals.h"
 #include "ops/property.h"
 #include "ops/iteration.h"
 #include "ops/upvalues.h"
 #include "ops/comparison.h"
-#include "ops/calls.h"
 
 int64_t jit_helper_stack_overflow(ant_t *js) {
   volatile char marker;
@@ -29,6 +31,10 @@ ant_value_t jit_helper_stack_overflow_error(sv_vm_t *vm, ant_t *js) {
 
 ant_value_t jit_helper_add(sv_vm_t *vm, ant_t *js, ant_value_t l, ant_value_t r) {
   if (vtype(l) == T_NUM && vtype(r) == T_NUM) return tov(tod(l) + tod(r));
+  if (vtype(l) == T_STR && vtype(r) == T_STR) {
+    ant_value_t res = do_string_op(js, TOK_PLUS, l, r);
+    return is_err(res) ? SV_JIT_BAILOUT : res;
+  }
   return SV_JIT_BAILOUT;
 }
 
@@ -120,11 +126,13 @@ ant_value_t jit_helper_str_flush_local(
 
 ant_value_t jit_helper_lt(sv_vm_t *vm, ant_t *js, ant_value_t l, ant_value_t r) {
   if (vtype(l) == T_NUM && vtype(r) == T_NUM) return js_bool(tod(l) < tod(r));
+  if (vtype(l) == T_STR && vtype(r) == T_STR) return js_bool(sv_strcmp(js, l, r) < 0);
   return SV_JIT_BAILOUT;
 }
 
 ant_value_t jit_helper_le(sv_vm_t *vm, ant_t *js, ant_value_t l, ant_value_t r) {
   if (vtype(l) == T_NUM && vtype(r) == T_NUM) return js_bool(tod(l) <= tod(r));
+  if (vtype(l) == T_STR && vtype(r) == T_STR) return js_bool(sv_strcmp(js, l, r) <= 0);
   return SV_JIT_BAILOUT;
 }
 
@@ -605,10 +613,29 @@ static inline sv_upvalue_t *jit_make_undef_upvalue(void) {
   return uv;
 }
 
+static sv_upvalue_t *jit_capture_upvalue(
+  sv_vm_t *vm, sv_upvalue_t **open_upvalues,
+  ant_value_t *slot
+) {
+  sv_upvalue_t **pp = open_upvalues ? open_upvalues : &vm->open_upvalues;
+
+  while (*pp && (*pp)->location > slot) pp = &(*pp)->next;
+  if (*pp && (*pp)->location == slot) return *pp;
+
+  sv_upvalue_t *uv = js_upvalue_alloc();
+  uv->location = slot;
+  uv->next = *pp;
+  *pp = uv;
+
+  return uv;
+}
+
 ant_value_t jit_helper_closure(
   sv_vm_t *vm, ant_t *js, sv_closure_t *parent_closure,
   ant_value_t this_val, ant_value_t *slots,
-  int slot_base, int slot_count, uint32_t const_idx
+  int slot_base, int slot_count, uint32_t const_idx,
+  const char *name, uint32_t name_len,
+  sv_upvalue_t **open_upvalues
 ) {
   sv_func_t *parent_func = parent_closure->func;
   sv_func_t *child = (sv_func_t *)(uintptr_t)vdata(parent_func->constants[const_idx]);
@@ -618,6 +645,8 @@ ant_value_t jit_helper_closure(
 
   closure->func = child;
   closure->bound_this = child->is_arrow ? this_val : js_mkundef();
+  closure->bound_argv = NULL;
+  closure->bound_argc = 0;
   closure->bound_args = js_mkundef();
   closure->super_val = js_mkundef();
   closure->call_flags = child->is_arrow ? SV_CALL_IS_ARROW : 0;
@@ -638,60 +667,30 @@ ant_value_t jit_helper_closure(
       continue;
     }
     
-    closure->upvalues[i] = sv_capture_upvalue(vm, &slots[idx]);
+    closure->upvalues[i] = jit_capture_upvalue(vm, open_upvalues, &slots[idx]);
   }
-
-  ant_value_t func_obj = mkobj(js, 0);
-  closure->func_obj = func_obj;
-  ant_value_t module_ctx = sv_get_current_closure_module_ctx(js, mkval(T_FUNC, (uintptr_t)parent_closure));
-  
-  js_mark_constructor(func_obj, !child->is_arrow && !child->is_method && !child->is_generator && !child->is_async);
-  js_setprop(js, func_obj, js->length_str, tov((double)child->function_length));
-  js_set_descriptor(js, func_obj, "length", 6, JS_DESC_C);
-  
-  if (is_object_type(module_ctx))
-    js_set_slot_wb(js, func_obj, SLOT_MODULE_CTX, module_ctx);
 
   ant_value_t func_val = mkval(T_FUNC, (uintptr_t)closure);
-  if (!child->is_arrow && !child->is_method && (!child->is_async || child->is_generator)) {
-    ant_value_t parent_proto = child->is_async
-      ? js->sym.async_generator_proto
-      : (child->is_generator ? js->sym.generator_proto : js->sym.object_proto);
-    sv_setup_function_prototype_with_parent(js, func_obj, func_val, parent_proto);
-  }
+  ant_value_t module_ctx = sv_get_current_closure_module_ctx(
+    js, mkval(T_FUNC, (uintptr_t)parent_closure)
+  );
   
-  if (child->is_async && child->is_generator) {
-    js_set_slot(func_obj, SLOT_ASYNC, js_true);
-    ant_value_t async_generator_proto = js_get_slot(js->global, SLOT_ASYNC_GENERATOR_PROTO);
-    if (vtype(async_generator_proto) == T_FUNC) js_set_proto_init(func_obj, async_generator_proto);
-  }
-  
-  else if (child->is_async) {
-    js_set_slot(func_obj, SLOT_ASYNC, js_true);
-    ant_value_t async_proto = js_get_slot(js->global, SLOT_ASYNC_PROTO);
-    if (vtype(async_proto) == T_FUNC) js_set_proto_init(func_obj, async_proto);
-  }
-  
-  else if (child->is_generator) {
-    ant_value_t generator_proto = js_get_slot(js->global, SLOT_GENERATOR_PROTO);
-    if (vtype(generator_proto) == T_FUNC) js_set_proto_init(func_obj, generator_proto);
-  }
-  
-  else {
-    ant_value_t func_proto = js_get_slot(js->global, SLOT_FUNC_PROTO);
-    if (vtype(func_proto) == T_FUNC) js_set_proto_init(func_obj, func_proto);
-  }
+  sv_init_closure_function_object(js, closure, func_val, module_ctx);
+  if (name) js_set_function_name(js, func_val, name, name_len);
 
   return func_val;
 }
 
-void jit_helper_close_upval(sv_vm_t *vm, uint16_t slot_idx, ant_value_t *slots, int slot_count) {
+void jit_helper_close_upval(
+  sv_vm_t *vm, uint16_t slot_idx, ant_value_t *slots, int slot_count,
+  sv_upvalue_t **open_upvalues
+) {
   if (!slots || slot_count <= 0) return;
   if ((int)slot_idx >= slot_count) return;
 
   ant_value_t *lo = slots + slot_idx;
   ant_value_t *hi = slots + slot_count;
-  sv_upvalue_t **pp = &vm->open_upvalues;
+  sv_upvalue_t **pp = open_upvalues ? open_upvalues : &vm->open_upvalues;
   
   while (*pp) {
     sv_upvalue_t *uv = *pp;
@@ -705,10 +704,33 @@ void jit_helper_close_upval(sv_vm_t *vm, uint16_t slot_idx, ant_value_t *slots, 
   }
 }
 
+void jit_helper_adopt_open_upvalues(sv_vm_t *vm, sv_upvalue_t **open_upvalues) {
+  if (!vm || !open_upvalues || !*open_upvalues) return;
+
+  sv_upvalue_t *uv = *open_upvalues;
+  *open_upvalues = NULL;
+
+  while (uv) {
+    sv_upvalue_t *next = uv->next;
+    if (uv->location == &uv->closed) {
+      uv->next = NULL;
+      uv = next;
+      continue;
+    }
+    
+    sv_upvalue_t **pp = &vm->open_upvalues;
+    while (*pp && (*pp)->location > uv->location) pp = &(*pp)->next;
+    uv->next = *pp;
+    *pp = uv;
+    uv = next;
+  }
+}
+
 ant_value_t jit_helper_bailout_resume(
   sv_vm_t *vm, sv_closure_t *closure,
   ant_value_t this_val, ant_value_t *args, int argc,
   ant_value_t *vstack, int64_t vstack_sp,
+  ant_value_t *params, int64_t n_params,
   ant_value_t *locals, int64_t n_locals,
   int64_t bc_offset
 ) {
@@ -718,14 +740,16 @@ ant_value_t jit_helper_bailout_resume(
 
   vm->jit_resume.active     = true;
   vm->jit_resume.ip_offset  = (int)bc_offset;
+  vm->jit_resume.params     = params;
+  vm->jit_resume.n_params   = n_params;
   vm->jit_resume.locals     = locals;
   vm->jit_resume.n_locals   = n_locals;
   vm->jit_resume.vstack     = vstack;
   vm->jit_resume.vstack_sp  = vstack_sp;
 
   return sv_execute_closure_entry(
-    vm, closure, closure->func_obj, js_mkundef(),
-    this_val, args, argc, NULL
+    vm, closure, mkval(T_FUNC, (uintptr_t)closure), 
+    js_mkundef(), this_val, args, argc, NULL
   );
 }
 
@@ -912,14 +936,14 @@ ant_value_t jit_helper_ushr(sv_vm_t *vm, ant_t *js, ant_value_t l, ant_value_t r
 }
 
 ant_value_t jit_helper_gt(sv_vm_t *vm, ant_t *js, ant_value_t l, ant_value_t r) {
-  if (vtype(l) == T_NUM && vtype(r) == T_NUM)
-    return js_bool(tod(l) > tod(r));
+  if (vtype(l) == T_NUM && vtype(r) == T_NUM) return js_bool(tod(l) > tod(r));
+  if (vtype(l) == T_STR && vtype(r) == T_STR) return js_bool(sv_strcmp(js, l, r) > 0);
   return SV_JIT_BAILOUT;
 }
 
 ant_value_t jit_helper_ge(sv_vm_t *vm, ant_t *js, ant_value_t l, ant_value_t r) {
-  if (vtype(l) == T_NUM && vtype(r) == T_NUM)
-    return js_bool(tod(l) >= tod(r));
+  if (vtype(l) == T_NUM && vtype(r) == T_NUM) return js_bool(tod(l) >= tod(r));
+  if (vtype(l) == T_STR && vtype(r) == T_STR) return js_bool(sv_strcmp(js, l, r) >= 0);
   return SV_JIT_BAILOUT;
 }
 

--- a/src/silver/ops/coercion.h
+++ b/src/silver/ops/coercion.h
@@ -259,16 +259,16 @@ static inline bool sv_with_binding_is_unscopable(
 
     ant_offset_t unscopables_off = lkp_sym_proto(js, with_obj, sym_off);
     bool has_unscopables = unscopables_off != 0;
-    bool saw_exotic = base_ptr && base_ptr->is_exotic;
+    bool saw_exotic = base_ptr && base_ptr->flags.is_exotic;
 
     if (!has_unscopables) {
       ant_value_t cur = with_obj;
       while (is_object_type(cur)) {
         ant_value_t cur_obj = js_as_obj(cur);
         ant_object_t *cur_ptr = js_obj_ptr(cur_obj);
-        if (cur_ptr && cur_ptr->is_exotic) saw_exotic = true;
+        if (cur_ptr && cur_ptr->flags.is_exotic) saw_exotic = true;
         prop_meta_t meta;
-        if (cur_ptr && cur_ptr->is_exotic && lookup_symbol_prop_meta(cur_obj, sym_off, &meta)) {
+        if (cur_ptr && cur_ptr->flags.is_exotic && lookup_symbol_prop_meta(cur_obj, sym_off, &meta)) {
           has_unscopables = true;
           break;
         }

--- a/src/silver/ops/globals.h
+++ b/src/silver/ops/globals.h
@@ -38,7 +38,7 @@ static inline bool sv_global_ic_try_get_hit(
   if (!ic || !interned) return false;
 
   ant_object_t *gptr = sv_global_obj_ptr(js);
-  if (!gptr || gptr->is_exotic || !gptr->shape) return false;
+  if (!gptr || gptr->flags.is_exotic || !gptr->shape) return false;
   if (ic->epoch != ant_ic_epoch_counter) return false;
   if (ic->cached_shape != gptr->shape) return false;
   if (ic->cached_index >= gptr->prop_count) return false;
@@ -61,7 +61,7 @@ static inline bool sv_global_ic_try_fill(
   if (!ic || !interned) return false;
 
   ant_object_t *gptr = sv_global_obj_ptr(js);
-  if (!gptr || gptr->is_exotic || !gptr->shape) return false;
+  if (!gptr || gptr->flags.is_exotic || !gptr->shape) return false;
 
   int32_t slot = ant_shape_lookup_interned(gptr->shape, interned);
   if (slot < 0) return false;

--- a/src/silver/ops/property.h
+++ b/src/silver/ops/property.h
@@ -85,7 +85,7 @@ static inline bool sv_try_get_shape_data_prop(
     *should_fallback = true;
     return false;
   }
-  if (ptr->is_exotic) {
+  if (ptr->flags.is_exotic) {
     *should_fallback = true;
     return false;
   }
@@ -171,7 +171,7 @@ static inline bool sv_ic_try_get_hit(
     prop_shape = receiver->shape;
   } else {
     ant_object_t *holder = ic->cached_holder;
-    if (!holder || holder->is_exotic || !holder->shape) return false;
+    if (!holder || holder->flags.is_exotic || !holder->shape) return false;
     if (receiver->proto != ic->guard.receiver_proto) return false;
     source = holder;
     prop_shape = holder->shape;
@@ -199,7 +199,7 @@ static inline bool sv_ic_probe_get_chain(
   sv_proto_guard_init(&guard);
   while (is_object_type(cur)) {
     ant_object_t *ptr = js_obj_ptr(js_as_obj(cur));
-    if (!ptr || ptr->is_exotic) return false;
+    if (!ptr || ptr->flags.is_exotic) return false;
     if (!ptr->shape) {
       ant_value_t next = ptr->proto;
       if (!is_object_type(next)) break;
@@ -414,13 +414,13 @@ static inline ant_value_t sv_prop_get_field_ic(
   bool track_ic = ic && !is_length_key(a->str, a->len);
 
   ant_value_t hit = js_mkundef();
-  if (ic && ptr && !ptr->is_exotic && track_ic &&
+  if (ic && ptr && !ptr->flags.is_exotic && track_ic &&
       sv_ic_try_get_hit(ic, ptr, a, &hit)) {
     sv_gf_ic_note_success(ic);
     return hit;
   }
 
-  if (ic && ptr && !ptr->is_exotic && track_ic) {
+  if (ic && ptr && !ptr->flags.is_exotic && track_ic) {
     ant_object_t *holder = NULL;
     uint32_t prop_idx = 0;
     ant_value_t out = js_mkundef();
@@ -476,7 +476,7 @@ static inline bool sv_try_put_field_fast(
   if (!is_object_type(obj)) return false;
 
   ant_object_t *ptr = js_obj_ptr(js_as_obj(obj));
-  if (!ptr || ptr->is_exotic || !ptr->shape) return false;
+  if (!ptr || ptr->flags.is_exotic || !ptr->shape) return false;
   if (ptr->type_tag == T_ARR && is_length_key(a->str, a->len)) return false;
 
   int32_t slot = ant_shape_lookup_interned(ptr->shape, a->str);
@@ -548,7 +548,7 @@ static inline ant_value_t sv_op_put_field(
   else if (a->len == 7 && memcmp(a->str, "replace", 7) == 0)
     regexp_note_replace_property_write();
 
-  if (ic && ptr && !ptr->is_exotic && ptr->shape && ic->epoch == ant_ic_epoch_counter &&
+  if (ic && ptr && !ptr->flags.is_exotic && ptr->shape && ic->epoch == ant_ic_epoch_counter &&
       ic->cached_shape == ptr->shape && ic->cached_holder == ptr &&
       ic->cached_index < ptr->prop_count) {
     const ant_shape_prop_t *prop = ant_shape_prop_at(ptr->shape, ic->cached_index);
@@ -564,8 +564,8 @@ static inline ant_value_t sv_op_put_field(
     }
   }
 
-  if (ic && ptr && !ptr->is_exotic && ptr->shape &&
-      !ptr->frozen && !ptr->sealed && ptr->extensible &&
+  if (ic && ptr && !ptr->flags.is_exotic && ptr->shape &&
+      !ptr->flags.frozen && !ptr->flags.sealed && ptr->flags.extensible &&
       ptr->type_tag != T_ARR &&
       !sv_is_proto_atom(a) &&
       ic->guard.add.epoch == ant_ic_epoch_counter &&
@@ -613,7 +613,7 @@ static inline ant_value_t sv_op_put_field(
     return out;
   }
 
-  if (ic && ptr && !ptr->is_exotic && ptr->shape) {
+  if (ic && ptr && !ptr->flags.is_exotic && ptr->shape) {
     int32_t slot = ant_shape_lookup_interned(ptr->shape, a->str);
     if (slot >= 0) {
       uint32_t prop_idx = (uint32_t)slot;
@@ -632,9 +632,9 @@ static inline ant_value_t sv_op_put_field(
         if (old_shape &&
             old_shape != ptr->shape &&
             !sv_is_proto_atom(a) &&
-            !ptr->frozen &&
-            !ptr->sealed &&
-            ptr->extensible &&
+            !ptr->flags.frozen &&
+            !ptr->flags.sealed &&
+            ptr->flags.extensible &&
             ptr->type_tag != T_ARR &&
             prop->attrs == ANT_PROP_ATTR_DEFAULT) {
           sv_ic_set_add_transition(ic, old_shape, ptr->shape, prop_idx, ant_ic_epoch_counter);
@@ -733,9 +733,9 @@ static inline bool sv_try_define_field_fast(
 
   ant_value_t as_obj = js_as_obj(obj);
   ant_object_t *ptr = js_obj_ptr(as_obj);
-  if (!ptr || ptr->is_exotic || !ptr->shape) return false;
+  if (!ptr || ptr->flags.is_exotic || !ptr->shape) return false;
   if (ptr->type_tag == T_ARR) return false;
-  if (ptr->frozen || ptr->sealed || !ptr->extensible) return false;
+  if (ptr->flags.frozen || ptr->flags.sealed || !ptr->flags.extensible) return false;
 
   int32_t slot = ant_shape_lookup_interned(ptr->shape, interned_key);
   if (slot >= 0) {

--- a/src/silver/ops/upvalues.h
+++ b/src/silver/ops/upvalues.h
@@ -2,8 +2,25 @@
 #define SV_UPVALUES_H
 
 #include "internal.h"
-#include "descriptors.h"
 #include "silver/engine.h"
+
+static inline ant_value_t sv_mkprop_interned_exact_key(
+  ant_t *js, ant_value_t obj,
+  const char *interned_key, const char *fallback_key,
+  size_t fallback_len, ant_value_t val, uint8_t attrs
+) {
+  if (!interned_key) interned_key = intern_string(fallback_key, fallback_len);
+  if (!interned_key) return js_mkerr(js, "oom");
+  return mkprop_interned_exact(js, obj, interned_key, val, attrs);
+}
+
+static inline ant_value_t sv_define_function_length(ant_t *js, ant_value_t func_obj, double length) {
+  return sv_mkprop_interned_exact_key(
+    js, func_obj,
+    js->intern.length, "length", 6,
+    tov(length), ANT_PROP_ATTR_CONFIGURABLE
+  );
+}
 
 static inline ant_value_t sv_setup_function_prototype_with_parent(
   ant_t *js, ant_value_t func_obj,
@@ -12,22 +29,22 @@ static inline ant_value_t sv_setup_function_prototype_with_parent(
   ant_value_t proto_obj = mkobj(js, 0);
   if (is_err(proto_obj)) return proto_obj;
 
-  ant_value_t ctor_key = js_mkstr(js, "constructor", 11);
-  if (is_err(ctor_key)) return ctor_key;
+  ant_value_t set_ctor = sv_mkprop_interned_exact_key(
+    js, proto_obj,
+    js->intern.constructor, "constructor", 11,
+    func_val, ANT_PROP_ATTR_WRITABLE | ANT_PROP_ATTR_CONFIGURABLE
+  );
   
-  ant_value_t set_ctor = js_setprop(js, proto_obj, ctor_key, func_val);
   if (is_err(set_ctor)) return set_ctor;
-  
-  js_set_descriptor(js, proto_obj, "constructor", 11, JS_DESC_W | JS_DESC_C);
   if (is_object_type(parent_proto)) js_set_proto_init(proto_obj, parent_proto);
 
-  ant_value_t proto_key = js_mkstr(js, "prototype", 9);
-  if (is_err(proto_key)) return proto_key;
+  ant_value_t set_proto = sv_mkprop_interned_exact_key(
+    js, func_obj,
+    js->intern.prototype, "prototype", 9,
+    proto_obj, ANT_PROP_ATTR_WRITABLE
+  );
   
-  ant_value_t set_proto = js_setprop(js, func_obj, proto_key, proto_obj);
   if (is_err(set_proto)) return set_proto;
-  js_set_descriptor(js, func_obj, "prototype", 9, JS_DESC_W);
-
   return js_mkundef();
 }
 
@@ -38,6 +55,56 @@ static inline ant_value_t sv_get_current_closure_module_ctx(ant_t *js, ant_value
   }
 
   return js_module_eval_active_ctx(js);
+}
+
+static inline void sv_init_closure_function_object(
+  ant_t *js,
+  sv_closure_t *closure,
+  ant_value_t func_val,
+  ant_value_t module_ctx
+) {
+  sv_func_t *child = closure->func;
+  ant_value_t func_obj = mkobj(js, 0);
+  closure->func_obj = func_obj;
+  if (is_err(func_obj) || !child) return;
+
+  js_mark_constructor(
+    func_obj,
+    !child->is_arrow && !child->is_method && !child->is_generator && !child->is_async
+  );
+  (void)sv_define_function_length(js, func_obj, (double)child->function_length);
+
+  if (is_object_type(module_ctx))
+    js_set_slot_wb(js, func_obj, SLOT_MODULE_CTX, module_ctx);
+
+  if (!child->is_arrow && !child->is_method && (!child->is_async || child->is_generator)) {
+    ant_value_t parent_proto = child->is_async
+      ? js->sym.async_generator_proto
+      : (child->is_generator ? js->sym.generator_proto : js->sym.object_proto);
+    (void)sv_setup_function_prototype_with_parent(js, func_obj, func_val, parent_proto);
+  }
+
+  if (child->is_async && child->is_generator) {
+    js_set_slot(func_obj, SLOT_ASYNC, js_true);
+    ant_value_t async_generator_proto = js_get_slot(js->global, SLOT_ASYNC_GENERATOR_PROTO);
+    if (vtype(async_generator_proto) == T_FUNC) js_set_proto_init(func_obj, async_generator_proto);
+  }
+  
+  else if (child->is_async) {
+    js_set_slot(func_obj, SLOT_ASYNC, js_true);
+    ant_value_t async_proto = js_get_slot(js->global, SLOT_ASYNC_PROTO);
+    if (vtype(async_proto) == T_FUNC) js_set_proto_init(func_obj, async_proto);
+  }
+  
+  else if (child->is_generator) {
+    ant_value_t generator_proto = js_get_slot(js->global, SLOT_GENERATOR_PROTO);
+    if (vtype(generator_proto) == T_FUNC) js_set_proto_init(func_obj, generator_proto);
+  }
+  
+  else {
+    ant_value_t func_proto = js_get_slot(js->global, SLOT_FUNC_PROTO);
+    if (vtype(func_proto) == T_FUNC) js_set_proto_init(func_obj, func_proto);
+  }
 }
 
 static inline ant_value_t sv_op_get_upval(
@@ -113,6 +180,8 @@ static inline ant_value_t sv_op_closure(
   sv_closure_t *closure = js_closure_alloc(js);
   closure->func = child;
   closure->bound_this = child->is_arrow ? frame->this : js_mkundef();
+  closure->bound_argv = NULL;
+  closure->bound_argc = 0;
   closure->bound_args = js_mkundef();
   closure->super_val = js_mkundef();
   closure->call_flags = child->is_arrow ? SV_CALL_IS_ARROW : 0;
@@ -130,44 +199,8 @@ static inline ant_value_t sv_op_closure(
 
   ant_value_t func_val = mkval(T_FUNC, (uintptr_t)closure);
   vm->stack[vm->sp++] = func_val;
-
-  ant_value_t func_obj = mkobj(js, 0);
-  closure->func_obj = func_obj;
   ant_value_t module_ctx = sv_get_current_closure_module_ctx(js, frame->callee);
-  
-  js_mark_constructor(func_obj, !child->is_arrow && !child->is_method && !child->is_generator && !child->is_async);
-  js_setprop(js, func_obj, js->length_str, tov((double)child->function_length));
-  js_set_descriptor(js, func_obj, "length", 6, JS_DESC_C);
-  
-  if (is_object_type(module_ctx)) js_set_slot_wb(js, func_obj, SLOT_MODULE_CTX, module_ctx);
-  if (!child->is_arrow && !child->is_method && (!child->is_async || child->is_generator)) {
-    ant_value_t parent_proto = child->is_async
-      ? js->sym.async_generator_proto
-      : (child->is_generator ? js->sym.generator_proto : js->sym.object_proto);
-    sv_setup_function_prototype_with_parent(js, func_obj, func_val, parent_proto);
-  }
-  
-  if (child->is_async && child->is_generator) {
-    js_set_slot(func_obj, SLOT_ASYNC, js_true);
-    ant_value_t async_generator_proto = js_get_slot(js->global, SLOT_ASYNC_GENERATOR_PROTO);
-    if (vtype(async_generator_proto) == T_FUNC) js_set_proto_init(func_obj, async_generator_proto);
-  }
-  
-  else if (child->is_async) {
-    js_set_slot(func_obj, SLOT_ASYNC, js_true);
-    ant_value_t async_proto = js_get_slot(js->global, SLOT_ASYNC_PROTO);
-    if (vtype(async_proto) == T_FUNC) js_set_proto_init(func_obj, async_proto);
-  }
-  
-  else if (child->is_generator) {
-    ant_value_t generator_proto = js_get_slot(js->global, SLOT_GENERATOR_PROTO);
-    if (vtype(generator_proto) == T_FUNC) js_set_proto_init(func_obj, generator_proto);
-  }
-  
-  else {
-    ant_value_t func_proto = js_get_slot(js->global, SLOT_FUNC_PROTO);
-    if (vtype(func_proto) == T_FUNC) js_set_proto_init(func_obj, func_proto);
-  }
+  sv_init_closure_function_object(js, closure, func_val, module_ctx);
   
   return js_mkundef();
 }

--- a/src/silver/swarm.c
+++ b/src/silver/swarm.c
@@ -417,6 +417,40 @@ static void mir_emit_fill_param_slots_from_args(
   }
 }
 
+static void mir_emit_fill_uncaptured_param_slots_from_args(
+  MIR_context_t ctx, MIR_item_t fn,
+  MIR_reg_t r_slotbuf, MIR_reg_t r_args, MIR_reg_t r_argc,
+  bool *captured_params, int param_count
+) {
+  if (!captured_params) return;
+  for (int i = 0; i < param_count; i++) {
+    if (captured_params[i]) continue;
+    MIR_label_t arg_present = MIR_new_label(ctx);
+    MIR_label_t arg_done = MIR_new_label(ctx);
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_UBGT,
+        MIR_new_label_op(ctx, arg_present),
+        MIR_new_reg_op(ctx, r_argc),
+        MIR_new_int_op(ctx, (int64_t)i)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_I64,
+          (MIR_disp_t)(i * (int)sizeof(ant_value_t)), r_slotbuf, 0, 1),
+        MIR_new_uint_op(ctx, mkval(T_UNDEF, 0))));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_JMP,
+        MIR_new_label_op(ctx, arg_done)));
+    MIR_append_insn(ctx, fn, arg_present);
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_I64,
+          (MIR_disp_t)(i * (int)sizeof(ant_value_t)), r_slotbuf, 0, 1),
+        MIR_new_mem_op(ctx, MIR_T_I64,
+          (MIR_disp_t)(i * (int)sizeof(ant_value_t)), r_args, 0, 1)));
+    MIR_append_insn(ctx, fn, arg_done);
+  }
+}
+
 static void mir_emit_spill_child_captured_locals(
   MIR_context_t ctx, MIR_item_t fn,
   sv_func_t *parent_func, sv_func_t *child,
@@ -8185,6 +8219,10 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
 
     MIR_reg_t r_resume_res = MIR_new_func_reg(ctx, jit_func->u.func,
                                                MIR_JSVAL, "resume_res");
+    if (has_captured_params) {
+      mir_emit_fill_uncaptured_param_slots_from_args(
+        ctx, jit_func, r_slotbuf, r_args, r_argc, captured_params, param_count);
+    }
     MIR_append_insn(ctx, jit_func,
       MIR_new_call_insn(ctx, 15,
         MIR_new_ref_op(ctx, resume_proto),

--- a/src/silver/swarm.c
+++ b/src/silver/swarm.c
@@ -67,6 +67,7 @@ static void jit_load_externals_once(sv_jit_ctx_t *jc) {
   LOAD_EXT(jit_helper_to_propkey);
   LOAD_EXT(jit_helper_bailout_resume);
   LOAD_EXT(jit_helper_close_upval);
+  LOAD_EXT(jit_helper_adopt_open_upvalues);
   LOAD_EXT(jit_helper_closure);
   LOAD_EXT(jit_helper_in);
   LOAD_EXT(jit_helper_instanceof);
@@ -442,22 +443,46 @@ static void mir_emit_close_marked_slots(
   MIR_context_t ctx, MIR_item_t fn,
   MIR_item_t close_upval_proto, MIR_item_t imp_close_upval,
   MIR_reg_t r_vm, MIR_reg_t r_slots,
+  MIR_reg_t r_open_upvalues,
   bool *captured, int start_idx, int slot_count
 ) {
   if (!captured || start_idx >= slot_count || slot_count <= 0 || !r_slots) return;
   if (start_idx < 0) start_idx = 0;
 
-  for (int i = start_idx; i < slot_count; i++) {
-    if (!captured[i]) continue;
-    MIR_append_insn(ctx, fn,
-      MIR_new_call_insn(ctx, 6,
-        MIR_new_ref_op(ctx, close_upval_proto),
-        MIR_new_ref_op(ctx, imp_close_upval),
-        MIR_new_reg_op(ctx, r_vm),
-        MIR_new_uint_op(ctx, (uint64_t)i),
-        MIR_new_reg_op(ctx, r_slots),
-        MIR_new_int_op(ctx, i + 1)));
+  int first_captured = -1;
+  for (int i = start_idx; i < slot_count; i++) if (captured[i]) {
+    first_captured = i;
+    break;
   }
+  if (first_captured < 0) return;
+
+  static uint32_t close_guard_seq = 0;
+  char open_name[32];
+  snprintf(open_name, sizeof(open_name), "open_upvals_%u", close_guard_seq++);
+  MIR_reg_t r_open = MIR_new_func_reg(ctx, fn->u.func, MIR_T_I64, open_name);
+  MIR_label_t no_open = MIR_new_label(ctx);
+  MIR_append_insn(ctx, fn,
+    MIR_new_insn(ctx, MIR_MOV,
+      MIR_new_reg_op(ctx, r_open),
+      MIR_new_mem_op(ctx, MIR_T_I64,
+        r_open_upvalues ? 0 : (MIR_disp_t)offsetof(sv_vm_t, open_upvalues),
+        r_open_upvalues ? r_open_upvalues : r_vm, 0, 1)));
+  MIR_append_insn(ctx, fn,
+    MIR_new_insn(ctx, MIR_BEQ,
+      MIR_new_label_op(ctx, no_open),
+      MIR_new_reg_op(ctx, r_open),
+      MIR_new_uint_op(ctx, 0)));
+
+  MIR_append_insn(ctx, fn,
+    MIR_new_call_insn(ctx, 7,
+      MIR_new_ref_op(ctx, close_upval_proto),
+      MIR_new_ref_op(ctx, imp_close_upval),
+      MIR_new_reg_op(ctx, r_vm),
+      MIR_new_uint_op(ctx, (uint64_t)first_captured),
+      MIR_new_reg_op(ctx, r_slots),
+      MIR_new_int_op(ctx, slot_count),
+      r_open_upvalues ? MIR_new_reg_op(ctx, r_open_upvalues) : MIR_new_uint_op(ctx, 0)));
+  MIR_append_insn(ctx, fn, no_open);
 }
 
 static inline void mir_emit_self_tail(
@@ -756,7 +781,7 @@ static bool mir_emit_get_field_ic_fastpath(
   if (is_length_key(atom->str, atom->len)) return false;
 
   sv_ic_entry_t *ic = &func->ic_slots[ic_idx];
-  if (!sv_gf_ic_active(ic->cached_aux)) return false;
+  if (!sv_gf_ic_active(ic->cached_aux) && func->code_len > 1024) return false;
   char gf_ic_name[32], gf_ice_name[32];
   char gf_ot_name[32], gf_op_name[32], gf_os_name[32], gf_ics_name[32];
   char gf_h_name[32], gf_hs_name[32], gf_idx_name[32], gf_pc_name[32];
@@ -2240,14 +2265,26 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
     func->jit_compile_failed = true;
     return NULL;
   }
-  if (!jit_is_eligible(func)) { func->jit_compile_failed = true; return NULL; }
+  
+  if (!jit_is_eligible(func)) {
+    func->jit_compile_failed = true;
+    return NULL;
+  }
+  
   func->jit_compiling = true;
-
   sv_jit_ctx_t *jc = jit_ctx_get(js);
-  if (!jc) { sv_jit_init(js); jc = jit_ctx_get(js); }
-  if (!jc) { func->jit_compiling = false; return NULL; }
+  
+  if (!jc) { 
+    sv_jit_init(js);
+    jc = jit_ctx_get(js);
+  }
+  
+  if (!jc) {
+    func->jit_compiling = false;
+    return NULL;
+  }
+  
   jit_load_externals_once(jc);
-
   MIR_context_t ctx = jc->ctx;
 
   char fname[128];
@@ -2255,7 +2292,6 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
            func->name ? func->name : "anon", (void *)func);
 
   MIR_module_t mod = MIR_new_module(ctx, fname);
-
   MIR_type_t ret_type = MIR_JSVAL;
 
   MIR_item_t self_proto = MIR_new_proto(ctx, "jit_proto",
@@ -2412,7 +2448,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
 
   MIR_type_t br_ret = MIR_JSVAL;
   MIR_item_t resume_proto = MIR_new_proto(ctx, "resume_proto",
-    1, &br_ret, 10,
+    1, &br_ret, 12,
     MIR_T_I64,  "vm",
     MIR_T_P,    "closure",
     MIR_JSVAL,  "this_val",
@@ -2420,13 +2456,15 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
     MIR_T_I32,  "argc",
     MIR_T_P,    "vstack",
     MIR_T_I64,  "vstack_sp",
+    MIR_T_P,    "params",
+    MIR_T_I64,  "n_params",
     MIR_T_P,    "locals",
     MIR_T_I64,  "n_locals",
     MIR_T_I64,  "bc_offset");
 
   MIR_type_t cl_ret = MIR_JSVAL;
   MIR_item_t closure_proto = MIR_new_proto(ctx, "closure_proto",
-    1, &cl_ret, 8,
+    1, &cl_ret, 11,
     MIR_T_I64,  "vm",
     MIR_T_I64,  "js",
     MIR_T_P,    "parent",
@@ -2434,14 +2472,23 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
     MIR_T_P,    "slots",
     MIR_T_I32,  "slot_base",
     MIR_T_I32,  "slot_count",
-    MIR_T_I32,  "const_idx");
+    MIR_T_I32,  "const_idx",
+    MIR_T_P,    "name",
+    MIR_T_I32,  "name_len",
+    MIR_T_P,    "open_upvalues");
 
   MIR_item_t close_upval_proto = MIR_new_proto(ctx, "close_upval_proto",
-    0, NULL, 4,
+    0, NULL, 5,
     MIR_T_I64, "vm",
     MIR_T_I32, "slot_idx",
     MIR_T_P,   "slots",
-    MIR_T_I32, "slot_count");
+    MIR_T_I32, "slot_count",
+    MIR_T_P,   "open_upvalues");
+
+  MIR_item_t adopt_open_upvalues_proto = MIR_new_proto(ctx, "adopt_open_upvalues_proto",
+    0, NULL, 2,
+    MIR_T_I64, "vm",
+    MIR_T_P,   "open_upvalues");
 
   MIR_item_t set_name_proto = MIR_new_proto(ctx, "sn_proto",
     0, NULL, 4,
@@ -2597,6 +2644,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
   MIR_item_t imp_to_propkey = MIR_new_import(ctx, "jit_helper_to_propkey");
   MIR_item_t imp_resume     = MIR_new_import(ctx, "jit_helper_bailout_resume");
   MIR_item_t imp_close_upval = MIR_new_import(ctx, "jit_helper_close_upval");
+  MIR_item_t imp_adopt_open_upvalues = MIR_new_import(ctx, "jit_helper_adopt_open_upvalues");
   MIR_item_t imp_closure     = MIR_new_import(ctx, "jit_helper_closure");
   MIR_item_t imp_in          = MIR_new_import(ctx, "jit_helper_in");
   MIR_item_t imp_get_length  = MIR_new_import(ctx, "jit_helper_get_length");
@@ -2876,30 +2924,6 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
   bool use_unified_slotbuf = has_captured_slots && has_captures;
   int slotbuf_count = use_unified_slotbuf ? (param_count + n_locals) : param_count;
 
-  if (has_captured_params && needs_bailout) {
-    free(vs.regs);
-    free(vs.known_func);
-    free(vs.d_regs);
-    free(vs.slot_type);
-    free(vs.known_const);
-    free(vs.has_const);
-    free(local_regs);
-    free(local_d_regs);
-    free(known_func_locals);
-    free(known_type_locals);
-    free(captured_params);
-    free(captured_locals);
-    
-    MIR_finish_func(ctx);
-    MIR_finish_module(ctx);
-    MIR_remove_module(ctx, mod);
-    
-    func->jit_compile_failed = true;
-    func->jit_compiling = false;
-    
-    return NULL;
-  }
-
   MIR_reg_t r_slotbuf = r_tmp2;
   if (has_captured_slots && slotbuf_count > 0) {
     r_slotbuf = MIR_new_func_reg(ctx, jit_func->u.func, MIR_T_I64, "slotbuf");
@@ -2925,6 +2949,20 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         MIR_new_uint_op(ctx, (uint64_t)n_locals * sizeof(ant_value_t))));
   } else {
     mir_load_imm(ctx, jit_func, r_lbuf, 0);
+  }
+
+  bool use_jit_upvalue_list = has_captured_slots;
+  MIR_reg_t r_jit_open_upvalues = 0;
+  if (use_jit_upvalue_list) {
+    r_jit_open_upvalues = MIR_new_func_reg(ctx, jit_func->u.func, MIR_T_I64, "jit_open_upvalues");
+    MIR_append_insn(ctx, jit_func,
+      MIR_new_insn(ctx, MIR_ALLOCA,
+        MIR_new_reg_op(ctx, r_jit_open_upvalues),
+        MIR_new_uint_op(ctx, sizeof(sv_upvalue_t *))));
+    MIR_append_insn(ctx, jit_func,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_I64, 0, r_jit_open_upvalues, 0, 1),
+        MIR_new_uint_op(ctx, 0)));
   }
 
   jit_bailout_emit_t bailout_ctx = {
@@ -3603,13 +3641,19 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         MIR_reg_t rl = vstack_pop(&vs);
         MIR_reg_t rd = vstack_push(&vs);
 
-	        if (fb_never_num) {
-	          int pre_op_sp = vs.sp + 1;
-	          mir_emit_bailout_jump_typed(ctx, jit_func,
-	            r_bailout_off, bc_off,
-	            r_bailout_sp, pre_op_sp, bailout_tramp,
-	            r_args_buf, &vs, local_regs, n_locals, r_lbuf, r_d_slot,
-	            vs.sp - 1, l_is_num, vs.sp, r_is_num);
+        if (fb_never_num) {
+          MIR_append_insn(ctx, jit_func,
+            MIR_new_insn(ctx, MIR_MOV,
+              MIR_new_reg_op(ctx, r_bailout_val),
+              MIR_new_reg_op(ctx, rl)));
+          mir_call_helper2(ctx, jit_func, rd,
+                           helper2_proto, imp_add,
+                           r_vm, r_js, rl, rr);
+          mir_emit_bailout_check_typed(ctx, jit_func, rd,
+            r_bailout_val, r_bailout_off, bc_off,
+            r_bailout_sp, vs.sp + 1, bailout_tramp,
+            r_args_buf, &vs, local_regs, n_locals, r_lbuf, r_d_slot,
+            vs.sp - 1, l_is_num, vs.sp, r_is_num);
         } else if (fb_num_only && l_is_num && r_is_num) {
           MIR_reg_t fd_r   = vs.d_regs[vs.sp];     
           MIR_reg_t fd_dst = vs.d_regs[vs.sp - 1]; 
@@ -5309,11 +5353,12 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         if (has_captured_params && idx < (uint16_t)param_count)
           mir_emit_close_marked_slots(ctx, jit_func,
             close_upval_proto, imp_close_upval,
-            r_vm, r_slotbuf, captured_params, (int)idx, param_count);
+            r_vm, r_slotbuf, r_jit_open_upvalues,
+            captured_params, (int)idx, param_count);
         if (has_captures)
           mir_emit_close_marked_slots(ctx, jit_func,
             close_upval_proto, imp_close_upval,
-            r_vm, r_lbuf, captured_locals,
+            r_vm, r_lbuf, r_jit_open_upvalues, captured_locals,
             idx >= (uint16_t)param_count ? (int)idx - param_count : 0, n_locals);
         break;
       }
@@ -5362,11 +5407,11 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         if (has_captured_slots)
           mir_emit_close_marked_slots(ctx, jit_func,
             close_upval_proto, imp_close_upval,
-            r_vm, r_slotbuf, captured_params, 0, param_count);
+            r_vm, r_slotbuf, r_jit_open_upvalues, captured_params, 0, param_count);
         if (has_captures)
           mir_emit_close_marked_slots(ctx, jit_func,
             close_upval_proto, imp_close_upval,
-            r_vm, r_lbuf, captured_locals, 0, n_locals);
+            r_vm, r_lbuf, r_jit_open_upvalues, captured_locals, 0, n_locals);
         MIR_append_insn(ctx, jit_func,
           MIR_new_ret_insn(ctx, 1, MIR_new_reg_op(ctx, ret_val)));
         break;
@@ -5376,11 +5421,11 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         if (has_captured_slots)
           mir_emit_close_marked_slots(ctx, jit_func,
             close_upval_proto, imp_close_upval,
-            r_vm, r_slotbuf, captured_params, 0, param_count);
+            r_vm, r_slotbuf, r_jit_open_upvalues, captured_params, 0, param_count);
         if (has_captures)
           mir_emit_close_marked_slots(ctx, jit_func,
             close_upval_proto, imp_close_upval,
-            r_vm, r_lbuf, captured_locals, 0, n_locals);
+            r_vm, r_lbuf, r_jit_open_upvalues, captured_locals, 0, n_locals);
         MIR_append_insn(ctx, jit_func,
           MIR_new_ret_insn(ctx, 1,
             MIR_new_uint_op(ctx, mkval(T_UNDEF, 0))));
@@ -5815,9 +5860,8 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         uint16_t ic_idx = sv_get_u16(ip + 5);
         MIR_label_t no_err = MIR_new_label(ctx);
         MIR_label_t slow = MIR_new_label(ctx);
-        bool has_fast_path = mir_emit_get_field_ic_fastpath(
-          ctx, jit_func, func, bc_off, ic_idx, atom, obj, dst, slow, r_ic_epoch_val);
-        if (has_fast_path) {
+        if (mir_emit_get_field_ic_fastpath(
+          ctx, jit_func, func, bc_off, ic_idx, atom, obj, dst, slow, r_ic_epoch_val)) {
           MIR_append_insn(ctx, jit_func,
             MIR_new_insn(ctx, MIR_JMP,
               MIR_new_label_op(ctx, no_err)));
@@ -5872,9 +5916,8 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         uint16_t ic_idx = sv_get_u16(ip + 5);
         MIR_label_t no_err = MIR_new_label(ctx);
         MIR_label_t slow = MIR_new_label(ctx);
-        bool has_fast_path = mir_emit_get_field_ic_fastpath(
-          ctx, jit_func, func, bc_off, ic_idx, atom, obj, dst, slow, r_ic_epoch_val);
-        if (has_fast_path) {
+        if (mir_emit_get_field_ic_fastpath(
+          ctx, jit_func, func, bc_off, ic_idx, atom, obj, dst, slow, r_ic_epoch_val)) {
           MIR_append_insn(ctx, jit_func,
             MIR_new_insn(ctx, MIR_JMP,
               MIR_new_label_op(ctx, no_err)));
@@ -8039,6 +8082,30 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
       case OP_CLOSURE: {
         uint32_t idx = sv_get_u32(ip + 1);
         if (idx >= (uint32_t)func->const_count) { ok = false; break; }
+        const char *name_str = NULL;
+        uint32_t name_len = 0;
+        int fused_set_name_size = 0;
+        uint8_t *next_ip = ip + sz;
+        if (next_ip < end && (sv_op_t)*next_ip == OP_SET_NAME) {
+          int next_sz = sv_op_size[OP_SET_NAME];
+          bool next_has_label = false;
+          int next_bc_off = (int)(next_ip - func->code);
+          for (int i = 0; i < lm.count; i++) {
+            if (lm.entries[i].bc_off == next_bc_off) {
+              next_has_label = true;
+              break;
+            }
+          }
+          if (!next_has_label && next_ip + next_sz <= end) {
+            uint32_t name_idx = sv_get_u32(next_ip + 1);
+            if (name_idx < (uint32_t)func->atom_count) {
+              sv_atom_t *name_atom = &func->atoms[name_idx];
+              name_str = name_atom->str;
+              name_len = name_atom->len;
+              fused_set_name_size = next_sz;
+            }
+          }
+        }
         MIR_reg_t dst = vstack_push(&vs);
         ant_value_t cv = func->constants[idx];
         sv_func_t *child = (sv_func_t *)(uintptr_t)vdata(cv);
@@ -8070,7 +8137,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
             break;
         }
         MIR_append_insn(ctx, jit_func,
-          MIR_new_call_insn(ctx, 11,
+          MIR_new_call_insn(ctx, 14,
             MIR_new_ref_op(ctx, closure_proto),
             MIR_new_ref_op(ctx, imp_closure),
             MIR_new_reg_op(ctx, dst),
@@ -8081,7 +8148,11 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
             MIR_new_reg_op(ctx, r_child_slots),
             MIR_new_int_op(ctx, child_slot_base),
             MIR_new_int_op(ctx, child_slot_count),
-            MIR_new_uint_op(ctx, (uint64_t)idx)));
+            MIR_new_uint_op(ctx, (uint64_t)idx),
+            MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)name_str),
+            MIR_new_uint_op(ctx, (uint64_t)name_len),
+            r_jit_open_upvalues ? MIR_new_reg_op(ctx, r_jit_open_upvalues) : MIR_new_uint_op(ctx, 0)));
+        sz += fused_set_name_size;
         break;
       }
 
@@ -8103,10 +8174,19 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
   if (needs_bailout) {
     MIR_append_insn(ctx, jit_func, bailout_tramp);
 
+    if (r_jit_open_upvalues) {
+      MIR_append_insn(ctx, jit_func,
+        MIR_new_call_insn(ctx, 4,
+          MIR_new_ref_op(ctx, adopt_open_upvalues_proto),
+          MIR_new_ref_op(ctx, imp_adopt_open_upvalues),
+          MIR_new_reg_op(ctx, r_vm),
+          MIR_new_reg_op(ctx, r_jit_open_upvalues)));
+    }
+
     MIR_reg_t r_resume_res = MIR_new_func_reg(ctx, jit_func->u.func,
                                                MIR_JSVAL, "resume_res");
     MIR_append_insn(ctx, jit_func,
-      MIR_new_call_insn(ctx, 13,
+      MIR_new_call_insn(ctx, 15,
         MIR_new_ref_op(ctx, resume_proto),
         MIR_new_ref_op(ctx, imp_resume),
         MIR_new_reg_op(ctx, r_resume_res),
@@ -8117,6 +8197,8 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         MIR_new_reg_op(ctx, r_argc),
         MIR_new_reg_op(ctx, r_args_buf),
         MIR_new_reg_op(ctx, r_bailout_sp),
+        has_captured_params ? MIR_new_reg_op(ctx, r_slotbuf) : MIR_new_uint_op(ctx, 0),
+        MIR_new_int_op(ctx, has_captured_params ? param_count : 0),
         MIR_new_reg_op(ctx, r_lbuf),
         MIR_new_int_op(ctx, n_locals),
         MIR_new_reg_op(ctx, r_bailout_off)));
@@ -8153,7 +8235,8 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
 
   func->jit_compiled_tfb_ver = func->tfb_version;
   func->jit_compiling = false;
-  return MIR_gen(ctx, jit_func);
+  sv_jit_func_t generated = MIR_gen(ctx, jit_func);
+  return generated;
 }
 
 static void sv_jit_compile_callees(ant_t *js, sv_func_t *func) {
@@ -8185,7 +8268,6 @@ ant_value_t sv_jit_try_compile_and_call(
   }
 
   fn->jit_code = (void *)jit;
-  sv_jit_compile_callees(js, fn);
   sv_jit_enter(js);
   ant_value_t result = jit(
     vm, ctx->this_val, js->new_target,

--- a/tests/bench_gc_mark_func.js
+++ b/tests/bench_gc_mark_func.js
@@ -87,6 +87,12 @@ function runCase(name, factory, opts = {}) {
   console.log(`const_slots=${stats.constSlots}`);
   console.log(`mark_func_ms=${stats.timeMs.toFixed(3)}`);
   console.log(`checksum=${checksum}`);
+
+  if (opts.expectedChecksum !== undefined && checksum !== opts.expectedChecksum) {
+    throw new Error(
+      `${name} checksum mismatch: got ${checksum}, expected ${opts.expectedChecksum}`
+    );
+  }
 }
 
 Ant.raw.gcMarkProfileEnable(true);
@@ -96,14 +102,16 @@ runCase('child-func-heavy', () => makeChildHeavyFunction(160), {
   fnCount: 20,
   rounds: 22,
   garbageRounds: 72,
-  garbageWidth: 224
+  garbageWidth: 224,
+  expectedChecksum: 5601420
 });
 
 runCase('template-slot-heavy', () => makeTemplateHeavyFunction(160), {
   fnCount: 20,
   rounds: 22,
   garbageRounds: 72,
-  garbageWidth: 224
+  garbageWidth: 224,
+  expectedChecksum: 211200
 });
 
 runCase(
@@ -119,6 +127,7 @@ runCase(
     fnCount: 20,
     rounds: 22,
     garbageRounds: 72,
-    garbageWidth: 224
+    garbageWidth: 224,
+    expectedChecksum: 2137740
   }
 );

--- a/tests/test_gc_async.js
+++ b/tests/test_gc_async.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 // Async GC stress: coroutine-heavy allocation without timers
 
 function stripAnsi(str) {
@@ -46,3 +56,4 @@ for (let count = 1; count <= 500; count++) {
 
 const a = Ant.stats();
 console.log(`done: total ${((a.pools.totalUsed + a.alloc.total) / 1024 / 1024).toFixed(1)}MB`);
+__gcPerfLog();

--- a/tests/test_gc_comprehensive.js
+++ b/tests/test_gc_comprehensive.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 console.log('=== Comprehensive GC Test ===');
 console.log('Starting...\n');
 
@@ -190,4 +200,5 @@ async function testAsyncGC() {
 testAsyncGC().then(result => {
   console.log('  Result:', result);
   console.log('\n=== All Tests Complete ===');
+  __gcPerfLog();
 });

--- a/tests/test_gc_coro.js
+++ b/tests/test_gc_coro.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 // Simulate TUI-like behavior: async handler with lots of string allocations
 
 function stripAnsi(str) {
@@ -57,6 +67,7 @@ const interval = setInterval(() => {
     setTimeout(() => {
       const a = Ant.stats();
       console.log(`done: total ${((a.pools.totalUsed + a.alloc.total) / 1024 / 1024).toFixed(1)}MB`);
+      __gcPerfLog();
     }, 10);
   }
 }, 10); // 500 * 10ms = 5 seconds

--- a/tests/test_gc_cycles.js
+++ b/tests/test_gc_cycles.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 console.log('=== Testing Multiple GC Cycles ===\n');
 
 let cycleData = { iteration: 0 };
@@ -14,3 +24,4 @@ console.log('  iteration:', cycleData.iteration);
 console.log('  data3.value:', cycleData.data3.value);
 
 console.log('\n=== Done ===');
+__gcPerfLog();

--- a/tests/test_gc_debug.js
+++ b/tests/test_gc_debug.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 console.log('=== Debug GC Test ===\n');
 
 // Test 1
@@ -84,3 +94,4 @@ console.log('  count:', counter.get());
 console.log('  OK\n');
 
 console.log('=== All tests passed ===');
+__gcPerfLog();

--- a/tests/test_gc_in_coro.js
+++ b/tests/test_gc_in_coro.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 // Test: GC compaction runs correctly inside coroutines.
 
 console.log('=== GC-in-coroutine test ===');
@@ -143,6 +153,7 @@ async function main() {
   trace('main: test5 complete');
 
   console.log('passed: ' + passed + ', failed: ' + failed);
+  __gcPerfLog();
   if (failed > 0) {
     console.log('FAIL');
     process.exit(1);

--- a/tests/test_gc_large.js
+++ b/tests/test_gc_large.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 console.log('=== GC Test with Large Objects ===\n');
 
 function fmt(bytes) {
@@ -60,3 +70,4 @@ console.log('');
 
 console.log('If arenaSize stayed same, GC reclaimed memory for reuse!');
 console.log('=== Test Complete ===');
+__gcPerfLog();

--- a/tests/test_gc_minimal8.js
+++ b/tests/test_gc_minimal8.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 console.log('=== Minimal Test 8 ===');
 console.log('Starting...');
 
@@ -45,3 +55,4 @@ for (let i = 0; i < 5; i = i + 1) {
   cycleData['data' + i] = { value: i * 10 };
 }
 console.log('Done');
+__gcPerfLog();

--- a/tests/test_gc_simple.js
+++ b/tests/test_gc_simple.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 console.log('=== Simple GC Test ===\n');
 
 // Test 1: Basic objects
@@ -12,3 +22,4 @@ map.set('key1', 'value1');
 console.log('After GC:', map.get('key1'));
 
 console.log('\n=== Done ===');
+__gcPerfLog();

--- a/tests/test_gc_stress10.js
+++ b/tests/test_gc_stress10.js
@@ -1,5 +1,15 @@
 import { Screen, colors, codes, pad, truncate } from '../examples/tui/tuey.js';
 
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 const screen = new Screen({ fullscreen: false, hideCursor: false });
 
 const logs = [
@@ -39,3 +49,4 @@ const f = Ant.stats();
 const fmem = (f.pools.totalUsed + f.alloc.total) / 1024 / 1024;
 console.log(`Done: ${total}s, total ${fmem.toFixed(1)}MB, rss ${(f.rss / 1024 / 1024).toFixed(1)}MB`);
 console.log('OK');
+__gcPerfLog();

--- a/tests/test_gc_stress7.js
+++ b/tests/test_gc_stress7.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 // Minimal crash: pad() + string concat in a nested loop
 function pad(s, n) {
   while (s.length < n) s += ' ';
@@ -13,3 +23,4 @@ for (let i = 0; i < 10000; i++) {
 }
 
 console.log('OK');
+__gcPerfLog();

--- a/tests/test_gc_tco.js
+++ b/tests/test_gc_tco.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 // Stress test: GC compaction during tail-call optimization
 // Verifies that tc.func, tc.closure_scope, and tc.args[] are properly
 // rooted so GC compaction doesn't corrupt them mid-trampoline.
@@ -187,3 +197,4 @@ if (failures === 0) {
 } else {
   console.log('Failures:', failures);
 }
+__gcPerfLog();

--- a/tests/test_gc_template_const_cache.cjs
+++ b/tests/test_gc_template_const_cache.cjs
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 function makeChildHeavyFunction(childCount) {
   let src = 'return function run(seed) {\n';
   for (let i = 0; i < childCount; i++) src += `function child_${i}(x) { return x + ${i}; }\n`;
@@ -59,3 +69,4 @@ for (let r = 0; r < 22; r++) {
 
 if (checksum !== 2137740) throw new Error(`bad checksum: ${checksum}`);
 console.log('ok');
+__gcPerfLog();

--- a/tests/test_gc_template_const_cache.cjs
+++ b/tests/test_gc_template_const_cache.cjs
@@ -1,0 +1,61 @@
+function makeChildHeavyFunction(childCount) {
+  let src = 'return function run(seed) {\n';
+  for (let i = 0; i < childCount; i++) src += `function child_${i}(x) { return x + ${i}; }\n`;
+  src += 'let acc = seed;\n';
+  for (let i = 0; i < childCount; i++) src += `acc = child_${i}(acc);\n`;
+  src += 'return acc;\n';
+  src += '}';
+  return new Function(src)();
+}
+
+function makeTemplateHeavyFunction(siteCount) {
+  let src = 'function tag(strs, ...args) { return strs.length + args.length; }\n';
+  src += 'return function run(seed) {\n';
+  src += 'let acc = 0;\n';
+  for (let i = 0; i < siteCount; i++) src += `acc += tag\`${i}:\${seed}:${i}\`;\n`;
+  src += 'return acc;\n';
+  src += '}';
+  return new Function(src)();
+}
+
+function churnGarbage(rounds, width) {
+  const ring = new Array(8);
+  for (let r = 0; r < rounds; r++) {
+    const batch = new Array(width);
+    for (let i = 0; i < width; i++) batch[i] = { i, text: 'x' + i, arr: [i, i + 1, i + 2, i + 3] };
+    ring[r & 7] = batch;
+  }
+}
+
+function runPlain(factory) {
+  const fns = [];
+  for (let i = 0; i < 20; i++) fns.push(factory());
+  for (let r = 0; r < 22; r++) {
+    for (let i = 0; i < fns.length; i++) fns[i](r);
+    churnGarbage(72, 224);
+  }
+}
+
+runPlain(() => makeChildHeavyFunction(160));
+runPlain(() => makeTemplateHeavyFunction(160));
+
+const pairs = [];
+for (let i = 0; i < 20; i++) pairs.push([makeChildHeavyFunction(96), makeTemplateHeavyFunction(96)]);
+
+let checksum = 0;
+for (let r = 0; r < 22; r++) {
+  for (let i = 0; i < pairs.length; i++) {
+    const child = pairs[i][0](r);
+    const templ = pairs[i][1](r);
+    const got = child + templ;
+    const expected = r + 4848;
+    if (got !== expected) {
+      throw new Error(`template const cache corruption at pair ${i} round ${r}: child=${child} templ=${templ} got=${got} expected=${expected}`);
+    }
+    checksum += got;
+  }
+  churnGarbage(72, 224);
+}
+
+if (checksum !== 2137740) throw new Error(`bad checksum: ${checksum}`);
+console.log('ok');

--- a/tests/test_gc_timer.js
+++ b/tests/test_gc_timer.js
@@ -1,3 +1,13 @@
+const __gcPerfNow = () => (
+  typeof performance !== 'undefined' && performance && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+);
+const __gcPerfStart = __gcPerfNow();
+function __gcPerfLog() {
+  console.log(`[perf] runtime: ${(__gcPerfNow() - __gcPerfStart).toFixed(2)}ms`);
+}
+
 // Timer GC stress: interval-driven allocation without coroutines
 
 function stripAnsi(str) {
@@ -52,5 +62,6 @@ const interval = setInterval(() => {
     clearInterval(interval);
     const a = Ant.stats();
     console.log(`done: total ${((a.pools.totalUsed + a.alloc.total) / 1024 / 1024).toFixed(1)}MB`);
+    __gcPerfLog();
   }
 }, 10);

--- a/tests/test_jit_sparse_captured_param_bailout.cjs
+++ b/tests/test_jit_sparse_captured_param_bailout.cjs
@@ -1,0 +1,35 @@
+function assertEq(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + JSON.stringify(expected) +
+      ", got " + JSON.stringify(actual) + " (" + typeof actual + ")");
+  }
+}
+
+function sparseCapturedParam(a, b, x) {
+  const g = () => a;
+  const y = x + 1;
+  return b;
+}
+
+for (let i = 0; i < 300; i++) sparseCapturedParam(1, 123, 2);
+assertEq(
+  sparseCapturedParam(1, "SENTINEL-B", "x"),
+  "SENTINEL-B",
+  "bailout preserves non-captured sparse param"
+);
+
+function sparseCapturedParamWithWrite(a, b, x) {
+  const g = () => a;
+  b = b + "-written";
+  const y = x + 1;
+  return b;
+}
+
+for (let i = 0; i < 300; i++) sparseCapturedParamWithWrite(1, "warm", 2);
+assertEq(
+  sparseCapturedParamWithWrite(1, "SENTINEL-B", "x"),
+  "SENTINEL-B-written",
+  "bailout preserves updated non-captured sparse param"
+);
+
+console.log("OK: test_jit_sparse_captured_param_bailout");

--- a/tests/test_node_events_once_prototype_spoof.cjs
+++ b/tests/test_node_events_once_prototype_spoof.cjs
@@ -1,0 +1,38 @@
+const assert = require('node:assert');
+const events = require('node:events');
+
+const { EventEmitter } = events;
+
+globalThis.onunhandledrejection = () => {};
+
+(async () => {
+  const timeout = setTimeout(() => {
+    throw new Error('events.once prototype spoof rejection timed out');
+  }, 50);
+
+  try {
+    let emitterRejected = false;
+    try {
+      await events.once(Object.create(EventEmitter.prototype), 'ready');
+    } catch {
+      emitterRejected = true;
+    }
+    assert.strictEqual(emitterRejected, true);
+
+    let targetRejected = false;
+    try {
+      await events.once(Object.create(EventTarget.prototype), 'ready');
+    } catch {
+      targetRejected = true;
+    }
+    assert.strictEqual(targetRejected, true);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  console.log('node-events-once-prototype-spoof:ok');
+})().catch((err) => {
+  setTimeout(() => {
+    throw err;
+  });
+});


### PR DESCRIPTION
- add JIT-local open-upvalue tracking and adopt live upvalues on bailout
- preserve captured parameter slots across bailout resume
- avoid retrying direct-call JIT compilation after known compile failure
- share closure function-object initialization between interpreter and JIT
- add small safe JIT helper fast paths for string ops and property ICs
- keep sparse major GC cadence driven by live/pool pressure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Events API now rejects objects spoofing EventEmitter/EventTarget prototypes.

* **Improvements**
  * Smarter GC thresholds and pooled-live accounting for more stable memory behavior.
  * Centralized object-state flags improving property, proxy and extensibility semantics.
  * JIT closure/parameter/upvalue handling hardened to reduce bailouts and improve performance.

* **Tests**
  * Added tests for event prototype spoofing, JIT bailout, template-const cache; many GC tests now log runtime.
  * Shared test helper for reliable server startup in EventSource/WebSocket examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theMackabu/ant/pull/26)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->