### PR TITLE
fix platform detecting musl erroneously

### DIFF
--- a/src/pkg/platform.zig
+++ b/src/pkg/platform.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const io = std.Io.Threaded.global_single_threaded.io();
 
 const LibcTag = enum(u8) {
     unknown = 0,
@@ -8,6 +7,7 @@ const LibcTag = enum(u8) {
     musl = 2,
     none = 3,
 };
+
 
 var cached_linux_libc = std.atomic.Value(u8).init(@intFromEnum(LibcTag.unknown));
 
@@ -72,11 +72,12 @@ fn detectLinuxLibc() LibcTag {
 
 fn detectLibcFromCommand(argv: []const []const u8) ?LibcTag {
     const allocator = std.heap.page_allocator;
-    const result = std.process.run(allocator, io, .{
+    var threaded_io = std.Io.Threaded.init(allocator, .{});
+    defer threaded_io.deinit();
+    const result = std.process.run(allocator, threaded_io.io(), .{
         .argv = argv,
         .stdout_limit = .limited(64 * 1024),
         .stderr_limit = .limited(64 * 1024),
-        .reserve_amount = 256,
     }) catch return null;
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
@@ -85,6 +86,7 @@ fn detectLibcFromCommand(argv: []const []const u8) ?LibcTag {
     if (detectLibcFromOutput(result.stderr)) |tag| return tag;
     return null;
 }
+
 
 fn detectLibcFromOutput(content: []const u8) ?LibcTag {
     if (containsAny(content, &.{ "musl libc", "musl " })) return .musl;
@@ -120,4 +122,11 @@ test "platform names use npm-compatible values" {
     try std.testing.expect(osName().len > 0);
     try std.testing.expect(cpuName().len > 0);
     try std.testing.expect(abiName().len > 0);
+}
+
+test "detectLinuxLibc detects runtime libc on linux" {
+    if (builtin.os.tag == .linux) {
+        const detected = detectLinuxLibc();
+        try std.testing.expect(detected != .unknown);
+    }
 }

--- a/src/pkg/platform.zig
+++ b/src/pkg/platform.zig
@@ -1,132 +1,162 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const process_env = @import("process_env.zig");
 
 const LibcTag = enum(u8) {
-    unknown = 0,
-    glibc = 1,
-    musl = 2,
-    none = 3,
+  unknown = 0,
+  glibc = 1,
+  musl = 2,
+  none = 3,
 };
 
+const LibcDetection = struct {
+  tag: LibcTag,
+  cacheable: bool,
+};
 
 var cached_linux_libc = std.atomic.Value(u8).init(@intFromEnum(LibcTag.unknown));
 
 pub fn osName() []const u8 {
-    return switch (builtin.os.tag) {
-        .macos => "darwin",
-        .linux => "linux",
-        .windows => "win32",
-        .freebsd => "freebsd",
-        else => "unknown",
-    };
+  return switch (builtin.os.tag) {
+    .macos => "darwin",
+    .linux => "linux",
+    .windows => "win32",
+    .freebsd => "freebsd",
+    else => "unknown",
+  };
 }
 
 pub fn cpuName() []const u8 {
-    return switch (builtin.cpu.arch) {
-        .aarch64 => "arm64",
-        .x86_64 => "x64",
-        .x86 => "ia32",
-        .arm => "arm",
-        else => "unknown",
-    };
+  return switch (builtin.cpu.arch) {
+    .aarch64 => "arm64",
+    .x86_64 => "x64",
+    .x86 => "ia32",
+    .arm => "arm",
+    else => "unknown",
+  };
 }
 
 pub fn abiName() []const u8 {
-    if (builtin.os.tag == .linux) return libcName() orelse targetAbiName();
-    return targetAbiName();
+  if (builtin.os.tag == .linux) return libcName() orelse targetAbiName();
+  return targetAbiName();
 }
 
 pub fn libcName() ?[]const u8 {
-    if (builtin.os.tag != .linux) return null;
+  if (builtin.os.tag != .linux) return null;
 
-    const cached: LibcTag = @enumFromInt(cached_linux_libc.load(.acquire));
-    if (cached != .unknown) return libcTagName(cached);
+  const cached: LibcTag = @enumFromInt(cached_linux_libc.load(.acquire));
+  if (cached != .unknown) return libcTagName(cached);
 
-    const detected = detectLinuxLibc();
-    cached_linux_libc.store(@intFromEnum(detected), .release);
-    return libcTagName(detected);
+  const detected = detectLinuxLibcUncached();
+  if (detected.cacheable) cached_linux_libc.store(@intFromEnum(detected.tag), .release);
+  return libcTagName(detected.tag);
 }
 
 fn libcTagName(tag: LibcTag) ?[]const u8 {
-    return switch (tag) {
-        .glibc => "glibc",
-        .musl => "musl",
-        .none, .unknown => null,
-    };
+  return switch (tag) {
+    .glibc => "glibc",
+    .musl => "musl",
+    .none, .unknown => null,
+  };
 }
 
 fn targetAbiName() []const u8 {
-    return switch (builtin.abi) {
-        .gnu, .gnueabi, .gnueabihf => "glibc",
-        .musl, .musleabi, .musleabihf => "musl",
-        else => @tagName(builtin.abi),
-    };
+  return switch (builtin.abi) {
+    .gnu, .gnueabi, .gnueabihf => "glibc",
+    .musl, .musleabi, .musleabihf => "musl",
+    else => @tagName(builtin.abi),
+  };
 }
 
 fn detectLinuxLibc() LibcTag {
-    if (detectLibcFromCommand(&.{ "getconf", "GNU_LIBC_VERSION" })) |tag| return tag;
-    if (detectLibcFromCommand(&.{ "ldd", "--version" })) |tag| return tag;
-    if (targetAbiLibcTag()) |tag| return tag;
-    return .none;
+  return detectLinuxLibcUncached().tag;
 }
 
-fn detectLibcFromCommand(argv: []const []const u8) ?LibcTag {
-    const allocator = std.heap.page_allocator;
-    var threaded_io = std.Io.Threaded.init(allocator, .{});
-    defer threaded_io.deinit();
-    const result = std.process.run(allocator, threaded_io.io(), .{
-        .argv = argv,
-        .stdout_limit = .limited(64 * 1024),
-        .stderr_limit = .limited(64 * 1024),
-    }) catch return null;
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
+fn detectLinuxLibcUncached() LibcDetection {
+  var probe_failed = false;
+  const commands = [_][]const []const u8{
+    &.{ "getconf", "GNU_LIBC_VERSION" },
+    &.{ "ldd", "--version" },
+  };
+  for (commands) |argv| {
+    const detected = detectLibcFromCommand(argv) catch {
+      probe_failed = true;
+      continue;
+    };
+    if (detected) |tag| return .{ .tag = tag, .cacheable = true };
+  }
 
-    if (detectLibcFromOutput(result.stdout)) |tag| return tag;
-    if (detectLibcFromOutput(result.stderr)) |tag| return tag;
-    return null;
+  return fallbackLinuxLibc(probe_failed);
 }
 
+fn fallbackLinuxLibc(probe_failed: bool) LibcDetection {
+  return .{
+    .tag = targetAbiLibcTag() orelse .none,
+    .cacheable = !probe_failed,
+  };
+}
+
+fn detectLibcFromCommand(argv: []const []const u8) !?LibcTag {
+  const allocator = std.heap.page_allocator;
+  var threaded_io = process_env.initThreaded(allocator);
+  defer threaded_io.deinit();
+  const result = try std.process.run(allocator, threaded_io.io(), .{
+    .argv = argv,
+    .stdout_limit = .limited(64 * 1024),
+    .stderr_limit = .limited(64 * 1024),
+  });
+  defer allocator.free(result.stdout);
+  defer allocator.free(result.stderr);
+
+  if (detectLibcFromOutput(result.stdout)) |tag| return tag;
+  if (detectLibcFromOutput(result.stderr)) |tag| return tag;
+  return null;
+}
 
 fn detectLibcFromOutput(content: []const u8) ?LibcTag {
-    if (containsAny(content, &.{ "musl libc", "musl " })) return .musl;
-    if (containsAny(content, &.{ "GNU libc", "GNU C Library", "glibc", "GLIBC" })) return .glibc;
-    return null;
+  if (containsAny(content, &.{ "musl libc", "musl " })) return .musl;
+  if (containsAny(content, &.{ "GNU libc", "GNU C Library", "glibc", "GLIBC" })) return .glibc;
+  return null;
 }
 
 fn containsAny(haystack: []const u8, needles: []const []const u8) bool {
-    for (needles) |needle| {
-        if (std.mem.indexOf(u8, haystack, needle) != null) return true;
-    }
-    return false;
+  for (needles) |needle| {
+    if (std.mem.indexOf(u8, haystack, needle) != null) return true;
+  }
+  return false;
 }
 
 fn targetAbiLibcTag() ?LibcTag {
-    return switch (builtin.abi) {
-        .gnu, .gnueabi, .gnueabihf => .glibc,
-        .musl, .musleabi, .musleabihf => .musl,
-        else => null,
-    };
+  return switch (builtin.abi) {
+    .gnu, .gnueabi, .gnueabihf => .glibc,
+    .musl, .musleabi, .musleabihf => .musl,
+    else => null,
+  };
 }
 
 test "detects libc from command output" {
-    try std.testing.expectEqual(LibcTag.glibc, detectLibcFromOutput("glibc 2.39").?);
-    try std.testing.expectEqual(LibcTag.glibc, detectLibcFromOutput("ldd (GNU libc) 2.39").?);
-    try std.testing.expectEqual(LibcTag.glibc, detectLibcFromOutput("ldd (GNU C Library) 2.39").?);
-    try std.testing.expectEqual(LibcTag.musl, detectLibcFromOutput("musl libc (x86_64)").?);
-    try std.testing.expect(detectLibcFromOutput("getconf: GNU_LIBC_VERSION: unknown variable") == null);
-    try std.testing.expect(detectLibcFromOutput("not an ldd marker") == null);
+  try std.testing.expectEqual(LibcTag.glibc, detectLibcFromOutput("glibc 2.39").?);
+  try std.testing.expectEqual(LibcTag.glibc, detectLibcFromOutput("ldd (GNU libc) 2.39").?);
+  try std.testing.expectEqual(LibcTag.glibc, detectLibcFromOutput("ldd (GNU C Library) 2.39").?);
+  try std.testing.expectEqual(LibcTag.musl, detectLibcFromOutput("musl libc (x86_64)").?);
+  try std.testing.expect(detectLibcFromOutput("getconf: GNU_LIBC_VERSION: unknown variable") == null);
+  try std.testing.expect(detectLibcFromOutput("not an ldd marker") == null);
+}
+
+test "failed libc probes do not cache the target ABI fallback" {
+  try std.testing.expect(!fallbackLinuxLibc(true).cacheable);
+  try std.testing.expect(fallbackLinuxLibc(false).cacheable);
 }
 
 test "platform names use npm-compatible values" {
-    try std.testing.expect(osName().len > 0);
-    try std.testing.expect(cpuName().len > 0);
-    try std.testing.expect(abiName().len > 0);
+  try std.testing.expect(osName().len > 0);
+  try std.testing.expect(cpuName().len > 0);
+  try std.testing.expect(abiName().len > 0);
 }
 
 test "detectLinuxLibc detects runtime libc on linux" {
-    if (builtin.os.tag == .linux) {
-        const detected = detectLinuxLibc();
-        try std.testing.expect(detected != .unknown);
-    }
+  if (builtin.os.tag == .linux) {
+    const detected = detectLinuxLibc();
+    try std.testing.expect(detected == .glibc or detected == .musl);
+  }
 }

--- a/src/pkg/process_env.zig
+++ b/src/pkg/process_env.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn current() std.process.Environ {
+  return switch (builtin.os.tag) {
+    .windows => .{ .block = .global },
+    else => blk: {
+      var env_count: usize = 0;
+      while (std.c.environ[env_count] != null) : (env_count += 1) {}
+      break :blk .{ .block = .{ .slice = std.c.environ[0..env_count :null] } };
+    },
+  };
+}
+
+pub fn initThreaded(allocator: std.mem.Allocator) std.Io.Threaded {
+  return .init(allocator, .{ .environ = current() });
+}
+
+test "current environment preserves PATH" {
+  if (builtin.os.tag == .windows) return;
+  const expected = std.c.getenv("PATH") orelse return;
+  const actual = try std.process.Environ.getAlloc(current(), std.testing.allocator, "PATH");
+  defer std.testing.allocator.free(actual);
+  try std.testing.expectEqualStrings(std.mem.span(expected), actual);
+}

--- a/src/pkg/root.zig
+++ b/src/pkg/root.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const process_env = @import("process_env.zig");
 const io = std.Io.Threaded.global_single_threaded.io();
 
 pub const cli = @import("cli.zig");
@@ -38,15 +39,7 @@ fn getAbsoluteEnv(name: [:0]const u8) ?[]const u8 {
 }
 
 fn currentEnvMap(allocator: std.mem.Allocator) !std.process.Environ.Map {
-  const environ: std.process.Environ = switch (builtin.os.tag) {
-    .windows => .{ .block = .global },
-    else => blk: {
-      var env_count: usize = 0;
-      while (std.c.environ[env_count] != null) : (env_count += 1) {}
-      break :blk .{ .block = .{ .slice = std.c.environ[0..env_count :null] } };
-    },
-  };
-  return environ.createMap(allocator);
+  return process_env.current().createMap(allocator);
 }
 
 fn scriptShell() []const u8 {
@@ -2611,7 +2604,7 @@ fn runTrustedPostinstall(
     return false;
   };
 
-  var process_io_state: std.Io.Threaded = .init(allocator, .{});
+  var process_io_state = process_env.initThreaded(allocator);
   defer process_io_state.deinit();
   const process_io = process_io_state.io();
 
@@ -3789,7 +3782,7 @@ fn runScriptCommand(
     &[_][]const u8{ scriptShell(), "/c", script_z }
   else &[_][]const u8{ scriptShell(), "-c", script_z };
 
-  var process_io_state: std.Io.Threaded = .init(allocator, .{});
+  var process_io_state = process_env.initThreaded(allocator);
   defer process_io_state.deinit();
   const process_io = process_io_state.io();
 


### PR DESCRIPTION
# #38 Problem & Root Cause

When ant install resolved platform-specific optional dependencies on Linux

(such as @rollup/rollup-linux-x64-gnu vs @rollup/rollup-linux-x64-musl),

it called platform.libcName() to detect the host's libc.

  1. platform.libcName() executed getconf GNU_LIBC_VERSION and ldd --version via detectLibcFromCommand().
  2. detectLibcFromCommand() passed std.Io.Threaded.global_single_threaded.io() to std.process.run().
  3. global_single_threaded is initialized statically with .allocator = .failing.
  4. Because .allocator was .failing, std.process.run() failed with error.OutOfMemory on every single execution of getconf / ldd.
  5. detectLibcFromCommand() caught error.OutOfMemory and returned null.
  6. detectLinuxLibc() fell back to targetAbiLibcTag(), which inspects the compile-time builtin.abi.
  7. Because the release binaries of ant distributed to Linux users (ant-linux-x64-musl) are compiled statically targeting musl (builtin.abi = .musl), targetAbiLibcTag() returned .musl on all Linux machines.
  8. As a result, ant falsely identified every glibc Linux machine as running musl, causing ant install to pick @rollup/rollup-linux-x64-musl instead of @rollup/rollup-linux-x64-gnu.

## Changes Made

In platform.zig:

- Initialized a proper std.Io.Threaded instance using std.heap.page_allocator inside detectLibcFromCommand() instead of using global_single_threaded.io().
- Removed the unused io top-level declaration.
- Added a unit test ensuring detectLinuxLibc() properly identifies the host libc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux libc/runtime detection with more reliable fallbacks and safer caching behavior.
  * Updated internal command execution to better handle process I/O and environment setup.
* **Tests**
  * Added coverage for libc detection caching on probe failures and for runtime libc detection on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->