### PR TITLE
dynamic export fixes

### DIFF
--- a/include/silver/compiler.h
+++ b/include/silver/compiler.h
@@ -23,12 +23,17 @@ typedef enum {
   SV_IMPORT_BIND_NAMED,
 } sv_import_bind_kind_t;
 
+typedef struct sv_export_name {
+  const char *name;
+  uint32_t len;
+  struct sv_export_name *next;
+} sv_export_name_t;
+
 typedef struct {
   uint8_t import_kind;
   const char *import_name;
   uint32_t import_name_len;
-  const char *export_name;
-  uint32_t export_name_len;
+  sv_export_name_t *exports;
 } sv_binding_meta_t;
 
 typedef struct {

--- a/include/silver/glue.h
+++ b/include/silver/glue.h
@@ -106,8 +106,8 @@ ant_value_t jit_helper_import_named(
 );
 
 ant_value_t jit_helper_export(
-  ant_t *js, const char *str, 
-  uint32_t len, ant_value_t value
+  ant_t *js, sv_closure_t *closure,
+  const char *str, uint32_t len, ant_value_t value
 );
 
 ant_value_t jit_helper_closure(

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -774,10 +774,7 @@ static void merge_binding_meta(sv_binding_meta_t *dst, const sv_binding_meta_t *
     dst->import_name_len = src->import_name_len;
   }
 
-  if (src->export_name) {
-    dst->export_name = src->export_name;
-    dst->export_name_len = src->export_name_len;
-  }
+  if (src->exports) dst->exports = src->exports;
 }
 
 static void ensure_upvalue_capacity(sv_compiler_t *c) {
@@ -1111,6 +1108,16 @@ static void emit_get_var(sv_compiler_t *c, const char *name, uint32_t len) {
   else emit_atom_op(c, OP_GET_GLOBAL, name, len);
 }
 
+static void emit_export_dups(sv_compiler_t *c, const sv_export_name_t *exports) {
+  for (const sv_export_name_t *e = exports; e; e = e->next)
+    emit_op(c, OP_DUP);
+}
+
+static void emit_export_writes(sv_compiler_t *c, const sv_export_name_t *exports) {
+  for (const sv_export_name_t *e = exports; e; e = e->next)
+    emit_atom_op(c, OP_EXPORT, e->name, e->len);
+}
+
 static void emit_set_var(sv_compiler_t *c, const char *name, uint32_t len, bool keep) {
   int local = resolve_local(c, name, len);
   if (local != -1) {
@@ -1119,18 +1126,17 @@ static void emit_set_var(sv_compiler_t *c, const char *name, uint32_t len, bool 
       return;
     }
     set_local_inferred_type(c, local, SV_TI_UNKNOWN);
-    const char *export_name = c->locals[local].binding.export_name;
-    uint32_t export_name_len = c->locals[local].binding.export_name_len;
-    if (export_name) emit_op(c, OP_DUP);
+    const sv_export_name_t *exports = c->locals[local].binding.exports;
+    emit_export_dups(c, exports);
 
     if (c->with_depth > 0) {
       uint8_t kind = c->locals[local].depth == -1 ? WITH_FB_ARG : WITH_FB_LOCAL;
-      uint16_t idx = kind == WITH_FB_ARG 
+      uint16_t idx = kind == WITH_FB_ARG
         ? (uint16_t)local
         : (uint16_t)(local - c->param_locals);
       if (keep) emit_op(c, OP_DUP);
       emit_with_put(c, name, len, kind, idx);
-      if (export_name) emit_atom_op(c, OP_EXPORT, export_name, export_name_len);
+      emit_export_writes(c, exports);
       return;
     }
     if (c->locals[local].depth == -1) {
@@ -1138,14 +1144,14 @@ static void emit_set_var(sv_compiler_t *c, const char *name, uint32_t len, bool 
       emit_u16(c, (uint16_t)local);
     } else {
       int slot = local - c->param_locals;
-      sv_op_t op = keep 
+      sv_op_t op = keep
         ? (slot <= 255 ? OP_SET_LOCAL8 : OP_SET_LOCAL)
         : (slot <= 255 ? OP_PUT_LOCAL8 : OP_PUT_LOCAL);
       emit_op(c, op);
       if (slot <= 255) emit(c, (uint8_t)slot);
       else emit_u16(c, (uint16_t)slot);
     }
-    if (export_name) emit_atom_op(c, OP_EXPORT, export_name, export_name_len);
+    emit_export_writes(c, exports);
     return;
   }
   int upval = resolve_upvalue(c, name, len);
@@ -1154,19 +1160,17 @@ static void emit_set_var(sv_compiler_t *c, const char *name, uint32_t len, bool 
       emit_const_assign_error(c, name, len);
       return;
     }
-    sv_binding_meta_t *meta = &c->upval_bindings[upval];
-    const char *export_name = meta->export_name;
-    uint32_t export_name_len = meta->export_name_len;
-    if (export_name) emit_op(c, OP_DUP);
+    const sv_export_name_t *exports = c->upval_bindings[upval].exports;
+    emit_export_dups(c, exports);
     if (c->with_depth > 0) {
       if (keep) emit_op(c, OP_DUP);
       emit_with_put(c, name, len, WITH_FB_UPVAL, (uint16_t)upval);
-      if (export_name) emit_atom_op(c, OP_EXPORT, export_name, export_name_len);
+      emit_export_writes(c, exports);
       return;
     }
     emit_op(c, keep ? OP_SET_UPVAL : OP_PUT_UPVAL);
     emit_u16(c, (uint16_t)upval);
-    if (export_name) emit_atom_op(c, OP_EXPORT, export_name, export_name_len);
+    emit_export_writes(c, exports);
     return;
   }
   if (has_module_import_binding(c) && is_ident_str(name, len, "import", 6)) {
@@ -1499,11 +1503,34 @@ static void annex_b_collect_block_var_funcs(sv_ast_t *node, sv_ast_list_t *out) 
   }
 }
 
-static void mark_export_binding(sv_compiler_t *c, const char *name, uint32_t len) {
+static void mark_export_binding_as(
+  sv_compiler_t *c,
+  const char *name, uint32_t len,
+  const char *export_name, uint32_t export_name_len
+) {
   int local = resolve_local(c, name, len);
   if (local == -1) return;
-  c->locals[local].binding.export_name = name;
-  c->locals[local].binding.export_name_len = len;
+
+  /* tail-append so binding meta already copied into nested compilers
+     (which share the list head) sees later aliases too */
+  sv_export_name_t **slot = &c->locals[local].binding.exports;
+  while (*slot) {
+    if ((*slot)->len == export_name_len &&
+        memcmp((*slot)->name, export_name, export_name_len) == 0)
+      return;
+    slot = &(*slot)->next;
+  }
+
+  sv_export_name_t *node = code_arena_bump(sizeof(sv_export_name_t));
+  if (!node) return;
+  node->name = export_name;
+  node->len = export_name_len;
+  node->next = NULL;
+  *slot = node;
+}
+
+static void mark_export_binding(sv_compiler_t *c, const char *name, uint32_t len) {
+  mark_export_binding_as(c, name, len, name, len);
 }
 
 static void mark_export_pattern(sv_compiler_t *c, sv_ast_t *pat) {
@@ -1587,8 +1614,20 @@ static void hoist_lexical_decls(sv_compiler_t *c, sv_ast_list_t *stmts) {
         emit_op(c, OP_SET_LOCAL_UNDEF);
         emit_u16(c, (uint16_t)slot);
       }
+      if (node->type == N_EXPORT) {
+        if (node->flags & EX_DEFAULT)
+          mark_export_binding_as(c, decl_node->str, decl_node->len, "default", 7);
+        else
+          mark_export_binding(c, decl_node->str, decl_node->len);
+      }
     } else if (decl_node->type == N_FUNC && decl_node->str && !(decl_node->flags & (FN_ARROW | FN_PAREN))) {
       ensure_local_at_depth(c, decl_node->str, decl_node->len, false, c->scope_depth);
+      if (node->type == N_EXPORT) {
+        if (node->flags & EX_DEFAULT)
+          mark_export_binding_as(c, decl_node->str, decl_node->len, "default", 7);
+        else
+          mark_export_binding(c, decl_node->str, decl_node->len);
+      }
     }
     if (!c->is_strict && (decl_node->type == N_IF || decl_node->type == N_LABEL)) {
       sv_ast_list_t funcs = {0};
@@ -1607,6 +1646,35 @@ static void hoist_lexical_decls(sv_compiler_t *c, sv_ast_list_t *stmts) {
         if (resolve_local_at_depth(c, fn->str, fn->len, 0) == -1)
           add_local(c, fn->str, fn->len, false, 0);
       }
+    }
+  }
+
+  /* second pass: export clauses and exported var decls can precede the
+     declarations they reference, so mark them once every hoisted local
+     exists (var locals were hoisted before this function ran) */
+  for (int i = 0; i < stmts->count; i++) {
+    sv_ast_t *node = stmts->items[i];
+    if (!node || node->type != N_EXPORT) continue;
+
+    if ((node->flags & EX_DECL) && node->left && node->left->type == N_VAR) {
+      for (int j = 0; j < node->left->args.count; j++) {
+        sv_ast_t *decl = node->left->args.items[j];
+        if (!decl || decl->type != N_VARDECL) continue;
+        mark_export_pattern(c, decl->left);
+      }
+      continue;
+    }
+
+    if (!(node->flags & EX_NAMED) || (node->flags & (EX_FROM | EX_DECL | EX_DEFAULT | EX_STAR)))
+      continue;
+    for (int j = 0; j < node->args.count; j++) {
+      sv_ast_t *spec = node->args.items[j];
+      if (!spec || spec->type != N_IMPORT_SPEC || !spec->left || !spec->right ||
+          spec->left->type != N_IDENT || spec->right->type != N_IDENT)
+        continue;
+      mark_export_binding_as(
+        c, spec->left->str, spec->left->len,
+        spec->right->str, spec->right->len);
     }
   }
 }
@@ -4037,11 +4105,7 @@ void compile_import_decl(sv_compiler_t *c, sv_ast_t *node) {
 }
 
 static void compile_export_emit(sv_compiler_t *c, const char *name, uint32_t len) {
-  int local = resolve_local(c, name, len);
-  if (local != -1) {
-    c->locals[local].binding.export_name = name;
-    c->locals[local].binding.export_name_len = len;
-  }
+  mark_export_binding(c, name, len);
   emit_get_var(c, name, len);
   emit_atom_op(c, OP_EXPORT, name, len);
 }

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -4106,8 +4106,19 @@ void compile_import_decl(sv_compiler_t *c, sv_ast_t *node) {
 
 static void compile_export_emit(sv_compiler_t *c, const char *name, uint32_t len) {
   mark_export_binding(c, name, len);
+  int local = resolve_local(c, name, len);
+  const sv_export_name_t *exports =
+    (local >= 0) ? c->locals[local].binding.exports : NULL;
+
   emit_get_var(c, name, len);
-  emit_atom_op(c, OP_EXPORT, name, len);
+  if (!exports) {
+    emit_atom_op(c, OP_EXPORT, name, len);
+    return;
+  }
+
+  for (const sv_export_name_t *e = exports->next; e; e = e->next)
+    emit_op(c, OP_DUP);
+  emit_export_writes(c, exports);
 }
 
 static void defer_export(sv_compiler_t *c, const char *name, uint32_t len) {

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -1001,6 +1001,7 @@ static void emit_with_put(
 }
 
 static void emit_put_local(sv_compiler_t *c, int local_idx);
+static void emit_get_local(sv_compiler_t *c, int local_idx);
 static void emit_put_local_typed(sv_compiler_t *c, int local_idx, uint8_t type);
 
 static inline void emit_get_module_import_binding(sv_compiler_t *c) {
@@ -1116,6 +1117,21 @@ static void emit_export_dups(sv_compiler_t *c, const sv_export_name_t *exports) 
 static void emit_export_writes(sv_compiler_t *c, const sv_export_name_t *exports) {
   for (const sv_export_name_t *e = exports; e; e = e->next)
     emit_atom_op(c, OP_EXPORT, e->name, e->len);
+}
+
+static void emit_export_writes_from_stack(sv_compiler_t *c, const sv_export_name_t *exports) {
+  if (!exports) return;
+  for (const sv_export_name_t *e = exports->next; e; e = e->next)
+    emit_op(c, OP_DUP);
+  emit_export_writes(c, exports);
+}
+
+static void emit_local_export_writes(sv_compiler_t *c, int local) {
+  if (local < 0) return;
+  const sv_export_name_t *exports = c->locals[local].binding.exports;
+  if (!exports) return;
+  emit_get_local(c, local);
+  emit_export_writes_from_stack(c, exports);
 }
 
 static void emit_set_var(sv_compiler_t *c, const char *name, uint32_t len, bool keep) {
@@ -4116,9 +4132,7 @@ static void compile_export_emit(sv_compiler_t *c, const char *name, uint32_t len
     return;
   }
 
-  for (const sv_export_name_t *e = exports->next; e; e = e->next)
-    emit_op(c, OP_DUP);
-  emit_export_writes(c, exports);
+  emit_export_writes_from_stack(c, exports);
 }
 
 static void defer_export(sv_compiler_t *c, const char *name, uint32_t len) {
@@ -4193,6 +4207,14 @@ static void compile_export_pattern(sv_compiler_t *c, sv_ast_t *pat) {
     default:
       break;
   }
+}
+
+static bool export_clause_is_metadata_only(sv_compiler_t *c, sv_ast_t *spec) {
+  if (!spec || !spec->left || spec->left->type != N_IDENT) return false;
+  int local = resolve_local_at_depth(c, spec->left->str, spec->left->len, c->scope_depth);
+  if (local < 0) return false;
+  sv_local_t *loc = &c->locals[local];
+  return loc->is_tdz && loc->binding.import_kind == SV_IMPORT_BIND_NONE;
 }
 
 void compile_export_decl(sv_compiler_t *c, sv_ast_t *node) {
@@ -4280,6 +4302,8 @@ void compile_export_decl(sv_compiler_t *c, sv_ast_t *node) {
         emit_atom_op(c, OP_IMPORT_NAMED, spec->left->str, spec->left->len);
       emit_atom_op(c, OP_EXPORT, spec->right->str, spec->right->len);
     } else {
+      if (export_clause_is_metadata_only(c, spec))
+        continue;
       emit_get_var(c, spec->left->str, spec->left->len);
       emit_atom_op(c, OP_EXPORT, spec->right->str, spec->right->len);
     }
@@ -4336,6 +4360,7 @@ void compile_var_decl(sv_compiler_t *c, sv_ast_t *node) {
         if (decl->right || !is_const) {
           emit_put_local_typed(c, idx, init_type);
           c->locals[idx].is_tdz = false;
+          emit_local_export_writes(c, idx);
           if (is_using) {
             if (c->using_stack_local >= 0) {
               emit_get_local(c, c->using_stack_local);
@@ -5638,6 +5663,7 @@ void compile_class(sv_compiler_t *c, sv_ast_t *node) {
     emit_op(c, OP_DUP);
     emit_put_local(c, outer_name_local);
     c->locals[outer_name_local].is_tdz = false;
+    emit_local_export_writes(c, outer_name_local);
   }
 
   if (has_class_scope) end_scope(c);

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -774,7 +774,7 @@ static void merge_binding_meta(sv_binding_meta_t *dst, const sv_binding_meta_t *
     dst->import_name_len = src->import_name_len;
   }
 
-  if (src->exports) dst->exports = src->exports;
+  if (!dst->exports && src->exports) dst->exports = src->exports;
 }
 
 static void ensure_upvalue_capacity(sv_compiler_t *c) {

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -1925,7 +1925,7 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
   L_IMPORT_SYNC:     { VM_CHECK(sv_op_import_sync(vm, js));            NEXT(1); }
   L_IMPORT_DEFAULT:  { sv_op_import_default(vm, js);                   NEXT(1); }
   L_IMPORT_NAMED:    { VM_CHECK(sv_op_import_named(vm, js, func, ip)); NEXT(5); }
-  L_EXPORT:          { VM_CHECK(sv_op_export(vm, js, func, ip));       NEXT(5); }
+  L_EXPORT:          { VM_CHECK(sv_op_export(vm, js, frame, func, ip)); NEXT(5); }
   L_EXPORT_ALL:      { VM_CHECK(sv_op_export_all(vm, js));             NEXT(1); }
 
   L_ENTER_WITH:   { VM_CHECK(sv_op_enter_with(vm, js, frame));  NEXT(1); }

--- a/src/silver/glue.c
+++ b/src/silver/glue.c
@@ -627,10 +627,12 @@ ant_value_t jit_helper_import_named(
 }
 
 ant_value_t jit_helper_export(
-  ant_t *js, const char *str, 
-  uint32_t len, ant_value_t value
+  ant_t *js, sv_closure_t *closure,
+  const char *str, uint32_t len, ant_value_t value
 ) {
-  return sv_module_export_cstr(js, str, (size_t)len, value);
+  ant_value_t func_obj = closure ? closure->func_obj : js_mkundef();
+  ant_value_t ns = sv_export_target_ns_from_func_obj(js, func_obj);
+  return sv_module_export_to_ns(js, ns, str, (size_t)len, value);
 }
 
 static inline sv_upvalue_t *jit_make_undef_upvalue(void) {

--- a/src/silver/ops/coercion.h
+++ b/src/silver/ops/coercion.h
@@ -10,12 +10,11 @@
 #include "silver/engine.h"
 #include "modules/symbol.h"
 
-static inline ant_value_t sv_module_export_cstr(
-  ant_t *js,
+static inline ant_value_t sv_module_export_to_ns(
+  ant_t *js, ant_value_t module_ns,
   const char *name, size_t len,
   ant_value_t value
 ) {
-  ant_value_t module_ns = js_module_eval_active_ns(js);
   if (vtype(module_ns) != T_OBJ)
     return js_mkerr_typed(js, JS_ERR_SYNTAX, "export used outside module");
 
@@ -26,6 +25,30 @@ static inline ant_value_t sv_module_export_cstr(
     js_set_slot_wb(js, module_ns, SLOT_DEFAULT, value);
 
   return tov(0);
+}
+
+static inline ant_value_t sv_module_export_cstr(
+  ant_t *js,
+  const char *name, size_t len,
+  ant_value_t value
+) {
+  return sv_module_export_to_ns(js, js_module_eval_active_ns(js), name, len, value);
+}
+
+/* exports executed inside a function (live-binding writes) must target the
+   function's own module, not whichever module is currently mid-eval */
+static inline ant_value_t sv_export_target_ns_from_func_obj(ant_t *js, ant_value_t func_obj) {
+  if (is_object_type(func_obj)) {
+    ant_value_t ns = js_module_ctx_namespace(js_get_slot(func_obj, SLOT_MODULE_CTX));
+    if (vtype(ns) == T_OBJ) return ns;
+  }
+  return js_module_eval_active_ns(js);
+}
+
+static inline ant_value_t sv_export_target_ns(ant_t *js, ant_value_t callee) {
+  if (vtype(callee) == T_FUNC)
+    return sv_export_target_ns_from_func_obj(js, js_func_obj(callee));
+  return js_module_eval_active_ns(js);
 }
 
 static inline ant_value_t sv_op_to_object(sv_vm_t *vm, ant_t *js) {
@@ -184,14 +207,18 @@ static inline ant_value_t sv_op_import_named(
   return tov(0);
 }
 
-static inline ant_value_t sv_op_export(sv_vm_t *vm, ant_t *js, sv_func_t *func, uint8_t *ip) {
+static inline ant_value_t sv_op_export(
+  sv_vm_t *vm, ant_t *js,
+  sv_frame_t *frame, sv_func_t *func, uint8_t *ip
+) {
   uint32_t atom_idx = sv_get_u32(ip + 1);
   if (atom_idx >= (uint32_t)func->atom_count)
     return js_mkerr(js, "invalid export atom index");
 
   ant_value_t value = vm->stack[--vm->sp];
   sv_atom_t *a = &func->atoms[atom_idx];
-  return sv_module_export_cstr(js, a->str, a->len, value);
+  ant_value_t ns = sv_export_target_ns(js, frame ? frame->callee : js_mkundef());
+  return sv_module_export_to_ns(js, ns, a->str, a->len, value);
 }
 
 static inline ant_value_t sv_op_export_all(sv_vm_t *vm, ant_t *js) {

--- a/src/silver/swarm.c
+++ b/src/silver/swarm.c
@@ -2338,8 +2338,9 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
 
   MIR_type_t exp_ret = MIR_JSVAL;
   MIR_item_t export_proto = MIR_new_proto(ctx, "exp_proto",
-    1, &exp_ret, 4,
+    1, &exp_ret, 5,
     MIR_T_I64, "js",
+    MIR_T_P,   "closure",
     MIR_T_P,   "str",
     MIR_T_I32, "len",
     MIR_JSVAL,  "val");
@@ -6172,11 +6173,12 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         vstack_ensure_boxed(&vs, vs.sp - 1, ctx, jit_func, r_d_slot);
         MIR_reg_t val = vstack_pop(&vs);
         MIR_append_insn(ctx, jit_func,
-          MIR_new_call_insn(ctx, 7,
+          MIR_new_call_insn(ctx, 8,
             MIR_new_ref_op(ctx, export_proto),
             MIR_new_ref_op(ctx, imp_export),
             MIR_new_reg_op(ctx, r_err_tmp),
             MIR_new_reg_op(ctx, r_js),
+            MIR_new_reg_op(ctx, r_closure),
             MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)atom->str),
             MIR_new_uint_op(ctx, (uint64_t)atom->len),
             MIR_new_reg_op(ctx, val)));

--- a/tests/export_live_binding_exporter.mjs
+++ b/tests/export_live_binding_exporter.mjs
@@ -1,0 +1,20 @@
+export let counter = 0
+export let compound = 0
+export let destructured = 0
+let inner = 0
+export { inner as alias }
+export let multi = 0
+export { multi as multiB, multi as multiC }
+
+export var varBinding = 0
+export default function dflt() { return 'orig' }
+
+export function bump() { counter++ }
+export function writeAll() {
+  compound += 5;
+  [destructured] = [42];
+  inner = 99;
+  multi = 7;
+  varBinding = 11;
+}
+export function swapDefault() { dflt = () => 'swapped' }

--- a/tests/export_live_binding_exporter.mjs
+++ b/tests/export_live_binding_exporter.mjs
@@ -7,6 +7,8 @@ export let multi = 0
 export { multi as multiB, multi as multiC }
 
 export var varBinding = 0
+export var deferredAlias
+export { deferredAlias as deferredAliasA, deferredAlias as deferredAliasB }
 export default function dflt() { return 'orig' }
 
 export function bump() { counter++ }

--- a/tests/export_live_binding_exporter.mjs
+++ b/tests/export_live_binding_exporter.mjs
@@ -1,6 +1,12 @@
 export let counter = 0
 export let compound = 0
 export let destructured = 0
+export { forwardLexical as forwardLexicalAlias }
+let forwardLexical = 41
+export { ForwardClass as ForwardClassAlias }
+class ForwardClass {
+  static value = 42
+}
 let inner = 0
 export { inner as alias }
 export let multi = 0

--- a/tests/export_live_binding_runner.mjs
+++ b/tests/export_live_binding_runner.mjs
@@ -27,6 +27,10 @@ assert(ns.alias === 99, `aliased export clause: expected 99, got ${ns.alias}`);
 assert(ns.multi === 7 && ns.multiB === 7 && ns.multiC === 7,
   `multi-alias export must update every name: got ${ns.multi}/${ns.multiB}/${ns.multiC}`);
 assert(ns.varBinding === 11, `export var live binding: expected 11, got ${ns.varBinding}`);
+assert('deferredAlias' in ns && 'deferredAliasA' in ns && 'deferredAliasB' in ns,
+  'deferred export var aliases should be published');
+assert(ns.deferredAlias === undefined && ns.deferredAliasA === undefined && ns.deferredAliasB === undefined,
+  `deferred export var aliases should start undefined: got ${ns.deferredAlias}/${ns.deferredAliasA}/${ns.deferredAliasB}`);
 
 ns.swapDefault();
 assert(ns.default() === 'swapped',

--- a/tests/export_live_binding_runner.mjs
+++ b/tests/export_live_binding_runner.mjs
@@ -1,0 +1,41 @@
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// Writes to exported bindings must propagate to the module namespace (live
+// bindings), even when the write happens inside a function called while a
+// different module is mid-eval, or after all module evaluation finished.
+import * as ns from './export_live_binding_exporter.mjs';
+import { counter, bump, writeAll } from './export_live_binding_exporter.mjs';
+
+function readCounter() {
+  return counter;
+}
+
+assert(ns.counter === 0, `initial counter should be 0, got ${ns.counter}`);
+
+bump();
+bump();
+assert(ns.counter === 2, `namespace read after bump: expected 2, got ${ns.counter}`);
+assert(counter === 2, `direct import read after bump: expected 2, got ${counter}`);
+assert(readCounter() === 2, `hoisted-function read after bump: expected 2, got ${readCounter()}`);
+
+writeAll();
+assert(ns.compound === 5, `compound assignment export: expected 5, got ${ns.compound}`);
+assert(ns.destructured === 42, `destructuring assignment export: expected 42, got ${ns.destructured}`);
+assert(ns.alias === 99, `aliased export clause: expected 99, got ${ns.alias}`);
+assert(ns.multi === 7 && ns.multiB === 7 && ns.multiC === 7,
+  `multi-alias export must update every name: got ${ns.multi}/${ns.multiB}/${ns.multiC}`);
+assert(ns.varBinding === 11, `export var live binding: expected 11, got ${ns.varBinding}`);
+
+ns.swapDefault();
+assert(ns.default() === 'swapped',
+  `reassigned default-function binding must live-update: got ${ns.default()}`);
+
+// after the microtask queue drains, no module eval is active; writes must
+// still find the exporter's namespace through the function's module ctx
+await new Promise(resolve => setTimeout(resolve, 0));
+bump();
+assert(ns.counter === 3, `post-eval bump: expected 3, got ${ns.counter}`);
+
+console.log('export.live.binding:ok');

--- a/tests/export_live_binding_runner.mjs
+++ b/tests/export_live_binding_runner.mjs
@@ -23,6 +23,10 @@ assert(readCounter() === 2, `hoisted-function read after bump: expected 2, got $
 writeAll();
 assert(ns.compound === 5, `compound assignment export: expected 5, got ${ns.compound}`);
 assert(ns.destructured === 42, `destructuring assignment export: expected 42, got ${ns.destructured}`);
+assert(ns.forwardLexicalAlias === 41,
+  `forward lexical alias: expected 41, got ${ns.forwardLexicalAlias}`);
+assert(ns.ForwardClassAlias.value === 42,
+  `forward class alias: expected 42, got ${ns.ForwardClassAlias?.value}`);
 assert(ns.alias === 99, `aliased export clause: expected 99, got ${ns.alias}`);
 assert(ns.multi === 7 && ns.multiB === 7 && ns.multiC === 7,
   `multi-alias export must update every name: got ${ns.multi}/${ns.multiB}/${ns.multiC}`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bindings can have multiple named exports/aliases (including multiple re-exports and default aliases).

* **Bug Fixes**
  * Export writes now consistently target the correct module namespace across execution contexts, preserving live-binding updates.

* **Tests**
  * Added end-to-end tests validating live-binding propagation, aliases, compound/destructured updates, default reassignment, and namespace reflections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->