### PR TITLE
guard JIT self-binding specialization

### DIFF
--- a/src/silver/swarm.c
+++ b/src/silver/swarm.c
@@ -4,6 +4,7 @@
 #include "silver/glue.h"
 #include "silver/engine.h"
 #include "silver/opcode.h"
+#include "ops/globals.h"
 
 #include "internal.h"
 #include "debug.h"
@@ -383,6 +384,40 @@ static void mir_emit_bailout_check(MIR_context_t ctx, MIR_item_t fn,
     r_bailout_sp, pre_op_sp, bailout_tramp,
     r_args_buf, vs, local_regs, n_locals, r_lbuf, r_d_slot,
     -1, false, -1, false);
+}
+
+static void mir_emit_self_binding_guard(
+  MIR_context_t ctx, MIR_item_t fn,
+  MIR_reg_t value, MIR_reg_t closure,
+  MIR_reg_t tag_tmp, MIR_reg_t expected_tmp,
+  int bc_off, int pre_op_sp,
+  jit_bailout_emit_t *bail
+) {
+  MIR_label_t match = MIR_new_label(ctx);
+  uint64_t func_tag = NANBOX_PREFIX
+    | ((ant_value_t)(T_FUNC & NANBOX_TYPE_MASK) << NANBOX_TYPE_SHIFT);
+
+  MIR_append_insn(ctx, fn,
+    MIR_new_insn(ctx, MIR_MOV,
+      MIR_new_reg_op(ctx, tag_tmp),
+      MIR_new_uint_op(ctx, func_tag)));
+  MIR_append_insn(ctx, fn,
+    MIR_new_insn(ctx, MIR_OR,
+      MIR_new_reg_op(ctx, expected_tmp),
+      MIR_new_reg_op(ctx, tag_tmp),
+      MIR_new_reg_op(ctx, closure)));
+  MIR_append_insn(ctx, fn,
+    MIR_new_insn(ctx, MIR_BEQ,
+      MIR_new_label_op(ctx, match),
+      MIR_new_reg_op(ctx, value),
+      MIR_new_reg_op(ctx, expected_tmp)));
+  mir_emit_bailout_jump_typed(ctx, fn,
+    bail->off, bc_off,
+    bail->sp, pre_op_sp, bail->tramp,
+    bail->args_buf, bail->vstack, bail->local_regs, bail->n_locals,
+    bail->lbuf, bail->d_slot,
+    -1, false, -1, false);
+  MIR_append_insn(ctx, fn, match);
 }
 
 
@@ -2339,6 +2374,64 @@ static jit_features_t jit_prescan_features(sv_func_t *func) {
   return f;
 }
 
+static bool jit_value_is_closure(
+  ant_value_t value, const sv_closure_t *expected
+) {
+  if (vtype(value) != T_FUNC) return false;
+  return js_func_closure(value) == expected;
+}
+
+static bool jit_try_get_global_data(
+  ant_t *js, sv_func_t *func, uint8_t *ip,
+  const sv_atom_t *atom, ant_value_t *out
+) {
+  if (!js || !func || !ip || !atom || !out) return false;
+  sv_ic_entry_t *ic = sv_global_ic_slot_for_ip(func, ip);
+  return sv_global_ic_try_get_hit(js->global, ic, atom->str, out) ||
+    sv_global_ic_try_fill(js->global, ic, atom->str, out);
+}
+
+static bool jit_mark_self_binding_guards(
+  ant_t *js, sv_func_t *func, sv_closure_t *hint_closure,
+  uint8_t *guard_sites
+) {
+  if (!js || !func || !hint_closure || !guard_sites) return false;
+
+  bool found = false;
+  uint8_t *ip = func->code;
+  uint8_t *end = func->code + func->code_len;
+  while (ip < end) {
+    sv_op_t op = (sv_op_t)*ip;
+    int sz = sv_op_size[op];
+    if (sz == 0) break;
+
+    if (op == OP_GET_UPVAL) {
+      uint16_t idx = sv_get_u16(ip + 1);
+      if (idx < (uint16_t)func->upvalue_count && func->upval_descs &&
+          hint_closure->upvalues && hint_closure->upvalues[idx] &&
+          jit_value_is_closure(
+            *hint_closure->upvalues[idx]->location, hint_closure)) {
+        guard_sites[ip - func->code] = 1;
+        found = true;
+      }
+    } else if (op == OP_GET_GLOBAL || op == OP_GET_GLOBAL_UNDEF) {
+      uint32_t idx = sv_get_u32(ip + 1);
+      if (idx < (uint32_t)func->atom_count) {
+        sv_atom_t *atom = &func->atoms[idx];
+        ant_value_t value;
+        if (jit_try_get_global_data(js, func, ip, atom, &value) &&
+            jit_value_is_closure(value, hint_closure)) {
+          guard_sites[ip - func->code] = 1;
+          found = true;
+        }
+      }
+    }
+
+    ip += sz;
+  }
+  return found;
+}
+
 static bool jit_is_eligible(sv_func_t *func) {
   if (func->is_async || func->is_generator) return false;
 
@@ -3057,7 +3150,14 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
   MIR_reg_t r_err_tmp = MIR_new_func_reg(ctx, jit_func->u.func, MIR_JSVAL, "err_tmp");
   mir_load_imm(ctx, jit_func, r_tmp2, 0);
 
+  uint8_t *self_binding_guards = calloc(
+    func->code_len > 0 ? (size_t)func->code_len : 1u, 1u);
   jit_features_t feat = jit_prescan_features(func);
+  if (jit_mark_self_binding_guards(
+        js, func, hint_closure, self_binding_guards)) {
+    feat.needs_bailout = true;
+    feat.needs_args_buf = true;
+  }
 
 
   MIR_reg_t r_d_slot = MIR_new_func_reg(ctx, jit_func->u.func, MIR_T_I64, "d_slot");
@@ -3458,8 +3558,13 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
           vs.sp = lm.entries[i].sp;
         if (vs.slot_type)
           memset(vs.slot_type, SLOT_BOXED, (size_t)vs.max);
+        if (vs.known_func)
+          memset(vs.known_func, 0, (size_t)vs.max * sizeof(sv_func_t *));
         if (vs.has_const)
           memset(vs.has_const, 0, (size_t)vs.max * sizeof(bool));
+        if (known_func_locals)
+          memset(known_func_locals, 0,
+                 (size_t)n_locals * sizeof(sv_func_t *));
         if (known_type_locals && local_d_regs) {
           for (int li = 0; li < n_locals; li++)
             if (known_type_locals[li] == SV_TI_NUM
@@ -5684,28 +5789,8 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
 
       case OP_GET_UPVAL: {
         uint16_t idx = sv_get_u16(ip + 1);
-
-        if (vs.known_func && hint_closure &&
-            idx < (uint16_t)func->upvalue_count &&
-            hint_closure->upvalues && hint_closure->upvalues[idx]) {
-          ant_value_t uv_val = *hint_closure->upvalues[idx]->location;
-          if (vtype(uv_val) == T_FUNC) {
-            sv_closure_t *ucl = js_func_closure(uv_val);
-            if (ucl && ucl->func == func) {
-              MIR_reg_t dst = vstack_push(&vs);
-              vs.known_func[vs.sp - 1] = func;
-              uint64_t func_tag = NANBOX_PREFIX
-                | ((ant_value_t)(T_FUNC & NANBOX_TYPE_MASK) << NANBOX_TYPE_SHIFT);
-              mir_load_imm(ctx, jit_func, r_tmp, func_tag);
-              MIR_append_insn(ctx, jit_func,
-                MIR_new_insn(ctx, MIR_OR,
-                  MIR_new_reg_op(ctx, dst),
-                  MIR_new_reg_op(ctx, r_tmp),
-                  MIR_new_reg_op(ctx, r_closure)));
-              break;
-            }
-          }
-        }
+        bool guarded_self_upval = self_binding_guards &&
+          self_binding_guards[bc_off] != 0;
 
         int un = upval_n++;
         char rn_uvs[32], rn_uv[32], rn_loc[32];
@@ -5716,6 +5801,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         MIR_reg_t r_uvs = MIR_new_func_reg(ctx, jit_func->u.func, MIR_T_I64, rn_uvs);
         MIR_reg_t r_uv  = MIR_new_func_reg(ctx, jit_func->u.func, MIR_T_I64, rn_uv);
         MIR_reg_t r_loc = MIR_new_func_reg(ctx, jit_func->u.func, MIR_T_I64, rn_loc);
+        int pre_op_sp = vs.sp;
         MIR_reg_t dst   = vstack_push(&vs);
 
         MIR_append_insn(ctx, jit_func,
@@ -5743,6 +5829,12 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
           MIR_new_insn(ctx, MIR_MOV,
             MIR_new_reg_op(ctx, dst),
             MIR_new_mem_op(ctx, MIR_JSVAL, 0, r_loc, 0, 1)));
+        if (guarded_self_upval) {
+          vs.known_func[vs.sp - 1] = func;
+          mir_emit_self_binding_guard(
+            ctx, jit_func, dst, r_closure, r_tmp, r_tmp2,
+            bc_off, pre_op_sp, &bailout_ctx);
+        }
         break;
       }
 
@@ -5859,26 +5951,10 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         uint32_t idx = sv_get_u32(ip + 1);
         if (idx >= (uint32_t)func->atom_count) { ok = false; break; }
         sv_atom_t *atom = &func->atoms[idx];
+        bool known_self_global = self_binding_guards &&
+          self_binding_guards[bc_off] != 0;
+        int pre_op_sp = vs.sp;
         MIR_reg_t dst = vstack_push(&vs);
-
-        if (vs.known_func) {
-          ant_value_t gv = jit_helper_get_global(js, atom->str, func, bc_off);
-          if (vtype(gv) == T_FUNC) {
-            sv_closure_t *gcl = js_func_closure(gv);
-            if (gcl && gcl->func == func) {
-              vs.known_func[vs.sp - 1] = func;
-              uint64_t func_tag = NANBOX_PREFIX
-                | ((ant_value_t)(T_FUNC & NANBOX_TYPE_MASK) << NANBOX_TYPE_SHIFT);
-              mir_load_imm(ctx, jit_func, r_tmp, func_tag);
-              MIR_append_insn(ctx, jit_func,
-                MIR_new_insn(ctx, MIR_OR,
-                  MIR_new_reg_op(ctx, dst),
-                  MIR_new_reg_op(ctx, r_tmp),
-                  MIR_new_reg_op(ctx, r_closure)));
-              break;
-            }
-          }
-        }
 
         MIR_append_insn(ctx, jit_func,
           MIR_new_call_insn(ctx, 7,
@@ -5889,6 +5965,12 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
             MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)atom->str),
             MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)func),
             MIR_new_int_op(ctx, (int64_t)bc_off)));
+        if (known_self_global) {
+          vs.known_func[vs.sp - 1] = func;
+          mir_emit_self_binding_guard(
+            ctx, jit_func, dst, r_closure, r_tmp, r_tmp2,
+            bc_off, pre_op_sp, &bailout_ctx);
+        }
         break;
       }
 
@@ -9181,6 +9263,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
   free(local_d_regs);
   free(known_func_locals);
   free(known_type_locals);
+  free(self_binding_guards);
   free(captured_params);
   free(captured_locals);
 

--- a/src/silver/swarm.c
+++ b/src/silver/swarm.c
@@ -6156,6 +6156,58 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         uint8_t idx = sv_get_u8(ip + 1);
         if (idx >= (uint8_t)n_locals) { ok = false; break; }
         if (known_func_locals) known_func_locals[idx] = NULL;
+
+        uint8_t fb = sv_func_type_feedback(func)
+          ? sv_func_type_feedback(func)[bc_off] : 0;
+        bool fb_num_only = fb && !(fb & ~SV_TFB_NUM);
+        bool loc_is_num = known_type_locals && local_d_regs &&
+          known_type_locals[idx] == SV_TI_NUM &&
+          (!captured_locals || !captured_locals[idx]);
+        bool rhs_is_num = vs.slot_type &&
+          vs.slot_type[vs.sp - 1] == SLOT_NUM;
+
+        if (fb_num_only && loc_is_num) {
+          int rhs_idx = vs.sp - 1;
+          int pre_op_sp = vs.sp;
+          MIR_reg_t rr = vs.regs[rhs_idx];
+          MIR_reg_t rr_d = vs.d_regs[rhs_idx];
+          MIR_label_t bail_direct = MIR_new_label(ctx);
+          MIR_label_t done = MIR_new_label(ctx);
+
+          if (!rhs_is_num) {
+            mir_emit_is_num_guard(ctx, jit_func, r_bool, rr, bail_direct);
+            mir_i64_to_d(ctx, jit_func, rr_d, rr, r_d_slot);
+          }
+
+          MIR_append_insn(ctx, jit_func,
+            MIR_new_insn(ctx, MIR_DADD,
+              MIR_new_reg_op(ctx, local_d_regs[idx]),
+              MIR_new_reg_op(ctx, local_d_regs[idx]),
+              MIR_new_reg_op(ctx, rr_d)));
+          mir_d_to_i64(ctx, jit_func,
+            local_regs[idx], local_d_regs[idx], r_d_slot);
+          if (has_captures && captured_locals && captured_locals[idx])
+            MIR_append_insn(ctx, jit_func,
+              MIR_new_insn(ctx, MIR_MOV,
+                MIR_new_mem_op(ctx, MIR_T_I64,
+                  (MIR_disp_t)((int)idx * (int)sizeof(ant_value_t)),
+                  r_lbuf, 0, 1),
+                MIR_new_reg_op(ctx, local_regs[idx])));
+          MIR_append_insn(ctx, jit_func,
+            MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, done)));
+
+          MIR_append_insn(ctx, jit_func, bail_direct);
+          mir_emit_bailout_jump_typed(ctx, jit_func,
+            r_bailout_off, bc_off,
+            r_bailout_sp, pre_op_sp, bailout_tramp,
+            r_args_buf, &vs, local_regs, n_locals, r_lbuf, r_d_slot,
+            -1, false, rhs_idx, rhs_is_num);
+          MIR_append_insn(ctx, jit_func, done);
+          vstack_pop(&vs);
+          break;
+        }
+
+        int pre_op_sp = vs.sp;
         vstack_ensure_boxed(&vs, vs.sp - 1, ctx, jit_func, r_d_slot);
         MIR_reg_t rr = vstack_pop(&vs);
 
@@ -6199,7 +6251,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
                          r_vm, r_js, local_regs[idx], rr);
         mir_emit_bailout_check(ctx, jit_func, local_regs[idx],
           r_bailout_val, r_bailout_off, bc_off,
-          r_bailout_sp, vs.sp, bailout_tramp,
+          r_bailout_sp, pre_op_sp, bailout_tramp,
           r_args_buf, &vs, local_regs, n_locals, r_lbuf, r_d_slot);
 
         MIR_append_insn(ctx, jit_func, done);

--- a/tests/test_jit_add_local_numeric_feedback.cjs
+++ b/tests/test_jit_add_local_numeric_feedback.cjs
@@ -1,0 +1,118 @@
+function assertSame(actual, expected, message) {
+  if (!Object.is(actual, expected)) {
+    throw new Error(`${message}: expected ${expected}, got ${actual}`);
+  }
+}
+
+function makeAdder(initial) {
+  let value = initial;
+
+  return {
+    run(n) {
+      let sum = 0;
+      for (let i = 0; i < n; i++) {
+        sum += value;
+      }
+      return sum;
+    },
+    set(next) {
+      value = next;
+    },
+  };
+}
+
+const adder = makeAdder(1.25);
+for (let i = 0; i < 300; i++) {
+  assertSame(adder.run(8), 10, "numeric warmup");
+}
+assertSame(adder.run(10_000), 12_500, "numeric fast path");
+
+// The numeric feedback guard must deopt before performing the addition when
+// the captured RHS changes type after JIT compilation.
+adder.set("x");
+assertSame(adder.run(3), "0xxx", "string feedback transition");
+
+adder.set(2);
+assertSame(adder.run(20), 40, "numeric execution after transition");
+
+adder.set(Symbol("value"));
+let threw = false;
+try {
+  adder.run(1);
+} catch (error) {
+  threw = error instanceof TypeError;
+}
+assertSame(threw, true, "symbol addition must still throw");
+
+function makeFastAdder(initial) {
+  let value = initial;
+
+  function run(n) {
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+      sum += value;
+    }
+    return sum;
+  }
+
+  function set(next) {
+    value = next;
+  }
+
+  return [run, set];
+}
+
+const [runFast, setFast] = makeFastAdder(0.5);
+for (let i = 0; i < 300; i++) {
+  assertSame(runFast(8), 4, "plain-function numeric warmup");
+}
+assertSame(runFast(10_000), 5_000, "plain-function numeric fast path");
+setFast("y");
+assertSame(runFast(3), "0yyy", "numeric fast-path deoptimization");
+
+function addFromSeed(seed, value, n) {
+  let sum = seed;
+  for (let i = 0; i < n; i++) {
+    sum += value;
+  }
+  return sum;
+}
+
+for (let i = 0; i < 300; i++) {
+  assertSame(addFromSeed(0, 2, 4), 8, "local numeric warmup");
+}
+assertSame(addFromSeed("", "a", 3), "aaa", "local type transition");
+
+function capturedTarget(n, changeAt) {
+  let sum = 0;
+  function replace(value) {
+    sum = value;
+  }
+
+  for (let i = 0; i < n; i++) {
+    if (i === changeAt) replace(100);
+    sum += 1;
+  }
+  return sum;
+}
+
+for (let i = 0; i < 300; i++) {
+  assertSame(capturedTarget(10, -1), 10, "captured target warmup");
+}
+assertSame(
+  capturedTarget(10, 5),
+  105,
+  "captured local mutation must remain synchronized"
+);
+
+function osrFirstCall(n, value) {
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    sum += value;
+  }
+  return sum;
+}
+
+assertSame(osrFirstCall(10_000, 0.5), 5_000, "OSR numeric fast path");
+
+console.log("PASS");

--- a/tests/test_jit_upvalue_self_reference.cjs
+++ b/tests/test_jit_upvalue_self_reference.cjs
@@ -1,0 +1,234 @@
+function assertSame(actual, expected, message) {
+  if (actual !== expected) throw new Error(message);
+}
+
+function makeMutableSelfReference() {
+  let current;
+  const original = function () {
+    return current;
+  };
+
+  current = original;
+  for (let i = 0; i < 300; i++) {
+    assertSame(original(), original, "warm mutable self-reference");
+  }
+
+  const replacement = function () {};
+  current = replacement;
+  return { original, replacement };
+}
+
+const pair = makeMutableSelfReference();
+assertSame(
+  pair.original(),
+  pair.replacement,
+  "JIT must observe reassigned mutable self-reference"
+);
+for (let i = 0; i < 300; i++) {
+  assertSame(
+    pair.original(),
+    pair.replacement,
+    "recompiled function must keep observing mutable self-reference"
+  );
+}
+
+globalThis.__antMutableGlobalSelf = function () {
+  return __antMutableGlobalSelf;
+};
+
+const globalOriginal = globalThis.__antMutableGlobalSelf;
+for (let i = 0; i < 300; i++) {
+  assertSame(
+    globalOriginal(),
+    globalOriginal,
+    "warm mutable global self-reference"
+  );
+}
+
+const globalReplacement = function () {};
+globalThis.__antMutableGlobalSelf = globalReplacement;
+assertSame(
+  globalOriginal(),
+  globalReplacement,
+  "JIT must observe reassigned global self-reference"
+);
+delete globalThis.__antMutableGlobalSelf;
+
+function makeCapturedTailCall() {
+  let current;
+  const original = function (n) {
+    if (n === 0) return 0;
+    return current(n - 1);
+  };
+  current = original;
+  return {
+    original,
+    replace(value) {
+      current = value;
+    },
+  };
+}
+
+const capturedTail = makeCapturedTailCall();
+for (let i = 0; i < 300; i++) {
+  assertSame(capturedTail.original(2), 0, "warm captured self tail call");
+}
+assertSame(
+  capturedTail.original(100_000),
+  0,
+  "captured self-reference must retain TCO"
+);
+capturedTail.replace(function () {
+  return 42;
+});
+assertSame(
+  capturedTail.original(1),
+  42,
+  "captured tail call must observe reassigned binding"
+);
+
+globalThis.__antMutableGlobalTail = function (n) {
+  if (n === 0) return 0;
+  return __antMutableGlobalTail(n - 1);
+};
+
+const globalTailOriginal = globalThis.__antMutableGlobalTail;
+for (let i = 0; i < 300; i++) {
+  assertSame(globalTailOriginal(2), 0, "warm global self tail call");
+}
+assertSame(
+  globalTailOriginal(100_000),
+  0,
+  "global self-reference must retain TCO"
+);
+globalThis.__antMutableGlobalTail = function () {
+  return 42;
+};
+assertSame(
+  globalTailOriginal(1),
+  42,
+  "global tail call must observe reassigned binding"
+);
+delete globalThis.__antMutableGlobalTail;
+
+function conditionalOther() {
+  return 42;
+}
+
+globalThis.__antConditionalSelf = function (n, chooseOther) {
+  if (n === 0) return 0;
+  return (chooseOther ? conditionalOther : __antConditionalSelf)(
+    n - 1,
+    chooseOther
+  );
+};
+
+const conditionalOriginal = globalThis.__antConditionalSelf;
+for (let i = 0; i < 300; i++) {
+  assertSame(conditionalOriginal(2, false), 0, "warm conditional self arm");
+}
+assertSame(
+  conditionalOriginal(1, true),
+  42,
+  "conditional merge must clear known self function"
+);
+delete globalThis.__antConditionalSelf;
+
+globalThis.__antLocalMergeSelf = function (n, chooseOther) {
+  if (n === 0) return 0;
+  let callee;
+  if (chooseOther) callee = conditionalOther;
+  else callee = __antLocalMergeSelf;
+  return callee(n - 1, chooseOther);
+};
+
+const localMergeOriginal = globalThis.__antLocalMergeSelf;
+for (let i = 0; i < 300; i++) {
+  assertSame(localMergeOriginal(2, false), 0, "warm local self arm");
+}
+assertSame(
+  localMergeOriginal(1, true),
+  42,
+  "control-flow merge must clear known function locals"
+);
+delete globalThis.__antLocalMergeSelf;
+
+function makeConstSibling(target) {
+  const captured = target;
+  return function () {
+    return captured;
+  };
+}
+
+const siblingSeed = makeConstSibling(null);
+const siblingReader = makeConstSibling(siblingSeed);
+for (let i = 0; i < 300; i++) {
+  assertSame(
+    siblingReader(),
+    siblingSeed,
+    "shared function body must preserve sibling closure identity"
+  );
+}
+
+function makeConstSelfOrSibling(previous) {
+  function inner() {
+    return current;
+  }
+  const current = previous || inner;
+  return inner;
+}
+
+const constSelf = makeConstSelfOrSibling(null);
+for (let i = 0; i < 300; i++) {
+  assertSame(constSelf(), constSelf, "warm const self-reference");
+}
+const constSibling = makeConstSelfOrSibling(constSelf);
+assertSame(
+  constSibling(),
+  constSelf,
+  "shared JIT code must load each closure's const upvalue"
+);
+
+let accessorReads = 0;
+const accessorTarget = function () {
+  return __antAccessorSelf;
+};
+Object.defineProperty(globalThis, "__antAccessorSelf", {
+  configurable: true,
+  get() {
+    accessorReads++;
+    return accessorTarget;
+  },
+});
+for (let i = 0; i < 300; i++) {
+  assertSame(accessorTarget(), accessorTarget, "accessor global self read");
+}
+assertSame(
+  accessorReads,
+  300,
+  "JIT compilation must not invoke a global accessor"
+);
+delete globalThis.__antAccessorSelf;
+
+let undefAccessorReads = 0;
+Object.defineProperty(globalThis, "__antAccessorTypeofSelf", {
+  configurable: true,
+  get() {
+    undefAccessorReads++;
+    return accessorTarget;
+  },
+});
+const readAccessorType = function () {
+  return typeof __antAccessorTypeofSelf;
+};
+for (let i = 0; i < 300; i++) {
+  assertSame(readAccessorType(), "function", "accessor global typeof read");
+}
+assertSame(
+  undefAccessorReads,
+  300,
+  "GET_GLOBAL_UNDEF compilation must not invoke a global accessor"
+);
+delete globalThis.__antAccessorTypeofSelf;
+
+console.log("PASS");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JIT correctness for self-referential functions accessed via upvalues or globals, including after reassignment and recompilation.
  - Restored reliable tail-call behavior for self-references, including deep recursion cases.
  - Corrected merging/reloading of optimization assumptions across control-flow joins.
  - Prevented global accessors from being invoked during optimized JIT execution.
  - Added a numeric fast path for local additions with deoptimization on type changes.
- **Tests**
  - Added coverage for self-reference identity, closure/global reassignment, tail calls, and numeric-addition JIT deoptimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->