### PR TITLE
Fix UB in next iterator

### DIFF
--- a/include/modules/symbol.h
+++ b/include/modules/symbol.h
@@ -74,4 +74,11 @@ static inline ant_value_t js_iter_result(ant_t *js, bool has_value, ant_value_t 
   return result;
 }
 
+static inline ant_value_t js_iter_next_result(ant_t *js, js_iter_advance_fn advance) {
+  js_iter_t it = { .iterator = js->this_val };
+  ant_value_t value = js_mkundef();
+  bool has_value = advance(js, &it, &value);
+  return js_iter_result(js, has_value, value);
+}
+
 #endif

--- a/src/modules/buffer.c
+++ b/src/modules/buffer.c
@@ -200,9 +200,7 @@ static bool advance_typedarray(ant_t *js, js_iter_t *it, ant_value_t *out) {
 }
 
 static ant_value_t ta_iter_next(ant_t *js, ant_value_t *args, int nargs) {
-  js_iter_t it = { .iterator = js->this_val };
-  ant_value_t value;
-  return js_iter_result(js, advance_typedarray(js, &it, &value), value);
+  return js_iter_next_result(js, advance_typedarray);
 }
 
 static ant_value_t ta_values(ant_t *js, ant_value_t *args, int nargs) {

--- a/src/modules/collections.c
+++ b/src/modules/collections.c
@@ -389,9 +389,7 @@ bool advance_map(ant_t *js, js_iter_t *it, ant_value_t *out) {
 }
 
 static ant_value_t map_iter_next(ant_t *js, ant_value_t *args, int nargs) {
-  js_iter_t it = { .iterator = js->this_val };
-  ant_value_t value;
-  return js_iter_result(js, advance_map(js, &it, &value), value);
+  return js_iter_next_result(js, advance_map);
 }
 
 static ant_value_t create_map_iterator(ant_t *js, ant_value_t map_obj, iter_type_t type) {
@@ -444,9 +442,7 @@ bool advance_set(ant_t *js, js_iter_t *it, ant_value_t *out) {
 }
 
 static ant_value_t set_iter_next(ant_t *js, ant_value_t *args, int nargs) {
-  js_iter_t it = { .iterator = js->this_val };
-  ant_value_t value;
-  return js_iter_result(js, advance_set(js, &it, &value), value);
+  return js_iter_next_result(js, advance_set);
 }
 
 static ant_value_t create_set_iterator(ant_t *js, ant_value_t set_obj, iter_type_t type) {

--- a/src/modules/headers.c
+++ b/src/modules/headers.c
@@ -370,9 +370,7 @@ bool advance_headers(ant_t *js, js_iter_t *it, ant_value_t *out) {
 }
 
 static ant_value_t headers_iter_next(ant_t *js, ant_value_t *args, int nargs) {
-  js_iter_t it = { .iterator = js->this_val };
-  ant_value_t value;
-  return js_iter_result(js, advance_headers(js, &it, &value), value);
+  return js_iter_next_result(js, advance_headers);
 }
 
 static ant_value_t make_headers_iter(ant_t *js, ant_value_t headers_obj, int kind) {

--- a/src/modules/symbol.c
+++ b/src/modules/symbol.c
@@ -173,9 +173,7 @@ static bool advance_string(ant_t *js, js_iter_t *it, ant_value_t *out) {
 }
 
 static ant_value_t arr_iter_next(ant_t *js, ant_value_t *args, int nargs) {
-  js_iter_t it = { .iterator = js->this_val };
-  ant_value_t value;
-  return js_iter_result(js, advance_array(js, &it, &value), value);
+  return js_iter_next_result(js, advance_array);
 }
 
 static ant_value_t get_array_iterator_prototype(ant_t *js) {
@@ -199,9 +197,7 @@ ant_value_t make_array_iterator(ant_t *js, ant_value_t array, int kind) {
 }
 
 static ant_value_t str_iter_next(ant_t *js, ant_value_t *args, int nargs) {
-  js_iter_t it = { .iterator = js->this_val };
-  ant_value_t value;
-  return js_iter_result(js, advance_string(js, &it, &value), value);
+  return js_iter_next_result(js, advance_string);
 }
 
 static ant_value_t get_string_iterator_prototype(ant_t *js) {

--- a/tests/test_promise_all_array_iterator.cjs
+++ b/tests/test_promise_all_array_iterator.cjs
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+const p = new Promise(resolve => setTimeout(() => resolve(30), 1));
+
+Promise.all([p]).then(values => {
+  assert.strictEqual(values[0], 30);
+  console.log('promise-all-array-iterator:ok');
+});
+
+p.then(value => {
+  assert.strictEqual(value, 30);
+});


### PR DESCRIPTION
Fixes #39 by not relying on parameter ordering. Thanks C.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how iterators are handled across several built-in collection and text types, making iteration behavior more consistent and centralized.

* **Tests**
  * Added coverage for `Promise.all` with a single-item array to confirm the resolved result is returned as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->