### PR TITLE
migrate away from stack-based coro

### DIFF
--- a/examples/embed/embed.c
+++ b/examples/embed/embed.c
@@ -25,7 +25,7 @@ static void print_header(int num, const char *title) {
 }
 
 static ant_t *create_js_runtime(void *stack_base) {
-  ant_t *js = js_create_dynamic();
+  ant_t *js = ant_create();
   if (!js) {
     fprintf(stderr, "Failed to create JS runtime\n");
     return NULL;

--- a/include/ant.h
+++ b/include/ant.h
@@ -37,8 +37,8 @@ if (!(cond)) {                                                              \
 #define js_false   (NANBOX_PREFIX | ((ant_value_t)T_BOOL << NANBOX_TYPE_SHIFT))
 #define js_bool(x) (js_false | (ant_value_t)!!(x))
 
-ant_t *js_create(void *buf, size_t len);
-ant_t *js_create_dynamic();
+// create a new ant isolate
+ant_t *ant_create();
 
 ant_value_t js_glob(ant_t *);
 void js_mark_constructor(ant_value_t value, bool is_constructor);

--- a/include/internal.h
+++ b/include/internal.h
@@ -145,7 +145,7 @@ typedef struct {
 
 struct ant_isolate_t {
   sv_vm_t *vm;
-  
+
   ant_module_t *module;
   ant_object_t *objects;
   ant_object_t *permanent_objects;
@@ -159,7 +159,9 @@ struct ant_isolate_t {
   ant_value_t **c_roots;
   size_t c_root_count;
   size_t c_root_cap;
+  
   struct gc_temp_root_scope *temp_roots;
+  struct coroutine *retired_coroutines;
 
   const char *code;
   const char *filename;

--- a/include/internal.h
+++ b/include/internal.h
@@ -483,7 +483,8 @@ ant_value_t js_create_arguments_object(ant_t *js, sv_vm_t *vm, ant_value_t calle
 
 void js_arguments_detach(ant_t *js, ant_value_t obj);
 void js_arguments_sync_slot(ant_t *js, ant_value_t obj, uint32_t idx, ant_value_t value);
-void js_arguments_rebind_frame(ant_t *js, ant_value_t obj, sv_vm_t *vm, int frame_index);
+void js_arguments_rebind_frame(ant_t *js, ant_value_t obj, int frame_index);
+void js_arguments_bind_direct(ant_t *js, ant_value_t obj, struct sv_frame *frame);
 
 ant_value_t coerce_to_str(ant_t *js, ant_value_t v);
 ant_value_t coerce_to_str_concat(ant_t *js, ant_value_t v);

--- a/include/modules/generator.h
+++ b/include/modules/generator.h
@@ -9,6 +9,5 @@ void generator_mark_for_gc(ant_t *js, ant_value_t gen);
 
 bool generator_resume_pending_request(ant_t *js, coroutine_t *coro, ant_value_t result);
 coroutine_t *generator_get_coro_for_gc(ant_value_t gen);
-coroutine_t *generator_get_coro_for_vm(ant_t *js, sv_vm_t *vm);
 
 #endif

--- a/include/reactor.h
+++ b/include/reactor.h
@@ -4,28 +4,25 @@
 #include "types.h"
 #include <uv.h>
 
-typedef enum {
-  WORK_MICROTASKS       = 1 << 0,
-  WORK_TIMERS           = 1 << 1,
-  WORK_IMMEDIATES       = 1 << 2,
-  WORK_COROUTINES       = 1 << 3,
-  WORK_COROUTINES_READY = 1 << 4,
-  WORK_FETCHES          = 1 << 5,
-  WORK_FS_OPS           = 1 << 6,
-  WORK_CHILD_PROCS      = 1 << 7,
-  WORK_READLINE         = 1 << 8,
-  WORK_STDIN            = 1 << 9,
-} work_flags_t;
-
-#define WORK_TASKS    (WORK_MICROTASKS | WORK_TIMERS | WORK_IMMEDIATES | WORK_COROUTINES | WORK_FETCHES)
-#define WORK_PENDING  (WORK_TASKS | WORK_FS_OPS | WORK_CHILD_PROCS | WORK_READLINE | WORK_STDIN)
-#define WORK_BLOCKING (WORK_MICROTASKS | WORK_IMMEDIATES | WORK_COROUTINES_READY)
-#define WORK_ASYNC    (WORK_READLINE | WORK_STDIN | WORK_TIMERS | WORK_FETCHES | WORK_FS_OPS | WORK_CHILD_PROCS)
-
 #define UV_CHECK_ALIVE uv_loop_alive(uv_default_loop())
 
-typedef void (*reactor_poll_hook_t)(void *data);
-void js_reactor_set_poll_hook(reactor_poll_hook_t hook, void *data);
+typedef enum {
+  WORK_MICROTASKS  = 1 << 0,
+  WORK_TIMERS      = 1 << 1,
+  WORK_IMMEDIATES  = 1 << 2,
+  WORK_FETCHES     = 1 << 3,
+  WORK_FS_OPS      = 1 << 4,
+  WORK_CHILD_PROCS = 1 << 5,
+  WORK_READLINE    = 1 << 6,
+  WORK_STDIN       = 1 << 7,
+} work_flags_t;
+
+enum {
+  WORK_TASKS    = (WORK_MICROTASKS | WORK_TIMERS | WORK_IMMEDIATES | WORK_FETCHES),
+  WORK_PENDING  = (WORK_TASKS | WORK_FS_OPS | WORK_CHILD_PROCS | WORK_READLINE | WORK_STDIN),
+  WORK_BLOCKING = (WORK_MICROTASKS | WORK_IMMEDIATES),
+  WORK_ASYNC    = (WORK_READLINE | WORK_STDIN | WORK_TIMERS | WORK_FETCHES | WORK_FS_OPS | WORK_CHILD_PROCS),
+};
 
 void js_poll_events(ant_t *js);
 void js_run_event_loop(ant_t *js);

--- a/include/silver/ast.h
+++ b/include/silver/ast.h
@@ -161,6 +161,8 @@ struct sv_ast {
 void sv_ast_list_push(sv_ast_list_t *list, sv_ast_t *node);
 bool sv_ast_can_be_expression_statement(const sv_ast_t *node);
 bool ast_references_arguments(const sv_ast_t *node);
+bool ast_contains_direct_suspend(const sv_ast_t *node, const sv_ast_t **out_offender);
+bool ast_contains_own_yield(const sv_ast_t *node, const sv_ast_t **out_offender);
 
 sv_ast_t *sv_ast_new(sv_node_type_t type);
 sv_ast_t *sv_parse(ant_t *js, const char *code, ant_offset_t clen, bool strict);

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -412,6 +412,7 @@ sv_activation_t *sv_activation_capture(
 
 bool sv_activation_install(sv_vm_t *vm, sv_activation_t *act);
 void sv_activation_seal(ant_t *js, sv_activation_t *act);
+void sv_activation_discard(sv_vm_t *vm, int entry_fp);
 
 static inline void gc_upvalue_write_barrier(ant_t *js, sv_upvalue_t *uv, ant_value_t new_val) {
   if (uv->location != &uv->closed || uv->in_remember_set) return;

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -412,7 +412,6 @@ sv_activation_t *sv_activation_capture(
 
 bool sv_activation_install(sv_vm_t *vm, sv_activation_t *act);
 void sv_activation_seal(ant_t *js, sv_activation_t *act);
-bool sv_slot_has_open_upvalue(sv_vm_t *vm, ant_value_t *slot);
 
 static inline void gc_upvalue_write_barrier(ant_t *js, sv_upvalue_t *uv, ant_value_t new_val) {
   if (uv->location != &uv->closed || uv->in_remember_set) return;

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -411,6 +411,7 @@ sv_activation_t *sv_activation_capture(
 );
 
 bool sv_activation_install(sv_vm_t *vm, sv_activation_t *act);
+void sv_activation_seal(ant_t *js, sv_activation_t *act);
 bool sv_slot_has_open_upvalue(sv_vm_t *vm, ant_value_t *slot);
 
 static inline void gc_upvalue_write_barrier(ant_t *js, sv_upvalue_t *uv, ant_value_t new_val) {

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -394,6 +394,23 @@ struct sv_upvalue {
   uint8_t in_remember_set;
 };
 
+typedef struct sv_activation {
+  int frame_count;
+  int stack_count;
+  int handler_count;
+  size_t capacity;
+  sv_upvalue_t *open_upvalues;
+  sv_frame_t *frames;
+  ant_value_t *slots;
+  sv_handler_t *handlers;
+} sv_activation_t;
+
+sv_activation_t *sv_activation_capture(
+  sv_vm_t *vm, int entry_fp, 
+  sv_activation_t *reuse
+);
+
+bool sv_activation_install(sv_vm_t *vm, sv_activation_t *act);
 bool sv_slot_has_open_upvalue(sv_vm_t *vm, ant_value_t *slot);
 
 static inline void gc_upvalue_write_barrier(ant_t *js, sv_upvalue_t *uv, ant_value_t new_val) {
@@ -596,13 +613,9 @@ static inline bool sv_vm_is_strict(const sv_vm_t *vm) {
   return false;
 }
 
+// TODO: use js->vm only
 static inline sv_vm_t *sv_vm_get_active(ant_t *js) {
-  if (!js) return NULL;
-  if (js->active_async_coro) {
-    if (js->active_async_coro->sv_vm) return js->active_async_coro->sv_vm;
-    if (js->active_async_coro->owner_vm) return js->active_async_coro->owner_vm;
-  }
-  return js->vm;
+  return js ? js->vm : NULL;
 }
 
 static inline bool sv_is_strict_context(ant_t *js) {

--- a/include/silver/vm.h
+++ b/include/silver/vm.h
@@ -7,16 +7,11 @@ typedef struct sv_vm sv_vm_t;
 typedef struct sv_func sv_func_t;
 size_t os_thread_stack_size(void);
 
-typedef enum {
-  SV_VM_MAIN,
-  SV_VM_ASYNC,
-} sv_vm_kind_t;
-
 extern int sv_user_stack_size_kb;
-sv_vm_t *sv_vm_create(ant_t *js, sv_vm_kind_t kind);
+sv_vm_t *sv_vm_create(ant_t *js);
 
 void sv_vm_destroy(sv_vm_t *vm);
-void sv_vm_limits(sv_vm_kind_t kind, int *out_stack_size, int *out_max_frames);
+void sv_vm_limits(int *out_stack_size, int *out_max_frames);
 
 void sv_vm_visit_frame_funcs(sv_vm_t *vm, void (*visitor)(void *, sv_func_t *), void *ctx);
 void sv_disasm(ant_t *js, sv_func_t *func, const char *label);

--- a/include/sugar.h
+++ b/include/sugar.h
@@ -21,7 +21,6 @@ typedef enum {
   CORO_HOLD_AWAIT     = 1u << 3,
 } coroutine_hold_t;
 
-// TODO: check padding
 typedef struct coroutine {
   ant_t *js;
 
@@ -37,16 +36,16 @@ typedef struct coroutine {
   ant_value_t async_promise;
   ant_module_t *module_eval_ctx;
 
-  struct coroutine *active_parent;
+  union {
+    struct coroutine *active_parent;
+    struct coroutine *retired_next;
+  };
+  
   struct coroutine *active_prev;
-
-  struct coroutine *next;
   struct sv_activation *act;
-
   coroutine_type_t type;
 
   int nargs;
-
   uint64_t gc_epoch;
   uint32_t refcount;
   uint8_t hold_bits;
@@ -71,11 +70,15 @@ void coroutine_release(coroutine_t *coro);
 void coroutine_hold(coroutine_t *coro, uint8_t hold);
 void coroutine_unhold(coroutine_t *coro, uint8_t hold);
 
-void reap_retired_coroutines(void);
+void reap_retired_coroutines(ant_t *js);
 void free_coroutine(coroutine_t *coro);
 void coroutine_clear_await_registration(coroutine_t *coro);
 
-ant_value_t start_async_in_coroutine(ant_t *js, const char *code, size_t code_len, ant_value_t closure_scope, ant_value_t *args, int nargs);
+ant_value_t start_async_in_coroutine(
+  ant_t *js, const char *code, size_t code_len,
+  ant_value_t closure_scope, ant_value_t *args, int nargs
+);
+
 ant_value_t resume_coroutine_wrapper(ant_t *js, ant_value_t *args, int nargs);
 ant_value_t reject_coroutine_wrapper(ant_t *js, ant_value_t *args, int nargs);
 

--- a/include/sugar.h
+++ b/include/sugar.h
@@ -17,57 +17,43 @@ typedef enum {
 
 typedef enum {
   CORO_HOLD_ACTIVE    = 1u << 0,
-  CORO_HOLD_PENDING   = 1u << 1,
   CORO_HOLD_GENERATOR = 1u << 2,
   CORO_HOLD_AWAIT     = 1u << 3,
 } coroutine_hold_t;
 
+// TODO: check padding
 typedef struct coroutine {
   ant_t *js;
-  
+
   ant_value_t this_val;
   ant_value_t super_val;
   ant_value_t new_target;
   ant_value_t result;
   ant_value_t async_func;
-  ant_value_t yield_value;
+  ant_value_t owner_gen;
   ant_value_t *args;
-  
+
   ant_value_t awaited_promise;
   ant_value_t async_promise;
   ant_module_t *module_eval_ctx;
-  
+
   struct coroutine *active_parent;
   struct coroutine *active_prev;
-  
-  struct coroutine *prev;
+
   struct coroutine *next;
-  
   struct sv_activation *act;
-  
-  ant_offset_t resume_point;
+
   coroutine_type_t type;
-  
+
   int nargs;
-  
+
   uint64_t gc_epoch;
   uint32_t refcount;
   uint8_t hold_bits;
-  
-  bool is_settled;
-  bool is_error;
-  bool is_done;
-  bool materialized;
-  bool is_ready;
-  bool did_suspend;
-  bool await_registered;
-  bool destroy_requested;
-} coroutine_t;
 
-typedef struct {
-  coroutine_t *head;
-  coroutine_t *tail;
-} coroutine_queue_t;
+  bool is_error;
+  bool await_registered;
+} coroutine_t;
 
 typedef enum {
   JS_AWAIT_PENDING = 0,
@@ -78,11 +64,6 @@ typedef struct {
   js_await_state_t state;
   ant_value_t value;
 } js_await_result_t;
-
-extern coroutine_queue_t pending_coroutines;
-
-void enqueue_coroutine(coroutine_t *coro);
-void remove_coroutine(coroutine_t *coro);
 
 void coroutine_retain(coroutine_t *coro);
 void coroutine_release(coroutine_t *coro);
@@ -101,8 +82,5 @@ ant_value_t reject_coroutine_wrapper(ant_t *js, ant_value_t *args, int nargs);
 js_await_result_t js_promise_await_coroutine(ant_t *js, ant_value_t promise, coroutine_t *coro);
 void js_promise_clear_await_coroutine(ant_t *js, ant_value_t promise, coroutine_t *coro);
 void settle_and_resume_coroutine(ant_t *js, coroutine_t *coro, ant_value_t value, bool is_error);
-
-bool has_ready_coroutines(void);
-bool has_pending_coroutines(void);
 
 #endif

--- a/include/sugar.h
+++ b/include/sugar.h
@@ -8,29 +8,6 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
-#include <minicoro.h>
-
-#define CORO_MALLOC(size) calloc(1, size)
-#define CORO_FREE(ptr) free(ptr)
-
-#define MCO_RESUME_SAVE(js_, mco_, res_) do {    \
-  void *_saved_cstk = (js_)->cstk.base;          \
-  size_t _saved_limit = (js_)->cstk.limit;       \
-  volatile char _stk_mark;                       \
-  if (!mco_running())                            \
-    (js_)->cstk.main_lo = (void *)&_stk_mark;    \
-  (res_) = mco_resume((mco_));                   \
-  (js_)->cstk.base = _saved_cstk;                \
-  (js_)->cstk.limit = _saved_limit;              \
-} while (0)
-
-#define MCO_CORO_STACK_ENTER(js_, mco_) do {     \
-  volatile char _coro_marker;                    \
-  (js_)->cstk.base = (void *)&_coro_marker;      \
-  (js_)->cstk.limit = (mco_)->stack_size;        \
-} while (0)
-
-#define CORO_PER_TICK_LIMIT 100000
 
 typedef enum {
   CORO_ASYNC_AWAIT,
@@ -66,17 +43,14 @@ typedef struct coroutine {
   struct coroutine *prev;
   struct coroutine *next;
   
-  mco_coro *mco;
-  struct sv_vm *owner_vm;
-  struct sv_vm *sv_vm;
+  struct sv_activation *act;
   
   ant_offset_t resume_point;
   coroutine_type_t type;
   
-  int owner_entry_fp;
-  int owner_saved_fp;
   int nargs;
   
+  uint64_t gc_epoch;
   uint32_t refcount;
   uint8_t hold_bits;
   
@@ -84,7 +58,6 @@ typedef struct coroutine {
   bool is_error;
   bool is_done;
   bool materialized;
-  bool mco_started;
   bool is_ready;
   bool did_suspend;
   bool await_registered;
@@ -107,7 +80,6 @@ typedef struct {
 } js_await_result_t;
 
 extern coroutine_queue_t pending_coroutines;
-extern uint32_t coros_this_tick;
 
 void enqueue_coroutine(coroutine_t *coro);
 void remove_coroutine(coroutine_t *coro);

--- a/meson/ant.version
+++ b/meson/ant.version
@@ -1,3 +1,3 @@
 major=12
 minor=3
-patch=1
+patch=0

--- a/meson/deps/meson.build
+++ b/meson/deps/meson.build
@@ -128,7 +128,6 @@ uthash_dep = subproject('uthash').get_variable('uthash_dep')
 yyjson_dep = subproject('yyjson').get_variable('yyjson_dep')
 uuidv7_dep = subproject('uuidv7').get_variable('uuidv7_dep')
 argtable3_dep = subproject('argtable3').get_variable('argtable3_dep')
-minicoro_dep = subproject('minicoro').get_variable('minicoro_dep')
 crprintf_dep = subproject('crprintf').get_variable('crprintf_dep')
 ada_dep = subproject('ada').get_variable('ada_dep')
 wamr_dep = subproject('wasm-micro-runtime').get_variable('wamr_dep')
@@ -254,7 +253,7 @@ endif
 ant_core_deps = [
   libffi_dep, crprintf_dep, argtable3_dep,
   llhttp, pcre2_dep, libuv_dep, base64_dep,
-  yyjson_dep, minicoro_dep, uuidv7_dep, tlsuv_dep, cares_dep,
+  yyjson_dep, uuidv7_dep, tlsuv_dep, cares_dep,
 ]
 
 ant_format_deps = [

--- a/packages/desktop/app/platform/mac/main.mm
+++ b/packages/desktop/app/platform/mac/main.mm
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 
     volatile char stack_base;
-    ant_t *js = js_create_dynamic();
+    ant_t *js = ant_create();
     if (!js) {
       fputs("failed to create Ant runtime\n", stderr);
       ant_desktop_cef_shutdown();

--- a/packages/desktop/browser/cef/renderer_ant_runtime.c
+++ b/packages/desktop/browser/cef/renderer_ant_runtime.c
@@ -52,7 +52,7 @@ static ant_value_t ImportModule(const char *specifier) {
 
 bool ant_renderer_runtime_initialize(void) {
   if (renderer_runtime) return true;
-  renderer_runtime = js_create_dynamic();
+  renderer_runtime = ant_create();
   if (!renderer_runtime) return false;
   if (!renderer_stack_base) {
     js_destroy(renderer_runtime);

--- a/src/ant.c
+++ b/src/ant.c
@@ -17090,7 +17090,6 @@ static ant_t *isolate_init(void *buf, size_t len) {
   memset(buf, 0, len);
   
   js = (ant_t *)buf;
-  rt->js = js;
   js_init_intern_cache(js);
   
   if (!fixed_arena_init(&js->obj_arena, sizeof(ant_object_t), offsetof(ant_object_t, mark_epoch), ANT_ARENA_MAX)) return NULL;
@@ -17114,7 +17113,8 @@ static ant_t *isolate_init(void *buf, size_t len) {
     fixed_arena_destroy(&js->obj_arena);
     return NULL;
   }
-  
+
+  rt->js = js;
   js->global = mkobj(js, 0);
   js->this_val = js->global;
   js->new_target = js_mkundef();

--- a/src/ant.c
+++ b/src/ant.c
@@ -3032,6 +3032,7 @@ void js_arguments_detach(ant_t *js, ant_value_t obj) {
   }
 
   state->frame_index = -1;
+  state->direct_frame = NULL;
   GC_ROOT_RESTORE(js, root_mark);
 }
 
@@ -17077,7 +17078,7 @@ static ant_value_t builtin_Proxy_revocable(ant_t *js, ant_value_t *args, int nar
   return result;
 }
 
-ant_t *js_create(void *buf, size_t len) {
+static ant_t *isolate_init(void *buf, size_t len) {
   ANT_ASSERT(
     (uintptr_t)buf <= ((1ULL << 53) - 1),
     "pointer exceeds 53-bit double-precision integer limit"
@@ -17602,15 +17603,23 @@ ant_t *js_create(void *buf, size_t len) {
   return js;
 }
 
-ant_t *js_create_dynamic() {
+ant_t *ant_create() {
   ant_t *js = (ant_t *)calloc(1, sizeof(*js));
   if (js == NULL) return NULL;
-  if (js_create(js, sizeof(*js)) == NULL) {
+  
+  if (isolate_init(js, sizeof(*js)) == NULL) {
     free(js);
     return NULL;
   }
+  
   js->owns_mem = true;
   js->vm = sv_vm_create(js);
+
+  if (!js->vm) {
+    js_destroy(js);
+    return NULL;
+  }
+
   return js;
 }
 

--- a/src/ant.c
+++ b/src/ant.c
@@ -17624,7 +17624,9 @@ ant_t *ant_create() {
 }
 
 void js_destroy(ant_t *js) {
-  if (js == NULL) return;  
+  if (js == NULL) return;
+  reap_retired_coroutines(js);
+
   if (js->vm) {
     sv_vm_destroy(js->vm);
     js->vm = NULL;

--- a/src/ant.c
+++ b/src/ant.c
@@ -49,7 +49,6 @@
 #include <float.h>
 #include <tlsuv/tlsuv.h>
 #include <tlsuv/http.h>
-#include <minicoro.h>
 
 #ifdef _WIN32
 #include <sys/stat.h>
@@ -2869,15 +2868,21 @@ shape_has:;
   return false;
 }
 
+// TODO: move into arguments.c
 enum { ANT_ARGUMENTS_NATIVE_TAG = 0x41524753u }; // ARGS
 
 typedef struct {
-  sv_vm_t *vm;
+  sv_frame_t *direct_frame;
   int frame_index;
   uint32_t mapped_count;
   uint8_t in_setter;
   uint8_t deleted[];
 } ant_arguments_state_t;
+
+static inline sv_frame_t *js_arguments_frame(ant_t *js, ant_arguments_state_t *state) {
+  if (state->direct_frame) return state->direct_frame;
+  return &js->vm->frames[state->frame_index];
+}
 
 static inline ant_arguments_state_t *js_arguments_state(ant_value_t obj) {
   return (ant_arguments_state_t *)js_get_native(obj, ANT_ARGUMENTS_NATIVE_TAG);
@@ -2896,7 +2901,7 @@ static ant_value_t js_arguments_getter(ant_t *js, ant_value_t obj, const char *k
     (uint32_t)idx < state->mapped_count &&
     !state->deleted[idx]
   ) {
-    sv_frame_t *frame = &state->vm->frames[state->frame_index];
+    sv_frame_t *frame = js_arguments_frame(js, state);
     return frame->bp[idx];
   }
 
@@ -2919,7 +2924,7 @@ static bool js_arguments_setter(
     (uint32_t)idx < state->mapped_count &&
     !state->deleted[idx]
   ) {
-    sv_frame_t *frame = &state->vm->frames[state->frame_index];
+    sv_frame_t *frame = js_arguments_frame(js, state);
     frame->bp[idx] = value;
   }
 
@@ -2980,7 +2985,6 @@ ant_value_t js_create_arguments_object(
       return js_mkerr(js, "oom");
     }
 
-    state->vm = vm;
     state->frame_index = (int)(frame - vm->frames);
     state->mapped_count = (uint32_t)mapped_count;
     
@@ -2995,11 +2999,17 @@ ant_value_t js_create_arguments_object(
   return arr;
 }
 
-void js_arguments_rebind_frame(ant_t *js, ant_value_t obj, sv_vm_t *vm, int frame_index) {
+void js_arguments_rebind_frame(ant_t *js, ant_value_t obj, int frame_index) {
   ant_arguments_state_t *state = js_arguments_state(obj);
-  if (!state || state->frame_index < 0 || !vm) return;
-  state->vm = vm;
+  if (!state || state->frame_index < 0) return;
   state->frame_index = frame_index;
+  state->direct_frame = NULL;
+}
+
+void js_arguments_bind_direct(ant_t *js, ant_value_t obj, sv_frame_t *frame) {
+  ant_arguments_state_t *state = js_arguments_state(obj);
+  if (!state || state->frame_index < 0 || !frame) return;
+  state->direct_frame = frame;
 }
 
 void js_arguments_detach(ant_t *js, ant_value_t obj) {
@@ -3009,7 +3019,7 @@ void js_arguments_detach(ant_t *js, ant_value_t obj) {
   GC_ROOT_SAVE(root_mark, js);
   GC_ROOT_PIN(js, obj);
 
-  sv_frame_t *frame = &state->vm->frames[state->frame_index];
+  sv_frame_t *frame = js_arguments_frame(js, state);
   ant_offset_t arr_len = get_array_length(js, obj);
   ant_offset_t limit = (ant_offset_t)state->mapped_count;
   if (arr_len < limit) limit = arr_len;
@@ -17600,7 +17610,7 @@ ant_t *js_create_dynamic() {
     return NULL;
   }
   js->owns_mem = true;
-  js->vm = sv_vm_create(js, SV_VM_MAIN);
+  js->vm = sv_vm_create(js);
   return js;
 }
 

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -536,7 +536,7 @@ static void gc_mark_coroutine(ant_t *js, coroutine_t *c) {
   gc_mark_value(js, c->async_promise);
   gc_mark_value(js, c->awaited_promise);
   gc_mark_value(js, c->result);
-  gc_mark_value(js, c->yield_value);
+  gc_mark_value(js, c->owner_gen);
   gc_mark_value(js, c->super_val);
   gc_mark_value(js, c->new_target);
   
@@ -577,7 +577,6 @@ static inline void gc_mark_promise_handlers(ant_t *js, ant_promise_state_t *pd) 
 static void gc_mark_roots(ant_t *js) {
   gc_scan_vm_stack(js, js->vm);
 
-  for (coroutine_t *c = pending_coroutines.head; c; c = c->next) gc_mark_coroutine(js, c);
   for (coroutine_t *c = js->active_async_coro; c; c = c->active_parent) gc_mark_coroutine(js, c);
 
   gc_mark_value(js, js->global);

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -21,9 +21,6 @@
 #include <sys/time.h>
 #include <utarray.h>
 
-#define MCO_API extern
-#include <minicoro.h>
-
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
 #include <sanitizer/asan_interface.h>
@@ -426,14 +423,15 @@ while (gc_mark_sp > 0) {
   gc_scan_obj(js, obj);
 }}
 
-static void gc_scan_vm_stack(ant_t *js, sv_vm_t *vm) {
-  if (!vm) return;
+static void gc_scan_frame_span(
+  ant_t *js, ant_value_t *slots, int slot_count,
+  sv_frame_t *frames, int frame_count, sv_upvalue_t *open_upvalues
+) {
+  for (int i = 0; i < slot_count; i++)
+    gc_mark_value(js, slots[i]);
 
-  for (int i = 0; i < vm->sp; i++)
-    gc_mark_value(js, vm->stack[i]);
-
-  for (int f = 0; f <= vm->fp; f++) {
-    sv_frame_t *frame = &vm->frames[f];
+  for (int f = 0; f < frame_count; f++) {
+    sv_frame_t *frame = &frames[f];
     gc_mark_func(js, frame->func);
     gc_mark_value(js, frame->callee);
     gc_mark_value(js, frame->this);
@@ -445,13 +443,13 @@ static void gc_scan_vm_stack(ant_t *js, sv_vm_t *vm) {
     gc_mark_value(js, frame->eval_env);
   }
 
-  for (sv_upvalue_t *uv = vm->open_upvalues; uv; uv = uv->next) {
+  for (sv_upvalue_t *uv = open_upvalues; uv; uv = uv->next) {
     uv->gc_epoch = gc_epoch;
     if (uv->location == &uv->closed) gc_mark_value(js, uv->closed);
   }
 
-  for (int f = 0; f <= vm->fp; f++) {
-  sv_frame_t *frame = &vm->frames[f];
+  for (int f = 0; f < frame_count; f++) {
+  sv_frame_t *frame = &frames[f];
   if (!frame->upvalues) continue;
   for (int j = 0; j < frame->upvalue_count; j++) {
     sv_upvalue_t *uv = frame->upvalues[j];
@@ -459,6 +457,16 @@ static void gc_scan_vm_stack(ant_t *js, sv_vm_t *vm) {
     uv->gc_epoch = gc_epoch;
     if (uv->location == &uv->closed) gc_mark_value(js, uv->closed);
   }}
+}
+
+static void gc_scan_vm_stack(ant_t *js, sv_vm_t *vm) {
+  if (!vm) return;
+  gc_scan_frame_span(js, vm->stack, vm->sp, vm->frames, vm->fp + 1, vm->open_upvalues);
+}
+
+static void gc_scan_activation(ant_t *js, sv_activation_t *act) {
+  if (!act || act->frame_count <= 0) return;
+  gc_scan_frame_span(js, act->slots, act->stack_count, act->frames, act->frame_count, act->open_upvalues);
 }
 
 static void gc_scan_range(ant_t *js, uintptr_t lo, uintptr_t hi) {
@@ -496,51 +504,33 @@ __attribute__((noinline))
 static void gc_scan_current_stack(ant_t *js) {
   jmp_buf jb;
   if (setjmp(jb) != 0) return;
-  volatile uint8_t sp_marker = 0;
-
-  mco_coro *running = mco_running();
-  uintptr_t base;
   
-  if (running && running->stack_base && running->stack_size > 0) {
-    base = (uintptr_t)running->stack_base + running->stack_size;
-  } else base = (uintptr_t)js->cstk.base;
-
+  volatile uint8_t sp_marker = 0;
   uintptr_t lo, hi;
-  if (!gc_get_stack_bounds(base, (uintptr_t)&sp_marker, &lo, &hi)) return;
-  gc_scan_range(js, lo, hi);
-}
-
-static void gc_scan_mco_stack(ant_t *js, mco_coro *mco, mco_coro *skip) {
-  if (!mco || mco == skip) return;
-  if (!mco->stack_base || mco->stack_size == 0) return;
-  uintptr_t lo = (uintptr_t)mco->stack_base;
-  uintptr_t hi = lo + mco->stack_size;
+  
+  if (
+    !gc_get_stack_bounds((uintptr_t)js->cstk.base, 
+    (uintptr_t)&sp_marker, &lo, &hi)
+  ) return;
+  
   gc_scan_range(js, lo, hi);
 }
 
 static void gc_scan_other_stacks(ant_t *js) {
-  mco_coro *running = mco_running();
-
-  if (running) {
-    for (mco_coro *a = running->prev_co; a; a = a->prev_co)
-      gc_scan_mco_stack(js, a, running);
-  }
-
-  for (coroutine_t *c = pending_coroutines.head; c; c = c->next)
-    gc_scan_mco_stack(js, c->mco, running);
-
   if (js->cstk.main_base && js->cstk.main_lo) {
     uintptr_t lo, hi;
     if (gc_get_stack_bounds(
       (uintptr_t)js->cstk.main_base,
-      (uintptr_t)js->cstk.main_lo, &lo, &hi))
-      gc_scan_range(js, lo, hi);
+      (uintptr_t)js->cstk.main_lo, &lo, &hi)
+    ) gc_scan_range(js, lo, hi);
   }
 }
 
 static void gc_mark_coroutine(ant_t *js, coroutine_t *c) {
-  if (!c) return;
-  gc_scan_vm_stack(js, c->sv_vm ? c->sv_vm : c->owner_vm);
+  if (!c || c->gc_epoch == gc_epoch) return;
+  c->gc_epoch = gc_epoch;
+  
+  gc_scan_activation(js, c->act);
   gc_mark_value(js, c->this_val);
   gc_mark_value(js, c->async_func);
   gc_mark_value(js, c->async_promise);

--- a/src/main.c
+++ b/src/main.c
@@ -857,7 +857,7 @@ int main(int argc, char *argv[]) {
   ant_t *js;
   volatile char stack_base;
   
-  if (!(js = js_create_dynamic())) {
+  if (!(js = ant_create())) {
     crfprintf(stderr, msg.ant_allocation_fatal);
     CLEANUP_ARGS_AND_ARGV();
     return EXIT_FAILURE;

--- a/src/modules/generator.c
+++ b/src/modules/generator.c
@@ -579,7 +579,6 @@ ant_value_t sv_call_generator_closure_dispatch(
     .active_parent = NULL,
     .is_error = false,
     .async_promise = js_mkundef(),
-    .next = NULL,
     .refcount = 1,
     .hold_bits = 0,
     .await_registered = false,

--- a/src/modules/generator.c
+++ b/src/modules/generator.c
@@ -182,7 +182,10 @@ static coroutine_t *generator_coro(ant_value_t gen) {
 static void generator_clear_coro(ant_value_t gen, coroutine_t *coro) {
   generator_data_t *data = generator_data(gen);
   if (data && data->coro == coro) data->coro = NULL;
-  if (coro) coroutine_unhold(coro, CORO_HOLD_GENERATOR);
+  if (coro) {
+    coro->owner_gen = js_mkundef();
+    coroutine_unhold(coro, CORO_HOLD_GENERATOR);
+  }
 }
 
 // TODO: collapse
@@ -199,27 +202,10 @@ void generator_mark_for_gc(ant_t *js, ant_value_t gen) {
   }
 }
 
-static ant_value_t generator_find_owner_in_list(ant_object_t *head, coroutine_t *coro) {
-  for (ant_object_t *obj = head; obj; obj = obj->next) {
-    ant_value_t candidate = js_obj_from_ptr(obj);
-    generator_data_t *data = generator_data(candidate);
-    if (data && data->coro == coro) return candidate;
-  }
-  return js_mkundef();
-}
-
-static ant_value_t generator_find_owner(ant_t *js, coroutine_t *coro) {
-  ant_value_t gen = generator_find_owner_in_list(js->objects, coro);
-  if (vtype(gen) != T_UNDEF) return gen;
-  gen = generator_find_owner_in_list(js->objects_old, coro);
-  if (vtype(gen) != T_UNDEF) return gen;
-  return generator_find_owner_in_list(js->permanent_objects, coro);
-}
-
 bool generator_resume_pending_request(ant_t *js, coroutine_t *coro, ant_value_t result) {
   if (!coro || coro->type != CORO_GENERATOR || vtype(coro->async_promise) != T_PROMISE) return false;
 
-  ant_value_t gen = generator_find_owner(js, coro);
+  ant_value_t gen = coro->owner_gen;
   generator_data_t *data = generator_data(gen);
   if (!data || !data->is_async) return false;
 
@@ -587,22 +573,16 @@ ant_value_t sv_call_generator_closure_dispatch(
     .awaited_promise = js_mkundef(),
     .result = js_mkundef(),
     .async_func = callee_func,
+    .owner_gen = gen,
     .args = copied_args,
     .nargs = argc,
     .active_parent = NULL,
-    .is_settled = false,
     .is_error = false,
-    .is_done = false,
-    .resume_point = 0,
-    .yield_value = js_mkundef(),
     .async_promise = js_mkundef(),
     .next = NULL,
-    .is_ready = false,
-    .did_suspend = false,
     .refcount = 1,
     .hold_bits = 0,
     .await_registered = false,
-    .destroy_requested = false,
   };
 
   *data = (generator_data_t){
@@ -610,6 +590,7 @@ ant_value_t sv_call_generator_closure_dispatch(
     .state = GEN_SUSPENDED_START,
     .is_async = closure->func->is_async,
   };
+  
   coroutine_hold(coro, CORO_HOLD_GENERATOR);
   coroutine_release(coro);
 

--- a/src/modules/generator.c
+++ b/src/modules/generator.c
@@ -218,7 +218,7 @@ static ant_value_t generator_find_owner(ant_t *js, coroutine_t *coro) {
 static coroutine_t *generator_find_coro_for_vm_in_list(ant_object_t *head, sv_vm_t *vm) {
   for (ant_object_t *obj = head; obj; obj = obj->next) {
     generator_data_t *data = generator_data(js_obj_from_ptr(obj));
-    if (data && data->coro && data->coro->sv_vm == vm && data->coro->owner_vm == vm) return data->coro;
+    if (data && data->coro && data->state == GEN_EXECUTING) return data->coro;
   }
   return NULL;
 }
@@ -264,7 +264,7 @@ bool generator_resume_pending_request(ant_t *js, coroutine_t *coro, ant_value_t 
     return true;
   }
 
-  if (coro->sv_vm && coro->sv_vm->suspended) {
+  if (coro->act && coro->act->frame_count > 0) {
     if (vtype(coro->awaited_promise) != T_UNDEF) {
       generator_set_state(gen, GEN_EXECUTING);
       GC_ROOT_RESTORE(js, root_mark);
@@ -318,8 +318,8 @@ static ant_value_t generator_resume_kind(
   GC_ROOT_PIN(js, gen);
   GC_ROOT_PIN(js, resume_value);
   coroutine_t *coro = generator_coro(gen);
-  
-  if (!coro || !coro->sv_vm) {
+
+  if (!coro || (!coro->act && generator_state(gen) != GEN_SUSPENDED_START)) {
     generator_set_state(gen, GEN_COMPLETED);
     if (resume_kind == SV_RESUME_THROW) {
       GC_ROOT_RESTORE(js, root_mark);
@@ -382,23 +382,50 @@ static ant_value_t generator_resume_kind(
   js->active_async_coro = coro;
   coroutine_hold(coro, CORO_HOLD_ACTIVE);
 
+  sv_vm_t *exec_vm = sv_vm_get_active(js);
   ant_value_t result;
+  
   if (state == GEN_SUSPENDED_START) {
     sv_closure_t *closure = (vtype(coro->async_func) == T_FUNC) ? js_func_closure(coro->async_func) : NULL;
     if (!closure || !closure->func) result = js_mkerr(js, "invalid generator function");
     else result = sv_execute_closure_entry(
-      coro->sv_vm, closure, coro->async_func,
+      exec_vm, closure, coro->async_func,
       coro->super_val, coro->this_val, coro->args, coro->nargs, NULL
     );
-  } else {
-    coro->sv_vm->suspended_resume_value = resume_value;
-    coro->sv_vm->suspended_resume_is_error = (resume_kind == SV_RESUME_THROW);
-    coro->sv_vm->suspended_resume_kind = resume_kind;
-    coro->sv_vm->suspended_resume_pending = true;
-    result = sv_resume_suspended(coro->sv_vm);
+  } else if (coro->act && sv_activation_install(exec_vm, coro->act)) {
+    exec_vm->suspended_resume_value = resume_value;
+    exec_vm->suspended_resume_is_error = (resume_kind == SV_RESUME_THROW);
+    exec_vm->suspended_resume_kind = resume_kind;
+    exec_vm->suspended_resume_pending = true;
+    result = sv_resume_suspended(exec_vm);
+  } else result = js_mkerr(js, "generator activation lost");
+
+  bool suspended_now = true;
+  bool yielded_here = exec_vm->suspended && exec_vm->suspended_entry_fp >= 0;
+  
+  if (yielded_here) {
+    sv_activation_t *act = sv_activation_capture(
+      exec_vm, exec_vm->suspended_entry_fp, 
+      coro->act
+    );
+    
+    if (act) coro->act = act; else {
+      int efp = exec_vm->suspended_entry_fp;
+      exec_vm->fp = efp - 1;
+      exec_vm->sp = exec_vm->frames[efp].prev_sp;
+      exec_vm->handler_depth = exec_vm->frames[efp].handler_base;
+      exec_vm->suspended = false;
+      exec_vm->suspended_resume_pending = false;
+      exec_vm->suspended_entry_fp = -1;
+      exec_vm->suspended_saved_fp = -1;
+      suspended_now = false;
+      result = js_mkerr(js, "out of memory capturing generator activation");
+    }
   }
   
+  if (suspended_now) suspended_now = coro->act && coro->act->frame_count > 0;
   GC_ROOT_PIN(js, result);
+  
   js->active_async_coro = saved_active;
   if (saved_active) saved_active->active_prev = NULL;
   
@@ -413,9 +440,10 @@ static ant_value_t generator_resume_kind(
     return result;
   }
 
-  if (coro->sv_vm && coro->sv_vm->suspended) {
+  if (suspended_now) {
     if (generator_is_async(gen) && vtype(coro->awaited_promise) != T_UNDEF) {
       generator_set_state(gen, GEN_EXECUTING);
+      
       if (vtype(coro->async_promise) != T_PROMISE) {
         coro->async_promise = js_mkpromise(js);
         GC_ROOT_PIN(js, coro->async_promise);
@@ -538,22 +566,15 @@ ant_value_t sv_call_generator_closure_dispatch(
   ant_value_t this_val, ant_value_t *args, int argc
 ) {
   if (!closure || !closure->func) return js_mkerr(js, "invalid generator function");
-
-  sv_vm_t *gen_vm = sv_vm_create(js, SV_VM_ASYNC);
-  if (!gen_vm) return js_mkerr(js, "out of memory for generator VM");
-
-  coroutine_t *coro = (coroutine_t *)CORO_MALLOC(sizeof(coroutine_t));
-  if (!coro) {
-    sv_vm_destroy(gen_vm);
-    return js_mkerr(js, "out of memory for generator");
-  }
+  
+  coroutine_t *coro = (coroutine_t *)calloc(1, sizeof(coroutine_t));
+  if (!coro) return js_mkerr(js, "out of memory for generator");
 
   ant_value_t *copied_args = NULL;
   if (argc > 0 && args) {
-    copied_args = (ant_value_t *)CORO_MALLOC(sizeof(ant_value_t) * (size_t)argc);
+    copied_args = (ant_value_t *)calloc(1, sizeof(ant_value_t) * (size_t)argc);
     if (!copied_args) {
-      sv_vm_destroy(gen_vm);
-      CORO_FREE(coro);
+      free(coro);
       return js_mkerr(js, "out of memory for generator args");
     }
     memcpy(copied_args, args, sizeof(ant_value_t) * (size_t)argc);
@@ -561,17 +582,15 @@ ant_value_t sv_call_generator_closure_dispatch(
 
   ant_value_t gen = js_mkgenerator(js);
   if (is_err(gen)) {
-    if (copied_args) CORO_FREE(copied_args);
-    sv_vm_destroy(gen_vm);
-    CORO_FREE(coro);
+    if (copied_args) free(copied_args);
+    free(coro);
     return gen;
   }
 
   generator_data_t *data = (generator_data_t *)calloc(1, sizeof(*data));
   if (!data) {
-    if (copied_args) CORO_FREE(copied_args);
-    sv_vm_destroy(gen_vm);
-    CORO_FREE(coro);
+    if (copied_args) free(copied_args);
+    free(coro);
     return js_mkerr(js, "out of memory for generator data");
   }
 
@@ -594,10 +613,6 @@ ant_value_t sv_call_generator_closure_dispatch(
     .yield_value = js_mkundef(),
     .async_promise = js_mkundef(),
     .next = NULL,
-    .mco = NULL,
-    .owner_vm = gen_vm,
-    .sv_vm = gen_vm,
-    .mco_started = false,
     .is_ready = false,
     .did_suspend = false,
     .refcount = 1,

--- a/src/modules/generator.c
+++ b/src/modules/generator.c
@@ -380,14 +380,7 @@ static ant_value_t generator_resume_kind(
     );
     
     if (act) coro->act = act; else {
-      int efp = exec_vm->suspended_entry_fp;
-      exec_vm->fp = efp - 1;
-      exec_vm->sp = exec_vm->frames[efp].prev_sp;
-      exec_vm->handler_depth = exec_vm->frames[efp].handler_base;
-      exec_vm->suspended = false;
-      exec_vm->suspended_resume_pending = false;
-      exec_vm->suspended_entry_fp = -1;
-      exec_vm->suspended_saved_fp = -1;
+      sv_activation_discard(exec_vm, exec_vm->suspended_entry_fp);
       suspended_now = false;
       result = js_mkerr(js, "out of memory capturing generator activation");
     }

--- a/src/modules/generator.c
+++ b/src/modules/generator.c
@@ -185,6 +185,7 @@ static void generator_clear_coro(ant_value_t gen, coroutine_t *coro) {
   if (coro) coroutine_unhold(coro, CORO_HOLD_GENERATOR);
 }
 
+// TODO: collapse
 coroutine_t *generator_get_coro_for_gc(ant_value_t gen) {
   return generator_coro(gen);
 }
@@ -213,23 +214,6 @@ static ant_value_t generator_find_owner(ant_t *js, coroutine_t *coro) {
   gen = generator_find_owner_in_list(js->objects_old, coro);
   if (vtype(gen) != T_UNDEF) return gen;
   return generator_find_owner_in_list(js->permanent_objects, coro);
-}
-
-static coroutine_t *generator_find_coro_for_vm_in_list(ant_object_t *head, sv_vm_t *vm) {
-  for (ant_object_t *obj = head; obj; obj = obj->next) {
-    generator_data_t *data = generator_data(js_obj_from_ptr(obj));
-    if (data && data->coro && data->state == GEN_EXECUTING) return data->coro;
-  }
-  return NULL;
-}
-
-coroutine_t *generator_get_coro_for_vm(ant_t *js, sv_vm_t *vm) {
-  if (!js || !vm) return NULL;
-  coroutine_t *coro = generator_find_coro_for_vm_in_list(js->objects, vm);
-  if (coro) return coro;
-  coro = generator_find_coro_for_vm_in_list(js->objects_old, vm);
-  if (coro) return coro;
-  return generator_find_coro_for_vm_in_list(js->permanent_objects, vm);
 }
 
 bool generator_resume_pending_request(ant_t *js, coroutine_t *coro, ant_value_t result) {

--- a/src/modules/timer.c
+++ b/src/modules/timer.c
@@ -825,7 +825,7 @@ static void process_microtasks_internal(ant_t *js, bool check_unhandled_rejectio
   timer_state.microtasks_processing = NULL;
   if (check_unhandled_rejections) js_check_unhandled_rejections(js);
   js->microtasks_draining = false;
-  reap_retired_coroutines();
+  reap_retired_coroutines(js);
 }
 
 void process_microtasks(ant_t *js) {

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -10,16 +10,11 @@
 #include "modules/readline.h"
 #include "modules/process.h"
 
-static reactor_poll_hook_t g_poll_hook = NULL;
-static void *g_poll_hook_data = NULL;
-
 static inline work_flags_t get_pending_work(void) {
   work_flags_t flags = 0;
   if (has_pending_microtasks())         flags |= WORK_MICROTASKS;
   if (has_pending_timers())             flags |= WORK_TIMERS;
   if (has_pending_immediates())         flags |= WORK_IMMEDIATES;
-  if (has_pending_coroutines())         flags |= WORK_COROUTINES;
-  if (has_ready_coroutines())           flags |= WORK_COROUTINES_READY;
   if (has_pending_fetches())            flags |= WORK_FETCHES;
   if (has_pending_fs_ops())             flags |= WORK_FS_OPS;
   if (has_pending_child_processes())    flags |= WORK_CHILD_PROCS;
@@ -29,15 +24,8 @@ static inline work_flags_t get_pending_work(void) {
 }
 
 static inline bool event_loop_alive(void) {
-  work_flags_t w = get_pending_work();
-  if (w & (WORK_PENDING & ~WORK_COROUTINES)) return true;
-  if ((w & WORK_COROUTINES) && (w & WORK_COROUTINES_READY)) return true;
-  return UV_CHECK_ALIVE;
-}
-
-void js_reactor_set_poll_hook(reactor_poll_hook_t hook, void *data) {
-  g_poll_hook = hook;
-  g_poll_hook_data = data;
+  if (get_pending_work() & WORK_PENDING) return true;
+  return uv_loop_alive(uv_default_loop());
 }
 
 void js_poll_events(ant_t *js) {
@@ -45,8 +33,6 @@ void js_poll_events(ant_t *js) {
 
   process_immediates(js);
   process_microtasks(js);
-  
-  if (g_poll_hook) g_poll_hook(g_poll_hook_data);
 }
 
 void js_run_event_loop(ant_t *js) {
@@ -56,10 +42,11 @@ drain:
     reap_retired_coroutines();
     work_flags_t work = get_pending_work();
     
-    if (work & WORK_BLOCKING) uv_run(uv_default_loop(), UV_RUN_NOWAIT);
-    else if ((work & WORK_ASYNC) || UV_CHECK_ALIVE) {
+    if (work & WORK_BLOCKING) 
+      uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+    else if ((work & WORK_ASYNC) || uv_loop_alive(uv_default_loop()))
       uv_run(uv_default_loop(), UV_RUN_ONCE);
-    } else break;
+    else break;
   } 
   
   js_poll_events(js);

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -39,7 +39,7 @@ void js_run_event_loop(ant_t *js) {
 drain:
   while (event_loop_alive()) {
     js_poll_events(js);
-    reap_retired_coroutines();
+    reap_retired_coroutines(js);
     work_flags_t work = get_pending_work();
     
     if (work & WORK_BLOCKING) 
@@ -50,7 +50,7 @@ drain:
   } 
   
   js_poll_events(js);
-  reap_retired_coroutines();
+  reap_retired_coroutines(js);
   ant_value_t code = js_mknum(0);
   emit_process_event("beforeExit", &code, 1);
   
@@ -59,8 +59,8 @@ drain:
 
 void js_reactor_pump_repl_nowait(ant_t *js) {
   js_poll_events(js);
-  reap_retired_coroutines();
+  reap_retired_coroutines(js);
   uv_run(uv_default_loop(), UV_RUN_NOWAIT);
   js_poll_events(js);
-  reap_retired_coroutines();
+  reap_retired_coroutines(js);
 }

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -41,28 +41,10 @@ void js_reactor_set_poll_hook(reactor_poll_hook_t hook, void *data) {
 }
 
 void js_poll_events(ant_t *js) {
-  coros_this_tick = 0;
   gc_maybe(js);
 
   process_immediates(js);
   process_microtasks(js);
-  
-  for (;;) {
-    coroutine_t *temp = NULL;
-    for (coroutine_t *c = pending_coroutines.head; c; c = c->next) 
-      if (c->is_ready && c->mco && mco_status(c->mco) == MCO_SUSPENDED) { temp = c; break; }
-    
-    if (!temp) break;
-    temp->is_ready = false;
-    coroutine_retain(temp);
-    
-    mco_result res;
-    MCO_RESUME_SAVE(js, temp->mco, res);
-    
-    if (res != MCO_SUCCESS || mco_status(temp->mco) == MCO_DEAD) 
-      remove_coroutine(temp);
-    coroutine_release(temp);
-  }
   
   if (g_poll_hook) g_poll_hook(g_poll_hook_data);
 }

--- a/src/silver/ast.c
+++ b/src/silver/ast.c
@@ -1372,6 +1372,7 @@ static sv_ast_t *parse_paren_expr(P) {
   return left;
 }
 
+// TODO: move into a ast_contains 
 bool ast_references_arguments(const sv_ast_t *node) {
   if (!node) return false;
   if (node->type == N_IDENT && node->len == 9 && memcmp(node->str, "arguments", 9) == 0)
@@ -1391,6 +1392,60 @@ bool ast_references_arguments(const sv_ast_t *node) {
   for (int i = 0; i < node->args.count; i++)
     if (ast_references_arguments(node->args.items[i])) return true;
     
+  return false;
+}
+
+bool ast_contains_direct_suspend(const sv_ast_t *node, const sv_ast_t **out_offender) {
+  if (!node) return false;
+
+  if (node->type == N_AWAIT || node->type == N_YIELD) {
+    if (out_offender) *out_offender = node;
+    return true;
+  }
+
+  if (node->type == N_FUNC || node->type == N_ARROW) {
+    bool plain_arrow = (node->flags & FN_ARROW) && !(node->flags & FN_ASYNC);
+    if (!plain_arrow) return false;
+  }
+
+  if (ast_contains_direct_suspend(node->left, out_offender))         return true;
+  if (ast_contains_direct_suspend(node->right, out_offender))        return true;
+  if (ast_contains_direct_suspend(node->cond, out_offender))         return true;
+  if (ast_contains_direct_suspend(node->body, out_offender))         return true;
+  if (ast_contains_direct_suspend(node->catch_param, out_offender))  return true;
+  if (ast_contains_direct_suspend(node->catch_body, out_offender))   return true;
+  if (ast_contains_direct_suspend(node->finally_body, out_offender)) return true;
+  if (ast_contains_direct_suspend(node->init, out_offender))         return true;
+  if (ast_contains_direct_suspend(node->update, out_offender))       return true;
+
+  for (int i = 0; i < node->args.count; i++)
+    if (ast_contains_direct_suspend(node->args.items[i], out_offender)) return true;
+
+  return false;
+}
+
+bool ast_contains_own_yield(const sv_ast_t *node, const sv_ast_t **out_offender) {
+  if (!node) return false;
+
+  if (node->type == N_YIELD) {
+    if (out_offender) *out_offender = node;
+    return true;
+  }
+
+  if (node->type == N_FUNC || node->type == N_ARROW)            return false;
+  if (ast_contains_own_yield(node->left, out_offender))         return true;
+  if (ast_contains_own_yield(node->right, out_offender))        return true;
+  if (ast_contains_own_yield(node->cond, out_offender))         return true;
+  if (ast_contains_own_yield(node->body, out_offender))         return true;
+  if (ast_contains_own_yield(node->catch_param, out_offender))  return true;
+  if (ast_contains_own_yield(node->catch_body, out_offender))   return true;
+  if (ast_contains_own_yield(node->finally_body, out_offender)) return true;
+  if (ast_contains_own_yield(node->init, out_offender))         return true;
+  if (ast_contains_own_yield(node->update, out_offender))       return true;
+
+  for (int i = 0; i < node->args.count; i++)
+    if (ast_contains_own_yield(node->args.items[i], out_offender)) return true;
+
   return false;
 }
 

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -3674,7 +3674,8 @@ static bool compile_inline_literal_eval(sv_compiler_t *c, sv_ast_t *node) {
   } else if (
     program->args.count == 1 &&
     is_inline_literal_eval_expr(program->args.items[0]) &&
-    inline_eval_can_compile_without_early_errors(c, program->args.items[0])
+    inline_eval_can_compile_without_early_errors(c, program->args.items[0]) &&
+    !ast_contains_direct_suspend(program->args.items[0], NULL)
   ) expr = program->args.items[0]; else {
     parse_arena_rewind(mark);
     c->js->thrown_exists = saved_thrown_exists;
@@ -6249,6 +6250,17 @@ sv_func_t *compile_function_body(
     &has_own_use_strict, &has_non_simple_params, true
   )) return NULL;
 
+  if (!(node->flags & FN_GENERATOR)) {
+    const sv_ast_t *offender = NULL;
+    bool found = ast_contains_own_yield(node->body, &offender);
+    for (int i = 0; !found && i < node->args.count; i++)
+      found = ast_contains_own_yield(node->args.items[i], &offender);
+    if (found) {
+      js_mkerr_typed(comp.js, JS_ERR_SYNTAX, "yield is only valid in generator functions");
+      return NULL;
+    }
+  }
+
   if (has_own_use_strict) comp.is_strict = true;
   for (int i = 0; i < node->args.count; i++) {
     sv_ast_t *p = node->args.items[i];
@@ -6814,6 +6826,20 @@ void sv_disasm(ant_t *js, sv_func_t *func, const char *label) {
 
 sv_func_t *sv_compile(ant_t *js, sv_ast_t *program, sv_compile_mode_t mode, const char *source, ant_offset_t source_len) {
   if (!program || program->type != N_PROGRAM) return NULL;
+
+  if (mode == SV_COMPILE_EVAL) {
+    const sv_ast_t *offender = NULL;
+    for (int i = 0; i < program->args.count; i++)
+      if (ast_contains_direct_suspend(program->args.items[i], &offender)) break;
+
+    if (offender) {
+      js_mkerr_typed(js, JS_ERR_SYNTAX, offender->type == N_AWAIT
+        ? "await is only valid in async functions and the top level bodies of modules"
+        : "yield is only valid in generator functions");
+      return NULL;
+    }
+  }
+  
   if (sv_compile_trace_unlikely) fprintf(
     stderr, "[compile] start kind=program mode=%d len=%u body=%d strict=%d\n",
     (int)mode, (unsigned)source_len,

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -291,6 +291,35 @@ bool sv_activation_install(sv_vm_t *vm, sv_activation_t *act) {
   return true;
 }
 
+static inline void sv_drop_frame_runtime_state(ant_t *js, sv_frame_t *frame) {
+  if (frame && vtype(frame->arguments_obj) != T_UNDEF) {
+    js_arguments_detach(js, frame->arguments_obj);
+    frame->arguments_obj = js_mkundef();
+  }
+}
+
+void sv_activation_discard(sv_vm_t *vm, int entry_fp) {
+  if (!vm || entry_fp < 0 || entry_fp > vm->fp) return;
+
+  if (vm->open_upvalues) {
+  for (int f = vm->fp; f >= entry_fp; f--) {
+    ant_value_t *drop_bp = vm->frames[f].bp;
+    if (drop_bp) sv_close_upvalues_from_slot(vm, drop_bp);
+  }}
+
+  for (int f = vm->fp; f >= entry_fp; f--)
+    sv_drop_frame_runtime_state(vm->js, &vm->frames[f]);
+
+  vm->fp = entry_fp - 1;
+  vm->sp = vm->frames[entry_fp].prev_sp;
+  vm->handler_depth = vm->frames[entry_fp].handler_base;
+
+  vm->suspended = false;
+  vm->suspended_resume_pending = false;
+  vm->suspended_entry_fp = -1;
+  vm->suspended_saved_fp = -1;
+}
+
 void sv_activation_seal(ant_t *js, sv_activation_t *act) {
   if (!js || !act || act->frame_count <= 0) return;
 
@@ -700,12 +729,6 @@ static inline void sv_sync_frame_locals(
   *frame = &vm->frames[vm->fp]; *func = (*frame)->func;
   *bp = (*frame)->bp; *lp = (*frame)->lp;
 }
-
-static inline void sv_drop_frame_runtime_state(ant_t *js, sv_frame_t *frame) {
-if (frame && vtype(frame->arguments_obj) != T_UNDEF) {
-  js_arguments_detach(js, frame->arguments_obj);
-  frame->arguments_obj = js_mkundef();
-}}
 
 static inline ant_value_t sv_stage_frame_args(
   sv_vm_t *vm, ant_t *js, sv_func_t *func, ant_value_t *args, int argc,

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -2,6 +2,13 @@
 #include "errors.h"
 #include <stdlib.h>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#endif
+
 #include "silver/engine.h"
 #include "silver/swarm.h"
 #include "modules/generator.h"
@@ -30,37 +37,83 @@
 #include "ops/objects.h"
 #include "ops/coercion.h"
 
-sv_vm_t *sv_vm_create(ant_t *js, sv_vm_kind_t kind) {
+enum {
+  SV_STACK_RESERVE = ((size_t)SV_STACK_HARD_MAX * sizeof(ant_value_t)),
+  SV_FRAMES_RESERVE = ((size_t)SV_FRAMES_HARD_MAX * sizeof(sv_frame_t)),
+  SV_VM_RESERVE = (SV_STACK_RESERVE + SV_FRAMES_RESERVE)
+};
+
+static void *sv_vm_reserve_storage(void) {
+#ifdef _WIN32
+  return VirtualAlloc(NULL, SV_VM_RESERVE, MEM_RESERVE, PAGE_READWRITE);
+#else
+  int flags = MAP_PRIVATE | MAP_ANON;
+#ifdef MAP_NORESERVE
+  flags |= MAP_NORESERVE;
+#endif
+  void *p = mmap(NULL, SV_VM_RESERVE, PROT_READ | PROT_WRITE, flags, -1, 0);
+  return p == MAP_FAILED ? NULL : p;
+#endif
+}
+
+static void sv_vm_release_storage(void *base) {
+  if (!base) return;
+#ifdef _WIN32
+  VirtualFree(base, 0, MEM_RELEASE);
+#else
+  munmap(base, SV_VM_RESERVE);
+#endif
+}
+
+static bool sv_vm_commit_storage(void *addr, size_t bytes) {
+#ifdef _WIN32
+  return VirtualAlloc(addr, bytes, MEM_COMMIT, PAGE_READWRITE) != NULL;
+#else
+  (void)addr; (void)bytes;
+  return true;
+#endif
+}
+
+sv_vm_t *sv_vm_create(ant_t *js) {
   int stack_size, max_frames;
-  sv_vm_limits(kind, &stack_size, &max_frames);
+  sv_vm_limits(&stack_size, &max_frames);
 
   sv_vm_t *vm = calloc(1, sizeof(*vm));
   if (!vm) return NULL;
-  
+
   vm->js = js;
   vm->fp = -1;
-  
+
   vm->stack_size = stack_size;
   vm->max_frames = max_frames;
-  
+
   vm->suspended_entry_fp = -1;
   vm->suspended_saved_fp = -1;
-  
-  vm->stack = calloc((size_t)stack_size, sizeof(ant_value_t));
-  vm->frames = calloc((size_t)max_frames, sizeof(sv_frame_t));
-  
-  if (!vm->stack || !vm->frames) { 
-    sv_vm_destroy(vm);
+
+  void *base = sv_vm_reserve_storage();
+  if (!base) {
+    free(vm);
     return NULL;
   }
-  
+
+  vm->stack = (ant_value_t *)base;
+  vm->frames = (sv_frame_t *)((char *)base + SV_STACK_RESERVE);
+
+  if (
+    !sv_vm_commit_storage(vm->stack, (size_t)stack_size * sizeof(ant_value_t)) ||
+    !sv_vm_commit_storage(vm->frames, (size_t)max_frames * sizeof(sv_frame_t))
+  ) {
+    sv_vm_release_storage(base);
+    free(vm);
+    return NULL;
+  }
+
   return vm;
 }
 
 void sv_vm_destroy(sv_vm_t *vm) {
   if (!vm) return;
-  free(vm->stack);
-  free(vm->frames);
+  sv_vm_release_storage(vm->stack);
   free(vm);
 }
 
@@ -68,12 +121,8 @@ static bool sv_vm_grow_frames(sv_vm_t *vm) {
   int new_max = vm->max_frames * 2;
   if (new_max > SV_FRAMES_HARD_MAX) new_max = SV_FRAMES_HARD_MAX;
   if (new_max <= vm->max_frames) return false;
-  
-  sv_frame_t *nf = realloc(vm->frames, (size_t)new_max * sizeof(sv_frame_t));
-  if (!nf) return false;
-  vm->frames = nf;
+  if (!sv_vm_commit_storage(vm->frames, (size_t)new_max * sizeof(sv_frame_t))) return false;
   vm->max_frames = new_max;
-  
   return true;
 }
 
@@ -81,28 +130,162 @@ static bool sv_vm_grow_stack(sv_vm_t *vm) {
   int new_size = vm->stack_size * 2;
   if (new_size > SV_STACK_HARD_MAX) new_size = SV_STACK_HARD_MAX;
   if (new_size <= vm->stack_size) return false;
-  
-  ant_value_t *old = vm->stack;
-  int old_size = vm->stack_size;
-  
-  ant_value_t *ns = realloc(vm->stack, (size_t)new_size * sizeof(ant_value_t));
-  if (!ns) return false;
-  
-  ptrdiff_t delta = ns - old;
-  vm->stack = ns;
+  if (!sv_vm_commit_storage(vm->stack, (size_t)new_size * sizeof(ant_value_t))) return false;
   vm->stack_size = new_size;
-  
-  if (delta != 0) {
-    for (int i = 0; i <= vm->fp; i++) {
-      if (vm->frames[i].bp) vm->frames[i].bp += delta;
-      if (vm->frames[i].lp) vm->frames[i].lp += delta;
-    }
-    for (sv_upvalue_t *uv = vm->open_upvalues; uv; uv = uv->next) if (
-      uv->location != &uv->closed &&
-      sv_slot_in_range(old, (size_t)old_size, uv->location)
-    ) uv->location += delta;
+  return true;
+}
+
+sv_activation_t *sv_activation_capture(sv_vm_t *vm, int entry_fp, sv_activation_t *reuse) {
+  if (!vm || vm->fp < 0 || entry_fp < 0 || entry_fp > vm->fp) return NULL;
+
+  sv_frame_t *entry_frame = &vm->frames[entry_fp];
+  int frame_count = vm->fp - entry_fp + 1;
+  int stack_base = entry_frame->prev_sp;
+  int stack_count = vm->sp - stack_base;
+  int handler_base = entry_frame->handler_base;
+  int handler_count = vm->handler_depth - handler_base;
+
+  if (stack_count < 0 || handler_count < 0) return NULL;
+
+  size_t frames_off = (sizeof(sv_activation_t) + 7) & ~(size_t)7;
+  size_t slots_off = frames_off + (size_t)frame_count * sizeof(sv_frame_t);
+  size_t handlers_off = slots_off + (size_t)stack_count * sizeof(ant_value_t);
+  size_t need = handlers_off + (size_t)handler_count * sizeof(sv_handler_t);
+
+  sv_activation_t *act = reuse;
+  if (!act || act->capacity < need) {
+    act = realloc(reuse, need);
+    if (!act) return NULL;
+    act->capacity = need;
   }
+
+  act->frames = (sv_frame_t *)((char *)act + frames_off);
+  act->slots = (ant_value_t *)((char *)act + slots_off);
+  act->handlers = (sv_handler_t *)((char *)act + handlers_off);
   
+  act->frame_count = frame_count;
+  act->stack_count = stack_count;
+  act->handler_count = handler_count;
+
+  ant_value_t *src_base = &vm->stack[stack_base];
+  if (stack_count > 0)
+    memcpy(act->slots, src_base, sizeof(ant_value_t) * (size_t)stack_count);
+
+  for (int i = 0; i < frame_count; i++) {
+    sv_frame_t *src = &vm->frames[entry_fp + i];
+    sv_frame_t *dst = &act->frames[i];
+    *dst = *src;
+
+    dst->prev_sp = src->prev_sp - stack_base;
+    dst->handler_base = (uint16_t)(src->handler_base - handler_base);
+    dst->handler_top = (uint16_t)(src->handler_top - handler_base);
+
+    if (src->bp) dst->bp = act->slots + (src->bp - src_base);
+    if (src->lp) dst->lp = act->slots + (src->lp - src_base);
+  }
+
+  for (int i = 0; i < frame_count; i++) if (vtype(act->frames[i].arguments_obj) != T_UNDEF) 
+    js_arguments_bind_direct(vm->js, act->frames[i].arguments_obj, &act->frames[i]);
+
+  for (int i = 0; i < handler_count; i++) {
+    sv_handler_t h = vm->handler_stack[handler_base + i];
+    h.saved_sp -= stack_base;
+    act->handlers[i] = h;
+  }
+
+  act->open_upvalues = NULL;
+  sv_upvalue_t **src_pp = &vm->open_upvalues;
+  sv_upvalue_t **dst_pp = &act->open_upvalues;
+  
+  while (*src_pp) {
+    sv_upvalue_t *uv = *src_pp;
+    if (stack_count <= 0 || !sv_slot_in_range(src_base, (size_t)stack_count, uv->location)) {
+      src_pp = &uv->next;
+      continue;
+    }
+
+    ptrdiff_t slot = uv->location - src_base;
+    *src_pp = uv->next;
+    uv->location = &act->slots[slot];
+    uv->next = NULL;
+    *dst_pp = uv;
+    dst_pp = &uv->next;
+  }
+
+  vm->fp = entry_fp - 1;
+  vm->sp = stack_base;
+  vm->handler_depth = handler_base;
+  vm->suspended = false;
+  vm->suspended_resume_pending = false;
+  vm->suspended_resume_is_error = false;
+  vm->suspended_resume_kind = SV_RESUME_NEXT;
+  vm->suspended_resume_value = js_mkundef();
+  vm->suspended_entry_fp = -1;
+  vm->suspended_saved_fp = -1;
+
+  return act;
+}
+
+bool sv_activation_install(sv_vm_t *vm, sv_activation_t *act) {
+  if (!vm || !act || act->frame_count < 1) return false;
+
+  while (vm->sp + act->stack_count > vm->stack_size)
+    if (!sv_vm_grow_stack(vm)) return false;
+  while (vm->fp + act->frame_count >= vm->max_frames)
+    if (!sv_vm_grow_frames(vm)) return false;
+  
+  if (vm->handler_depth + act->handler_count > SV_HANDLER_MAX) return false;
+
+  int entry_fp = vm->fp + 1;
+  int stack_base = vm->sp;
+  int handler_base = vm->handler_depth;
+  ant_value_t *dst_base = &vm->stack[stack_base];
+
+  if (act->stack_count > 0)
+    memcpy(dst_base, act->slots, sizeof(ant_value_t) * (size_t)act->stack_count);
+
+  for (int i = 0; i < act->frame_count; i++) {
+    sv_frame_t *src = &act->frames[i];
+    sv_frame_t *dst = &vm->frames[entry_fp + i];
+    *dst = *src;
+
+    dst->prev_sp = src->prev_sp + stack_base;
+    dst->handler_base = (uint16_t)(src->handler_base + handler_base);
+    dst->handler_top = (uint16_t)(src->handler_top + handler_base);
+
+    if (src->bp) dst->bp = dst_base + (src->bp - act->slots);
+    if (src->lp) dst->lp = dst_base + (src->lp - act->slots);
+
+    if (vtype(dst->arguments_obj) != T_UNDEF)
+      js_arguments_rebind_frame(vm->js, dst->arguments_obj, entry_fp + i);
+  }
+
+  for (int i = 0; i < act->handler_count; i++) {
+    sv_handler_t h = act->handlers[i];
+    h.saved_sp += stack_base;
+    vm->handler_stack[handler_base + i] = h;
+  }
+
+  if (act->open_upvalues) {
+    sv_upvalue_t *tail = act->open_upvalues;
+    for (sv_upvalue_t *uv = act->open_upvalues;; uv = uv->next) {
+      uv->location = dst_base + (uv->location - act->slots);
+      if (!uv->next) { tail = uv; break; }
+    }
+    tail->next = vm->open_upvalues;
+    vm->open_upvalues = act->open_upvalues;
+    act->open_upvalues = NULL;
+  }
+
+  vm->sp = stack_base + act->stack_count;
+  vm->fp = entry_fp + act->frame_count - 1;
+  vm->handler_depth = handler_base + act->handler_count;
+
+  vm->suspended = true;
+  vm->suspended_entry_fp = entry_fp;
+  vm->suspended_saved_fp = entry_fp - 1;
+
+  act->frame_count = 0;
   return true;
 }
 
@@ -1842,7 +2025,7 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
       goto sv_throw;
     }
     if (await_result.state == SV_AWAIT_SUSPENDED) {
-      if (await_result.handoff) vm_result = js_mkundef();
+      vm_result = js_mkundef();
       goto sv_leave;
     }
     NEXT(1);
@@ -1860,16 +2043,13 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
     vm->suspended_saved_fp = entry_fp - 1;
     
     sv_await_result_t await_result = sv_await_value(vm, js, await_val);
-    if (await_result.state == SV_AWAIT_SUSPENDED && await_result.handoff) {
-      vm->suspended_entry_fp = -1;
-      vm->suspended_saved_fp = -1;
+    vm->suspended_entry_fp = -1;
+    vm->suspended_saved_fp = -1;
+
+    if (await_result.state == SV_AWAIT_SUSPENDED) {
       vm_result = js_mkundef();
       goto sv_leave;
     }
-    
-    if (await_result.state == SV_AWAIT_SUSPENDED) goto sv_leave;
-    vm->suspended_entry_fp = -1;
-    vm->suspended_saved_fp = -1;
     
     if (await_result.state == SV_AWAIT_ERROR) {
       sv_err = await_result.value;
@@ -1882,7 +2062,7 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
   
   L_YIELD: {
     ant_value_t yielded = vm->stack[--vm->sp];
-    coroutine_t *coro = sv_async_get_active_coro_for_vm(js, vm);
+    coroutine_t *coro = sv_async_active_coro(js);
     if (!coro || coro->type != CORO_GENERATOR)
       coro = generator_get_coro_for_vm(js, vm);
     if (!coro || coro->type != CORO_GENERATOR) {
@@ -1913,7 +2093,7 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
   L_YIELD_STAR_NEXT:
   L_YIELD_STAR_THROW:
   L_YIELD_STAR_RETURN: {
-    coroutine_t *coro = sv_async_get_active_coro_for_vm(js, vm);
+    coroutine_t *coro = sv_async_active_coro(js);
     if (!coro || coro->type != CORO_GENERATOR)
       coro = generator_get_coro_for_vm(js, vm);
     if (!coro || coro->type != CORO_GENERATOR) {

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -11,7 +11,6 @@
 
 #include "silver/engine.h"
 #include "silver/swarm.h"
-#include "modules/generator.h"
 #include "modules/regex.h"
 
 #include "ops/literals.h"
@@ -2086,8 +2085,6 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
   L_YIELD: {
     ant_value_t yielded = vm->stack[--vm->sp];
     coroutine_t *coro = sv_async_active_coro(js);
-    if (!coro || coro->type != CORO_GENERATOR)
-      coro = generator_get_coro_for_vm(js, vm);
     if (!coro || coro->type != CORO_GENERATOR) {
       sv_err = js_mkerr(js, "yield can only be used inside generator functions");
       goto sv_throw;
@@ -2117,8 +2114,6 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
   L_YIELD_STAR_THROW:
   L_YIELD_STAR_RETURN: {
     coroutine_t *coro = sv_async_active_coro(js);
-    if (!coro || coro->type != CORO_GENERATOR)
-      coro = generator_get_coro_for_vm(js, vm);
     if (!coro || coro->type != CORO_GENERATOR) {
       sv_err = js_mkerr(js, "yield can only be used inside generator functions");
       goto sv_throw;

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -533,13 +533,6 @@ static inline void sv_record_slot_feedback(
   sv_tfb_record_local(func, (int)(slot_idx - func->param_count), value);
 }
 
-bool sv_slot_has_open_upvalue(sv_vm_t *vm, ant_value_t *slot) {
-  if (!vm || !slot) return false;
-  for (sv_upvalue_t *uv = vm->open_upvalues; uv; uv = uv->next)
-    if (uv->location == slot) return true;
-  return false;
-}
-
 ant_value_t sv_string_builder_read_value(ant_t *js, ant_value_t value) {
   if (vtype(value) == T_STR && str_is_heap_builder(value))
     return str_materialize(js, value);
@@ -2089,8 +2082,6 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
       sv_err = js_mkerr(js, "yield can only be used inside generator functions");
       goto sv_throw;
     }
-    coro->yield_value = yielded;
-    coro->did_suspend = true;
     vm->suspended = true;
     vm->suspended_entry_fp = entry_fp;
     vm->suspended_saved_fp = entry_fp - 1;
@@ -2141,8 +2132,6 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
       NEXT(3);
     }
 
-    coro->yield_value = yielded;
-    coro->did_suspend = true;
     vm->suspended = true;
     vm->suspended_entry_fp = entry_fp;
     vm->suspended_saved_fp = entry_fp - 1;

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -38,9 +38,10 @@
 #include "ops/coercion.h"
 
 enum {
+  SV_VM_GUARD_SIZE = (size_t)65536,
   SV_STACK_RESERVE = ((size_t)SV_STACK_HARD_MAX * sizeof(ant_value_t)),
   SV_FRAMES_RESERVE = ((size_t)SV_FRAMES_HARD_MAX * sizeof(sv_frame_t)),
-  SV_VM_RESERVE = (SV_STACK_RESERVE + SV_FRAMES_RESERVE)
+  SV_VM_RESERVE = (SV_STACK_RESERVE + SV_VM_GUARD_SIZE + SV_FRAMES_RESERVE)
 };
 
 static void *sv_vm_reserve_storage(void) {
@@ -52,7 +53,9 @@ static void *sv_vm_reserve_storage(void) {
   flags |= MAP_NORESERVE;
 #endif
   void *p = mmap(NULL, SV_VM_RESERVE, PROT_READ | PROT_WRITE, flags, -1, 0);
-  return p == MAP_FAILED ? NULL : p;
+  if (p == MAP_FAILED) return NULL;
+  mprotect((char *)p + SV_STACK_RESERVE, SV_VM_GUARD_SIZE, PROT_NONE);
+  return p;
 #endif
 }
 
@@ -97,7 +100,7 @@ sv_vm_t *sv_vm_create(ant_t *js) {
   }
 
   vm->stack = (ant_value_t *)base;
-  vm->frames = (sv_frame_t *)((char *)base + SV_STACK_RESERVE);
+  vm->frames = (sv_frame_t *)((char *)base + SV_STACK_RESERVE + SV_VM_GUARD_SIZE);
 
   if (
     !sv_vm_commit_storage(vm->stack, (size_t)stack_size * sizeof(ant_value_t)) ||
@@ -287,6 +290,26 @@ bool sv_activation_install(sv_vm_t *vm, sv_activation_t *act) {
 
   act->frame_count = 0;
   return true;
+}
+
+void sv_activation_seal(ant_t *js, sv_activation_t *act) {
+  if (!js || !act || act->frame_count <= 0) return;
+
+  for (sv_upvalue_t *uv = act->open_upvalues; uv;) {
+    sv_upvalue_t *next = uv->next;
+    uv->closed = *uv->location;
+    uv->location = &uv->closed;
+    uv->next = NULL;
+    uv = next;
+  }
+  act->open_upvalues = NULL;
+
+  for (int i = 0; i < act->frame_count; i++) {
+    ant_value_t args_obj = act->frames[i].arguments_obj;
+    if (vtype(args_obj) == T_UNDEF) continue;
+    if (js_obj_ptr(args_obj)->mark_epoch == ANT_GC_DEAD) continue;
+    js_arguments_detach(js, args_obj);
+  }
 }
 
 #ifdef ANT_JIT

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -53,7 +53,10 @@ static void *sv_vm_reserve_storage(void) {
 #endif
   void *p = mmap(NULL, SV_VM_RESERVE, PROT_READ | PROT_WRITE, flags, -1, 0);
   if (p == MAP_FAILED) return NULL;
-  mprotect((char *)p + SV_STACK_RESERVE, SV_VM_GUARD_SIZE, PROT_NONE);
+  if (mprotect((char *)p + SV_STACK_RESERVE, SV_VM_GUARD_SIZE, PROT_NONE) != 0) {
+    munmap(p, SV_VM_RESERVE);
+    return NULL;
+  }
   return p;
 #endif
 }
@@ -79,6 +82,9 @@ static bool sv_vm_commit_storage(void *addr, size_t bytes) {
 sv_vm_t *sv_vm_create(ant_t *js) {
   int stack_size, max_frames;
   sv_vm_limits(&stack_size, &max_frames);
+
+  if (stack_size > SV_STACK_HARD_MAX) stack_size = SV_STACK_HARD_MAX;
+  if (max_frames > SV_FRAMES_HARD_MAX) max_frames = SV_FRAMES_HARD_MAX;
 
   sv_vm_t *vm = calloc(1, sizeof(*vm));
   if (!vm) return NULL;

--- a/src/silver/limits.c
+++ b/src/silver/limits.c
@@ -16,7 +16,6 @@
 #endif
 
 #define SV_DEFAULT_STACK_KB  984
-#define SV_ASYNC_STACK_KB    64
 #define SV_BYTES_PER_SLOT    ((int)sizeof(uint64_t))
 
 int sv_user_stack_size_kb = 0;
@@ -45,13 +44,7 @@ size_t os_thread_stack_size(void) {
 #endif
 }
 
-void sv_vm_limits(sv_vm_kind_t kind, int *out_stack_size, int *out_max_frames) {
-  if (kind == SV_VM_ASYNC) {
-    *out_stack_size = (SV_ASYNC_STACK_KB * 1024) / SV_BYTES_PER_SLOT;
-    *out_max_frames = 256;
-    return;
-  }
-
+void sv_vm_limits(int *out_stack_size, int *out_max_frames) {
   int stack_kb = (sv_user_stack_size_kb > 0)
     ? sv_user_stack_size_kb
     : SV_DEFAULT_STACK_KB;

--- a/src/silver/ops/async.h
+++ b/src/silver/ops/async.h
@@ -4,7 +4,6 @@
 #include "ant.h"
 #include "sugar.h"
 #include "gc/roots.h"
-#include "modules/generator.h"
 #include "silver/engine.h"
 
 typedef enum {
@@ -259,8 +258,6 @@ static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value
   }
 
   coroutine_t *coro = sv_async_active_coro(js);
-  if (!coro) coro = generator_get_coro_for_vm(js, vm);
-
   if (!coro) {
     out.state = SV_AWAIT_ERROR;
     out.value = js_mkerr(js, "await can only be used inside async functions");

--- a/src/silver/ops/async.h
+++ b/src/silver/ops/async.h
@@ -2,92 +2,10 @@
 #define SV_ASYNC_H
 
 #include "ant.h"
+#include "sugar.h"
 #include "gc/roots.h"
 #include "modules/generator.h"
-#include "sugar.h"
 #include "silver/engine.h"
-
-#include <minicoro.h>
-typedef struct {
-  ant_t *js;
-  coroutine_t *coro;
-} sv_coro_header_t;
-
-typedef struct {
-  ant_t *js;
-  
-  coroutine_t *coro;
-  sv_closure_t *closure;
-  
-  ant_value_t callee_func;
-  ant_value_t super_val;
-  ant_value_t this_val;
-  ant_value_t *args;
-  
-  int argc;
-  sv_vm_t *vm;
-} sv_async_ctx_t;
-
-static inline bool sv_async_func_supports_lazy_start(sv_func_t *func) {
-  if (!func || !func->has_await || func->is_generator) return false;
-
-  for (int off = 0; off < func->code_len;) {
-    sv_op_t op = (sv_op_t)func->code[off];
-    if (
-      op == OP_AWAIT_ITER_NEXT ||
-      op == OP_YIELD ||
-      op == OP_YIELD_STAR_NEXT ||
-      op == OP_YIELD_STAR_THROW ||
-      op == OP_YIELD_STAR_RETURN
-    ) return false;
-    
-    int size = sv_op_size[op];
-    if (size <= 0) return false;
-    
-    off += size;
-  }
-
-  return true;
-}
-static void sv_mco_async_entry(mco_coro *mco) {
-  sv_async_ctx_t *ctx = (sv_async_ctx_t *)mco_get_user_data(mco);
-  ant_t *js = ctx->js;
-  MCO_CORO_STACK_ENTER(js, mco);
-
-  ant_value_t super_val = ctx->super_val;
-  if (ctx->coro) {
-    super_val = ctx->coro->super_val;
-    js->new_target = ctx->coro->new_target;
-  }
-
-  sv_vm_t *vm = ctx->vm;
-  ant_value_t result = sv_execute_closure_entry(
-    vm, ctx->closure, ctx->callee_func, 
-    super_val, ctx->this_val, ctx->args, ctx->argc, NULL
-  );
-
-  ant_value_t promise = ctx->coro->async_promise;
-  if (vm && vm->suspended) return;
-
-  if (is_err(result)) {
-    ant_value_t reject_value = js->thrown_exists ? js->thrown_value : result;
-    js->thrown_exists = false;
-    js->thrown_value = js_mkundef();
-    js_reject_promise(js, promise, reject_value);
-    js_maybe_drain_microtasks_after_async_settle(js);
-  } else {
-    js_resolve_promise(js, promise, result);
-    js_maybe_drain_microtasks_after_async_settle(js);
-  }
-}
-
-typedef struct {
-  ant_t *js;
-  coroutine_t *coro;
-  sv_func_t   *func;
-  ant_value_t this_val;
-  sv_vm_t *vm;
-} sv_tla_ctx_t;
 
 typedef enum {
   SV_AWAIT_READY = 0,
@@ -98,7 +16,6 @@ typedef enum {
 typedef struct {
   sv_await_state_t state;
   ant_value_t value;
-  bool handoff;
 } sv_await_result_t;
 
 static inline void sv_async_link_activation(ant_t *js, coroutine_t *coro) {
@@ -126,25 +43,13 @@ static inline void sv_async_unlink_activation(ant_t *js, coroutine_t *coro) {
   coroutine_unhold(coro, CORO_HOLD_ACTIVE);
 }
 
-static inline bool sv_async_coro_matches_vm(const coroutine_t *coro, const sv_vm_t *vm) {
-  if (!coro || !vm) return false;
-  if (coro->sv_vm == vm) return true;
-  return coro->owner_vm == vm;
-}
-
-static inline coroutine_t *sv_async_get_active_coro_for_vm(ant_t *js, sv_vm_t *vm) {
-  if (!js || !js->active_async_coro) return NULL;
-  if (!vm) return js->active_async_coro;
-
-  for (coroutine_t *it = js->active_async_coro; it; it = it->active_parent) {
-    if (sv_async_coro_matches_vm(it, vm)) return it;
-  }
-
-  return NULL;
+// TODO: flatten
+static inline coroutine_t *sv_async_active_coro(ant_t *js) {
+  return js ? js->active_async_coro : NULL;
 }
 
 static inline void sv_async_init_activation(
-  coroutine_t *coro, ant_t *js, sv_vm_t *owner_vm, ant_value_t promise,
+  coroutine_t *coro, ant_t *js, ant_value_t promise,
   ant_value_t this_val, ant_value_t super_val, ant_value_t new_target,
   ant_value_t async_func, int nargs
 ) {
@@ -163,13 +68,8 @@ static inline void sv_async_init_activation(
     .active_parent = NULL,
     .prev = NULL,
     .next = NULL,
-    .mco = NULL,
-    .owner_vm = owner_vm,
-    .sv_vm = NULL,
     .resume_point = 0,
     .type = CORO_ASYNC_AWAIT,
-    .owner_entry_fp = owner_vm ? owner_vm->fp : -1,
-    .owner_saved_fp = owner_vm ? owner_vm->fp - 1 : -1,
     .nargs = nargs,
     .refcount = 1,
     .hold_bits = 0,
@@ -177,7 +77,6 @@ static inline void sv_async_init_activation(
     .is_error = false,
     .is_done = false,
     .materialized = false,
-    .mco_started = false,
     .is_ready = false,
     .did_suspend = false,
     .await_registered = false,
@@ -185,157 +84,11 @@ static inline void sv_async_init_activation(
   };
 }
 
-static inline void sv_async_move_open_upvalues(
-  sv_vm_t *source_vm, sv_vm_t *async_vm,
-  ant_value_t *source_base, ant_value_t *dest_base, size_t stack_count
-) {
-  if (!source_vm || !async_vm || !source_base || !dest_base || stack_count == 0) return;
-
-  sv_upvalue_t **src_pp = &source_vm->open_upvalues;
-  sv_upvalue_t **dst_pp = &async_vm->open_upvalues;
-
-  while (*src_pp) {
-    sv_upvalue_t *uv = *src_pp;
-    if (!sv_slot_in_range(source_base, stack_count, uv->location)) {
-      src_pp = &uv->next;
-      continue;
-    }
-
-    ptrdiff_t slot = uv->location - source_base;
-    *src_pp = uv->next;
-    uv->location = &dest_base[slot];
-    uv->next = NULL;
-    *dst_pp = uv;
-    dst_pp = &uv->next;
-  }
-}
-
-static inline sv_vm_t *sv_async_prepare_materialization(
-  sv_vm_t *source_vm, ant_t *js, coroutine_t *coro
-) {
-  if (!source_vm || !js || !coro || coro->sv_vm) return coro ? coro->sv_vm : NULL;
-  if (source_vm->fp < 0) return NULL;
-
-  int entry_fp = source_vm->suspended_entry_fp;
-  if (entry_fp < 0 || entry_fp > source_vm->fp) entry_fp = source_vm->fp;
-
-  sv_frame_t *entry_frame = &source_vm->frames[entry_fp];
-  int frame_count = source_vm->fp - entry_fp + 1;
-  int stack_base = entry_frame->prev_sp;
-  int stack_count = source_vm->sp - stack_base;
-  int handler_base = entry_frame->handler_base;
-  int handler_count = source_vm->handler_depth - handler_base;
-
-  sv_vm_t *async_vm = sv_vm_create(js, SV_VM_ASYNC);
-  if (!async_vm) return NULL;
-  if (stack_count < 0 || stack_count > async_vm->stack_size) {
-    sv_vm_destroy(async_vm);
-    return NULL;
-  }
-  if (frame_count < 1 || frame_count > async_vm->max_frames) {
-    sv_vm_destroy(async_vm);
-    return NULL;
-  }
-  if (handler_count < 0 || handler_count > SV_HANDLER_MAX) {
-    sv_vm_destroy(async_vm);
-    return NULL;
-  }
-
-  if (stack_count > 0) {
-    memcpy(
-      async_vm->stack,
-      &source_vm->stack[stack_base],
-      sizeof(ant_value_t) * (size_t)stack_count
-    );
-  }
-  async_vm->sp = stack_count;
-  async_vm->fp = frame_count - 1;
-
-  for (int i = 0; i < frame_count; i++) {
-    sv_frame_t *src = &source_vm->frames[entry_fp + i];
-    sv_frame_t *dst = &async_vm->frames[i];
-    *dst = *src;
-    
-    dst->prev_sp = src->prev_sp - stack_base;
-    dst->handler_base = (uint16_t)(src->handler_base - handler_base);
-    dst->handler_top = (uint16_t)(src->handler_top - handler_base);
-
-    if (src->bp)
-      dst->bp = async_vm->stack + (src->bp - &source_vm->stack[stack_base]);
-    if (src->lp)
-      dst->lp = async_vm->stack + (src->lp - &source_vm->stack[stack_base]);
-    if (vtype(dst->arguments_obj) != T_UNDEF)
-      js_arguments_rebind_frame(js, dst->arguments_obj, async_vm, i);
-  }
-
-  if (handler_count > 0) {
-    memcpy(
-      async_vm->handler_stack,
-      &source_vm->handler_stack[handler_base],
-      sizeof(sv_handler_t) * (size_t)handler_count
-    );
-  }
-  async_vm->handler_depth = handler_count;
-
-  async_vm->suspended = true;
-  async_vm->suspended_entry_fp = 0;
-  async_vm->suspended_saved_fp = -1;
-  async_vm->suspended_resume_pending = false;
-  async_vm->suspended_resume_is_error = false;
-  async_vm->suspended_resume_kind = SV_RESUME_NEXT;
-  async_vm->suspended_resume_value = js_mkundef();
-
-  return async_vm;
-}
-
-static inline bool sv_async_materialize_activation(
-  sv_vm_t *source_vm, sv_vm_t *async_vm, coroutine_t *coro
-) {
-  if (!source_vm || !async_vm || !coro || source_vm->fp < 0) return false;
-
-  int entry_fp = source_vm->suspended_entry_fp;
-  if (entry_fp < 0 || entry_fp > source_vm->fp) entry_fp = source_vm->fp;
-  sv_frame_t *entry_frame = &source_vm->frames[entry_fp];
-  ant_value_t *source_base = &source_vm->stack[entry_frame->prev_sp];
-  size_t stack_count = (size_t)(source_vm->sp - entry_frame->prev_sp);
-  sv_async_move_open_upvalues(
-    source_vm, async_vm, source_base, async_vm->stack, stack_count
-  );
-
-  coro->owner_entry_fp = source_vm->suspended_entry_fp;
-  coro->owner_saved_fp = source_vm->suspended_saved_fp;
-  coro->sv_vm = async_vm;
-  coro->materialized = true;
-  return true;
-}
-
-static void sv_mco_tla_entry(mco_coro *mco) {
-  sv_tla_ctx_t *ctx = (sv_tla_ctx_t *)mco_get_user_data(mco);
-  ant_t *js = ctx->js;
-  sv_vm_t *vm = ctx->vm;
-  MCO_CORO_STACK_ENTER(js, mco);
-
-  ant_value_t result = sv_execute_entry(vm, ctx->func, ctx->this_val, NULL, 0);
-  ant_value_t promise = ctx->coro->async_promise;
-  if (vm && vm->suspended) return;
-
-  if (is_err(result)) {
-    ant_value_t reject_value = js->thrown_exists ? js->thrown_value : result;
-    js->thrown_exists = false;
-    js->thrown_value = js_mkundef();
-    js_reject_promise(js, promise, reject_value);
-    js_maybe_drain_microtasks_after_async_settle(js);
-  } else {
-    js_resolve_promise(js, promise, result);
-    js_maybe_drain_microtasks_after_async_settle(js);
-  }
-}
-
 static inline ant_value_t sv_capture_tla_module_ctx(ant_t *js, coroutine_t *coro) {
   if (!js || !coro || !js->module || vtype(js->module->module_ns) != T_OBJ)
     return js_mkundef();
 
-  ant_module_t *ctx = CORO_MALLOC(sizeof(ant_module_t));
+  ant_module_t *ctx = calloc(1, sizeof(ant_module_t));
   if (!ctx) return js_mkerr(js, "out of memory for TLA module context");
 
   *ctx = *js->module;
@@ -347,26 +100,20 @@ static inline ant_value_t sv_capture_tla_module_ctx(ant_t *js, coroutine_t *coro
 }
 
 static inline ant_value_t sv_start_tla(ant_t *js, sv_func_t *func, ant_value_t this_val) {
-  if (++coros_this_tick > CORO_PER_TICK_LIMIT) {
-    js->fatal_error = true;
-    return js_mkerr_typed(js, JS_ERR_RANGE | JS_ERR_NO_STACK,
-      "Maximum async operations per tick exceeded");
-  }
-
   ant_value_t promise = js_mkpromise(js);
-  if (func && (!func->has_await || sv_async_func_supports_lazy_start(func))) {
+  if (func) {
     GC_ROOT_SAVE(root_mark, js);
     GC_ROOT_PIN(js, this_val);
     GC_ROOT_PIN(js, promise);
 
-    coroutine_t *coro = (coroutine_t *)CORO_MALLOC(sizeof(coroutine_t));
+    coroutine_t *coro = (coroutine_t *)calloc(1, sizeof(coroutine_t));
     if (!coro) {
       GC_ROOT_RESTORE(js, root_mark);
       return js_mkerr(js, "out of memory for TLA coroutine");
     }
 
     sv_async_init_activation(
-      coro, js, js->vm, promise, this_val,
+      coro, js, promise, this_val,
       js_mkundef(), js_mkundef(), js_mkundef(), 0
     );
 
@@ -385,7 +132,7 @@ static inline ant_value_t sv_start_tla(ant_t *js, sv_func_t *func, ant_value_t t
     );
     sv_async_unlink_activation(js, coro);
 
-    if (coro->sv_vm && coro->sv_vm->suspended) {
+    if (coro->act && coro->act->frame_count > 0) {
       coroutine_release(coro);
       GC_ROOT_RESTORE(js, root_mark);
       return promise;
@@ -405,100 +152,7 @@ static inline ant_value_t sv_start_tla(ant_t *js, sv_func_t *func, ant_value_t t
     return promise;
   }
 
-  sv_tla_ctx_t *ctx = (sv_tla_ctx_t *)CORO_MALLOC(sizeof(sv_tla_ctx_t));
-  if (!ctx) return js_mkerr(js, "out of memory for TLA context");
-
-  sv_vm_t *async_vm = sv_vm_create(js, SV_VM_ASYNC);
-  if (!async_vm) { CORO_FREE(ctx); return js_mkerr(js, "out of memory for TLA VM"); }
-
-  ctx->js = js;
-  ctx->func = func;
-  ctx->this_val = this_val;
-  ctx->coro = NULL;
-  ctx->vm = async_vm;
-
-  size_t stack_size = 0;
-  const char *env_stack = getenv("ANT_CORO_STACK_SIZE");
-  if (env_stack) {
-    size_t sz = (size_t)atoi(env_stack) * 1024;
-    if (sz >= 32 * 1024 && sz <= 8 * 1024 * 1024) stack_size = sz;
-  }
-
-  mco_desc desc = mco_desc_init(sv_mco_tla_entry, stack_size);
-  desc.user_data = ctx;
-
-  mco_coro *mco = NULL;
-  mco_result res = mco_create(&mco, &desc);
-  if (res != MCO_SUCCESS) {
-    sv_vm_destroy(async_vm); CORO_FREE(ctx);
-    return js_mkerr(js, "failed to create TLA coroutine");
-  }
-
-  coroutine_t *coro = (coroutine_t *)CORO_MALLOC(sizeof(coroutine_t));
-  if (!coro) {
-    mco_destroy(mco);
-    sv_vm_destroy(async_vm); CORO_FREE(ctx);
-    return js_mkerr(js, "out of memory for TLA coroutine");
-  }
-
-  *coro = (coroutine_t){
-    .js = js,
-    .type = CORO_ASYNC_AWAIT,
-    .this_val = this_val,
-    .super_val = js_mkundef(),
-    .new_target = js_mkundef(),
-    .awaited_promise = js_mkundef(),
-    .result = js_mkundef(),
-    .async_func = js_mkundef(),
-    .args = NULL,
-    .nargs = 0,
-    .active_parent = NULL,
-    .is_settled = false,
-    .is_error = false,
-    .is_done = false,
-    .resume_point = 0,
-    .yield_value = js_mkundef(),
-    .async_promise = promise,
-    .next = NULL,
-    .mco = mco,
-    .owner_vm = async_vm,
-    .sv_vm = async_vm,
-    .mco_started = false,
-    .is_ready = true,
-    .did_suspend = false,
-    .refcount = 1,
-    .hold_bits = 0,
-    .await_registered = false,
-    .destroy_requested = false,
-  };
-
-  ant_value_t module_res = sv_capture_tla_module_ctx(js, coro);
-  if (is_err(module_res)) {
-    coroutine_release(coro);
-    return module_res;
-  }
-
-  ctx->coro = coro;
-  enqueue_coroutine(coro);
-  
-  sv_async_link_activation(js, coro);
-  MCO_RESUME_SAVE(js, mco, res);
-  sv_async_unlink_activation(js, coro);
-
-  if (res != MCO_SUCCESS && mco_status(mco) != MCO_DEAD) {
-    remove_coroutine(coro);
-    coroutine_release(coro);
-    return js_mkerr(js, "failed to start TLA coroutine");
-  }
-
-  coro->mco_started = true;
-  if (mco_status(mco) == MCO_DEAD) {
-    remove_coroutine(coro);
-  }
-
-  coroutine_release(coro);
-
-  return promise;
+  return js_mkerr(js, "top-level await module cannot start");
 }
 
 static inline ant_value_t sv_start_async_closure(
@@ -506,12 +160,6 @@ static inline ant_value_t sv_start_async_closure(
   sv_closure_t *closure, ant_value_t callee_func, ant_value_t super_val,
   ant_value_t this_val, ant_value_t *args, int argc
 ) {
-  if (++coros_this_tick > CORO_PER_TICK_LIMIT) {
-    js->fatal_error = true;
-    return js_mkerr_typed(js, JS_ERR_RANGE | JS_ERR_NO_STACK,
-      "Maximum async operations per tick exceeded");
-  }
-
   if (caller_vm && closure && closure->func && !closure->func->has_await) {
     GC_ROOT_SAVE(root_mark, js);
     GC_ROOT_PIN(js, callee_func);
@@ -540,43 +188,42 @@ static inline ant_value_t sv_start_async_closure(
     return promise;
   }
 
-  if (closure && closure->func && sv_async_func_supports_lazy_start(closure->func)) {
+  if (caller_vm && closure && closure->func) {
     GC_ROOT_SAVE(root_mark, js);
     GC_ROOT_PIN(js, callee_func);
     GC_ROOT_PIN(js, super_val);
     GC_ROOT_PIN(js, this_val);
     
-    if (args) {
+    if (args)
       for (int i = 0; i < argc; i++) GC_ROOT_PIN(js, args[i]);
-    }
     
     ant_value_t promise = js_mkpromise(js);
     GC_ROOT_PIN(js, promise);
-    coroutine_t *coro = (coroutine_t *)CORO_MALLOC(sizeof(coroutine_t));
+    
+    coroutine_t *coro = (coroutine_t *)calloc(1, sizeof(coroutine_t));
     if (!coro) {
       GC_ROOT_RESTORE(js, root_mark);
       return js_mkerr(js, "out of memory for async coroutine");
     }
 
     sv_async_init_activation(
-      coro, js, caller_vm, promise, this_val,
+      coro, js, promise, this_val,
       super_val, js->new_target, callee_func, argc
     );
+  
     sv_async_link_activation(js, coro);
-    
     ant_value_t result = sv_execute_closure_entry(
       caller_vm, closure, callee_func, 
       super_val, this_val, args, argc, NULL
     );
-
     sv_async_unlink_activation(js, coro);
-
-    if (coro->sv_vm && coro->sv_vm->suspended) {
+  
+    if (coro->act && coro->act->frame_count > 0) {
       coroutine_release(coro);
       GC_ROOT_RESTORE(js, root_mark);
       return promise;
     }
-    
+  
     if (is_err(result)) {
       ant_value_t reject_value = js->thrown_exists ? js->thrown_value : result;
       js->thrown_exists = false;
@@ -587,119 +234,17 @@ static inline ant_value_t sv_start_async_closure(
     }
     coroutine_release(coro);
     GC_ROOT_RESTORE(js, root_mark);
-    
+  
     return promise;
   }
 
-  ant_value_t promise = js_mkpromise(js);
-  sv_async_ctx_t *ctx = (sv_async_ctx_t *)CORO_MALLOC(sizeof(sv_async_ctx_t));
-  if (!ctx) return js_mkerr(js, "out of memory for async context");
-
-  sv_vm_t *async_vm = sv_vm_create(js, SV_VM_ASYNC);
-  if (!async_vm) { CORO_FREE(ctx); return js_mkerr(js, "out of memory for async VM"); }
-
-  ctx->js = js;
-  ctx->closure = closure;
-  ctx->callee_func = callee_func;
-  ctx->super_val = super_val;
-  ctx->this_val = this_val;
-  ctx->args = NULL;
-  ctx->argc = argc;
-  ctx->coro = NULL;
-  ctx->vm = async_vm;
-
-  if (argc > 0 && args) {
-    ctx->args = (ant_value_t *)CORO_MALLOC(sizeof(ant_value_t) * (size_t)argc);
-    if (!ctx->args) {
-      sv_vm_destroy(async_vm); CORO_FREE(ctx);
-      return js_mkerr(js, "out of memory for async args");
-    }
-    memcpy(ctx->args, args, sizeof(ant_value_t) * (size_t)argc);
-  }
-
-  size_t stack_size = 0;
-  const char *env_stack = getenv("ANT_CORO_STACK_SIZE");
-  if (env_stack) {
-    size_t sz = (size_t)atoi(env_stack) * 1024;
-    if (sz >= 32 * 1024 && sz <= 8 * 1024 * 1024) stack_size = sz;
-  }
-
-  mco_desc desc = mco_desc_init(sv_mco_async_entry, stack_size);
-  desc.user_data = ctx;
-
-  mco_coro *mco = NULL;
-  mco_result res = mco_create(&mco, &desc);
-  if (res != MCO_SUCCESS) {
-    if (ctx->args) CORO_FREE(ctx->args);
-    sv_vm_destroy(async_vm); CORO_FREE(ctx);
-    return js_mkerr(js, "failed to create async coroutine");
-  }
-
-  coroutine_t *coro = (coroutine_t *)CORO_MALLOC(sizeof(coroutine_t));
-  if (!coro) {
-    mco_destroy(mco);
-    if (ctx->args) CORO_FREE(ctx->args);
-    sv_vm_destroy(async_vm); CORO_FREE(ctx);
-    return js_mkerr(js, "out of memory for coroutine");
-  }
-
-  *coro = (coroutine_t){
-    .js = js,
-    .type = CORO_ASYNC_AWAIT,
-    .this_val = this_val,
-    .super_val = super_val,
-    .new_target = js->new_target,
-    .awaited_promise = js_mkundef(),
-    .result = js_mkundef(),
-    .async_func = callee_func,
-    .args = ctx->args,
-    .nargs = argc,
-    .active_parent = NULL,
-    .is_settled = false,
-    .is_error = false,
-    .is_done = false,
-    .resume_point = 0,
-    .yield_value = js_mkundef(),
-    .async_promise = promise,
-    .next = NULL,
-    .mco = mco,
-    .owner_vm = async_vm,
-    .sv_vm = async_vm,
-    .mco_started = false,
-    .is_ready = true,
-    .did_suspend = false,
-    .refcount = 1,
-    .hold_bits = 0,
-    .await_registered = false,
-    .destroy_requested = false,
-  };
-
-  ctx->coro = coro;
-  enqueue_coroutine(coro);
-  MCO_RESUME_SAVE(js, mco, res);
-  mco_state start_status = mco_status(mco);
-
-  if (res != MCO_SUCCESS && start_status != MCO_DEAD) {
-    remove_coroutine(coro);
-    coroutine_release(coro);
-    return js_mkerr(js, "failed to start async coroutine");
-  }
-
-  coro->mco_started = true;
-  if (start_status == MCO_DEAD) {
-    remove_coroutine(coro);
-  }
-
-  coroutine_release(coro);
-
-  return promise;
+  return js_mkerr(js, "async function cannot start (unsupported form)");
 }
 
 static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value_t value) {
   sv_await_result_t out = {
     .state = SV_AWAIT_READY,
     .value = js_mkundef(),
-    .handoff = false,
   };
 
   value = js_promise_assimilate_awaitable(js, value);
@@ -713,16 +258,7 @@ static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value
     return out;
   }
 
-  mco_coro *current_mco = mco_running();
-  coroutine_t *coro = NULL;
-  
-  if (current_mco) {
-    sv_coro_header_t *hdr = (sv_coro_header_t *)mco_get_user_data(current_mco);
-    coroutine_t *mco_coro = hdr ? hdr->coro : NULL;
-    if (mco_coro && (!vm || sv_async_coro_matches_vm(mco_coro, vm))) coro = mco_coro;
-  }
-  
-  if (!coro) coro = sv_async_get_active_coro_for_vm(js, vm);
+  coroutine_t *coro = sv_async_active_coro(js);
   if (!coro) coro = generator_get_coro_for_vm(js, vm);
 
   if (!coro) {
@@ -731,29 +267,11 @@ static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value
     return out;
   }
 
-  bool on_own_mco = current_mco && coro->mco == current_mco;
-  sv_vm_t *prepared_vm = NULL; bool handoff = false;
-  
-  if (!on_own_mco && vm && coro->owner_vm == vm && !coro->sv_vm) {
-    prepared_vm = sv_async_prepare_materialization(vm, js, coro);
-    if (!prepared_vm) {
-      out.state = SV_AWAIT_ERROR;
-      out.value = js_mkerr(js, "out of memory for async VM");
-      return out;
-    }
-    handoff = true;
-  }
-
   coro->is_settled = false;
   coro->is_ready = false;
   js_await_result_t await_result = js_promise_await_coroutine(js, value, coro);
 
   if (await_result.state == JS_AWAIT_ERROR) {
-    if (prepared_vm) {
-      sv_vm_destroy(prepared_vm);
-      coro->sv_vm = NULL;
-      coro->materialized = false;
-    }
     coro->is_settled = false;
     out.state = SV_AWAIT_ERROR;
     out.value = js_throw(js, await_result.value);
@@ -761,44 +279,19 @@ static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value
   }
 
   coro->did_suspend = true;
-  if (!on_own_mco) {
-    if (prepared_vm) if (!sv_async_materialize_activation(vm, prepared_vm, coro)) {
-      coroutine_clear_await_registration(coro);
-      sv_vm_destroy(prepared_vm);
-      out.state = SV_AWAIT_ERROR;
-      out.value = js_mkerr(js, "failed to materialize async activation");
-      return out;
-    }
-    
-    out.state = SV_AWAIT_SUSPENDED;
-    out.handoff = handoff;
-    
-    if (handoff) coro->sv_vm->suspended = true;
-    else if (coro->sv_vm) coro->sv_vm->suspended = true;
-    
-    return out;
-  }
-  
-  mco_result mco_res = mco_yield(current_mco);
-  if (mco_res != MCO_SUCCESS) {
+
+  sv_activation_t *act = sv_activation_capture(vm, vm->suspended_entry_fp, coro->act);
+  if (!act) {
+    coroutine_clear_await_registration(coro);
     out.state = SV_AWAIT_ERROR;
-    out.value = js_mkerr(js, "failed to yield coroutine");
+    out.value = js_mkerr(js, "out of memory capturing async activation");
     return out;
   }
 
-  MCO_CORO_STACK_ENTER(js, current_mco);
-  out.value = coro->result;
-  bool is_error = coro->is_error;
-  
-  coro->is_settled = false;
-  coro->awaited_promise = js_mkundef();
-  if (is_error) {
-    out.state = SV_AWAIT_ERROR;
-    out.value = js_throw(js, out.value);
-    return out;
-  }
+  coro->act = act;
+  coro->materialized = true;
 
-  out.state = SV_AWAIT_READY;
+  out.state = SV_AWAIT_SUSPENDED;
   return out;
 }
 

--- a/src/silver/ops/async.h
+++ b/src/silver/ops/async.h
@@ -261,7 +261,15 @@ static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value
     return out;
   }
 
-  sv_activation_t *act = sv_activation_capture(vm, vm->suspended_entry_fp, coro->act);
+  int entry_fp = vm->suspended_entry_fp;
+  if (entry_fp < 0 || entry_fp > vm->fp) {
+    coroutine_clear_await_registration(coro);
+    out.state = SV_AWAIT_ERROR;
+    out.value = js_mkerr(js, "await suspended without a valid entry frame");
+    return out;
+  }
+
+  sv_activation_t *act = sv_activation_capture(vm, entry_fp, coro->act);
   if (!act) {
     coroutine_clear_await_registration(coro);
     out.state = SV_AWAIT_ERROR;

--- a/src/silver/ops/async.h
+++ b/src/silver/ops/async.h
@@ -60,26 +60,18 @@ static inline void sv_async_init_activation(
     .new_target = new_target,
     .result = js_mkundef(),
     .async_func = async_func,
-    .yield_value = js_mkundef(),
+    .owner_gen = js_mkundef(),
     .args = NULL,
     .awaited_promise = js_mkundef(),
     .async_promise = promise,
     .active_parent = NULL,
-    .prev = NULL,
     .next = NULL,
-    .resume_point = 0,
     .type = CORO_ASYNC_AWAIT,
     .nargs = nargs,
     .refcount = 1,
     .hold_bits = 0,
-    .is_settled = false,
     .is_error = false,
-    .is_done = false,
-    .materialized = false,
-    .is_ready = false,
-    .did_suspend = false,
     .await_registered = false,
-    .destroy_requested = false,
   };
 }
 
@@ -228,9 +220,8 @@ static inline ant_value_t sv_start_async_closure(
       js->thrown_exists = false;
       js->thrown_value = js_mkundef();
       js_reject_promise(js, promise, reject_value);
-    } else {
-      js_resolve_promise(js, promise, result);
-    }
+    } else js_resolve_promise(js, promise, result);
+
     coroutine_release(coro);
     GC_ROOT_RESTORE(js, root_mark);
   
@@ -264,18 +255,12 @@ static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value
     return out;
   }
 
-  coro->is_settled = false;
-  coro->is_ready = false;
   js_await_result_t await_result = js_promise_await_coroutine(js, value, coro);
-
   if (await_result.state == JS_AWAIT_ERROR) {
-    coro->is_settled = false;
     out.state = SV_AWAIT_ERROR;
     out.value = js_throw(js, await_result.value);
     return out;
   }
-
-  coro->did_suspend = true;
 
   sv_activation_t *act = sv_activation_capture(vm, vm->suspended_entry_fp, coro->act);
   if (!act) {
@@ -286,9 +271,8 @@ static inline sv_await_result_t sv_await_value(sv_vm_t *vm, ant_t *js, ant_value
   }
 
   coro->act = act;
-  coro->materialized = true;
-
   out.state = SV_AWAIT_SUSPENDED;
+  
   return out;
 }
 

--- a/src/silver/ops/async.h
+++ b/src/silver/ops/async.h
@@ -65,7 +65,6 @@ static inline void sv_async_init_activation(
     .awaited_promise = js_mkundef(),
     .async_promise = promise,
     .active_parent = NULL,
-    .next = NULL,
     .type = CORO_ASYNC_AWAIT,
     .nargs = nargs,
     .refcount = 1,

--- a/src/silver/ops/iteration.h
+++ b/src/silver/ops/iteration.h
@@ -386,8 +386,20 @@ static inline sv_await_result_t sv_op_await_iter_next(sv_vm_t *vm, ant_t *js) {
   sv_await_result_t out = {
     .state = SV_AWAIT_READY,
     .value = js_mkundef(),
-    .handoff = false,
   };
+
+  bool has_resumed_value = vm->sp >= 5 &&
+    vtype(vm->stack[vm->sp - 2]) == T_BOOL &&
+    vtype(vm->stack[vm->sp - 3]) == T_NUM &&
+    (int)js_getnum(vm->stack[vm->sp - 3]) == SV_ITER_GENERIC;
+
+  if (has_resumed_value) {
+    ant_value_t value = vm->stack[--vm->sp];
+    ant_value_t done = vm->stack[--vm->sp];
+    vm->stack[vm->sp++] = value;
+    vm->stack[vm->sp++] = done;
+    return out;
+  }
 
   ant_value_t result = js_mkundef();
   bool has_resumed_result = vm->sp >= 4 &&
@@ -398,44 +410,66 @@ static inline sv_await_result_t sv_op_await_iter_next(sv_vm_t *vm, ant_t *js) {
   else {
     ant_value_t next_method = vm->stack[vm->sp - 2];
     ant_value_t iterator = vm->stack[vm->sp - 3];
-    if (!is_callable(next_method))
-      return (sv_await_result_t){ .state = SV_AWAIT_ERROR, .value = js_mkerr(js, "iterator.next is not a function"), .handoff = false };
-    result = sv_vm_call(vm, js, next_method, iterator, NULL, 0, NULL, false);
-    if (is_err(result))
-      return (sv_await_result_t){ .state = SV_AWAIT_ERROR, .value = result, .handoff = false };
+    if (!is_callable(next_method)) return (sv_await_result_t){ 
+      .state = SV_AWAIT_ERROR,
+      .value = js_mkerr(js, "iterator.next is not a function") 
+    };
+    
+    result = sv_vm_call(
+      vm, js,
+      next_method, iterator,
+      NULL, 0, NULL, false
+    );
+    
+    if (is_err(result)) return (sv_await_result_t){ 
+      .state = SV_AWAIT_ERROR,
+      .value = result 
+    };
   }
 
   if (!has_resumed_result && vtype(result) == T_PROMISE) {
     vm->suspended_entry_fp = vm->fp;
     vm->suspended_saved_fp = vm->fp - 1;
+    
     sv_await_result_t awaited = sv_await_value(vm, js, result);
-    if (awaited.state != SV_AWAIT_SUSPENDED || awaited.handoff) {
-      vm->suspended_entry_fp = -1;
-      vm->suspended_saved_fp = -1;
-    }
+    vm->suspended_entry_fp = -1;
+    vm->suspended_saved_fp = -1;
+    
     if (awaited.state != SV_AWAIT_READY) return awaited;
     result = awaited.value;
   }
+  
   ant_value_t done = js_mkundef();
   ant_value_t value = js_mkundef();
   sv_iter_result_unpack(js, result, &done, &value);
-  if (is_err(done))
-    return (sv_await_result_t){ .state = SV_AWAIT_ERROR, .value = done, .handoff = false };
-  if (is_err(value))
-    return (sv_await_result_t){ .state = SV_AWAIT_ERROR, .value = value, .handoff = false };
+  
+  if (is_err(done)) return (sv_await_result_t){ 
+    .state = SV_AWAIT_ERROR,
+    .value = done
+  };
+  
+  if (is_err(value)) return (sv_await_result_t){
+    .state = SV_AWAIT_ERROR,
+    .value = value
+  };
+  
   if (vtype(value) == T_PROMISE) {
+    vm->stack[vm->sp++] = mkval(T_BOOL, js_truthy(js, done));
     vm->suspended_entry_fp = vm->fp;
     vm->suspended_saved_fp = vm->fp - 1;
+    
     sv_await_result_t awaited_val = sv_await_value(vm, js, value);
-    if (awaited_val.state != SV_AWAIT_SUSPENDED || awaited_val.handoff) {
-      vm->suspended_entry_fp = -1;
-      vm->suspended_saved_fp = -1;
-    }
+    vm->suspended_entry_fp = -1;
+    vm->suspended_saved_fp = -1;
+    
     if (awaited_val.state != SV_AWAIT_READY) return awaited_val;
+    vm->sp--;
     value = awaited_val.value;
   }
+  
   vm->stack[vm->sp++] = value;
   vm->stack[vm->sp++] = mkval(T_BOOL, js_truthy(js, done));
+  
   return out;
 }
 

--- a/src/sugar.c
+++ b/src/sugar.c
@@ -5,15 +5,7 @@
 #include "modules/timer.h"
 #include "silver/engine.h"
 
-#define MCO_USE_VMEM_ALLOCATOR
-#define MCO_ZERO_MEMORY
-#define MCO_DEFAULT_STACK_SIZE (1024 * 1024)
-#define MINICORO_IMPL
-#include <minicoro.h>
-
-uint32_t coros_this_tick = 0;
 coroutine_queue_t pending_coroutines = {NULL, NULL};
-
 static bool coro_stack_size_initialized = false;
 static coroutine_t *retired_coroutines = NULL;
 
@@ -69,30 +61,22 @@ static void retire_coroutine_storage(coroutine_t *coro) {
 static void destroy_coroutine_resources(coroutine_t *coro) {
   if (!coro) return;
 
-  if (coro->mco) {
-    void *ctx = mco_get_user_data(coro->mco);
-    if (ctx) CORO_FREE(ctx);
-    mco_destroy(coro->mco);
-    coro->mco = NULL;
-  }
-
   if (coro->args) {
-    CORO_FREE(coro->args);
+    free(coro->args);
     coro->args = NULL;
   }
 
-  if (coro->sv_vm) {
-    sv_vm_destroy(coro->sv_vm);
-    coro->sv_vm = NULL;
+  if (coro->act) {
+    free(coro->act);
+    coro->act = NULL;
   }
 
   if (coro->module_eval_ctx) {
-    CORO_FREE(coro->module_eval_ctx);
+    free(coro->module_eval_ctx);
     coro->module_eval_ctx = NULL;
   }
 
   coro->js = NULL;
-  coro->owner_vm = NULL;
   coro->active_parent = NULL;
   coro->materialized = false;
 }
@@ -109,7 +93,7 @@ static void coroutine_release_storage(coroutine_t *coro) {
   if (js && js->vm_exec_depth > 0) retire_coroutine_storage(coro);
   else {
     destroy_coroutine_resources(coro);
-    CORO_FREE(coro);
+    free(coro);
   }
 }
 
@@ -139,7 +123,7 @@ void reap_retired_coroutines(void) {
   while (coro) {
     coroutine_t *next = coro->next;
     destroy_coroutine_resources(coro);
-    CORO_FREE(coro);
+    free(coro);
     coro = next;
   }
 }
@@ -216,66 +200,66 @@ static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
   if (!coro) return;
   coroutine_retain(coro);
 
-  if (!coro->mco) {
-    if (!coro->sv_vm || !coro->sv_vm->suspended) {
-      coroutine_release(coro);
-      return;
-    }
-    
+  if (coro->act && coro->act->frame_count > 0) {
+    sv_vm_t *vm = sv_vm_get_active(js);
     coro->is_ready = false;
-    coro->sv_vm->suspended_resume_value = coro->result;
-    coro->sv_vm->suspended_resume_is_error = coro->is_error;
-    coro->sv_vm->suspended_resume_kind = coro->is_error ? SV_RESUME_THROW : SV_RESUME_NEXT;
-    coro->sv_vm->suspended_resume_pending = true;
-    
     coroutine_activate(js, coro);
-    ant_value_t result = sv_resume_suspended(coro->sv_vm);
-    
+
+    ant_value_t result;
+    if (!sv_activation_install(vm, coro->act)) 
+      result = js_mkerr(js, "failed to install async activation");
+    else {
+      vm->suspended_resume_value = coro->result;
+      vm->suspended_resume_is_error = coro->is_error;
+      vm->suspended_resume_kind = coro->is_error ? SV_RESUME_THROW : SV_RESUME_NEXT;
+      vm->suspended_resume_pending = true;
+      result = sv_resume_suspended(vm);
+    }
+
     coro->is_settled = false;
-    if (coro->sv_vm->suspended) {
-      coroutine_deactivate(js, coro);
+
+    if (vm->suspended && vm->suspended_entry_fp >= 0) {
+    sv_activation_t *act = sv_activation_capture(vm, vm->suspended_entry_fp, coro->act);
+    
+    if (act) coro->act = act;
+    else {
+      int efp = vm->suspended_entry_fp;
+      vm->fp = efp - 1;
+      vm->sp = vm->frames[efp].prev_sp;
+      vm->handler_depth = vm->frames[efp].handler_base;
+      vm->suspended = false;
+      vm->suspended_resume_pending = false;
+      vm->suspended_entry_fp = -1;
+      vm->suspended_saved_fp = -1;
+      result = js_mkerr(js, "out of memory capturing activation");
+    }}
+
+    bool suspended_again = coro->act && coro->act->frame_count > 0;
+    coroutine_deactivate(js, coro);
+
+    if (suspended_again) {
       if (generator_resume_pending_request(js, coro, result)) return;
       coroutine_release(coro);
       return;
     }
-    
-    coroutine_deactivate(js, coro);
-    
+
     if (generator_resume_pending_request(js, coro, result)) {
       coroutine_release(coro);
       return;
     }
-    
+
     if (is_err(result)) {
       ant_value_t reject_value = js->thrown_exists ? js->thrown_value : result;
       js->thrown_exists = false;
       js->thrown_value = js_mkundef();
       js_reject_promise(js, coro->async_promise, reject_value);
     } else js_resolve_promise(js, coro->async_promise, result);
-    
+
     js_maybe_drain_microtasks_after_async_settle(js);
     coroutine_release(coro);
     
     return;
   }
-
-  if (mco_status(coro->mco) != MCO_SUSPENDED) {
-    coroutine_release(coro);
-    return;
-  }
-
-  coro->is_ready = false;
-  mco_result res;
-  
-  bool activate_for_module = coroutine_has_module_eval_ctx(coro);
-  if (activate_for_module) coroutine_activate(js, coro);
-  MCO_RESUME_SAVE(js, coro->mco, res);
-  
-  if (activate_for_module) coroutine_deactivate(js, coro);
-  mco_state status = mco_status(coro->mco);
-
-  if (res != MCO_SUCCESS || status == MCO_DEAD)
-    remove_coroutine(coro);
 
   coroutine_release(coro);
 }

--- a/src/sugar.c
+++ b/src/sugar.c
@@ -129,6 +129,25 @@ static inline void settle_coroutine(coroutine_t *coro, ant_value_t *args, int na
   coro->is_error = is_error;
 }
 
+static ant_value_t coroutine_resume_and_recapture(ant_t *js, sv_vm_t *vm, coroutine_t *coro) {
+  vm->suspended_resume_value = coro->result;
+  vm->suspended_resume_is_error = coro->is_error;
+  vm->suspended_resume_kind = coro->is_error ? SV_RESUME_THROW : SV_RESUME_NEXT;
+  vm->suspended_resume_pending = true;
+
+  ant_value_t result = sv_resume_suspended(vm);
+  if (!vm->suspended || vm->suspended_entry_fp < 0) return result;
+
+  sv_activation_t *act = sv_activation_capture(vm, vm->suspended_entry_fp, coro->act);
+  if (act) {
+    coro->act = act;
+    return result;
+  }
+
+  sv_activation_discard(vm, vm->suspended_entry_fp);
+  return js_mkerr(js, "out of memory capturing activation");
+}
+
 static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
   if (!coro) return;
   coroutine_retain(coro);
@@ -142,22 +161,7 @@ static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
       sv_activation_seal(js, coro->act);
       coro->act->frame_count = 0;
       result = js_mkerr(js, "failed to install async activation");
-    } else {
-      vm->suspended_resume_value = coro->result;
-      vm->suspended_resume_is_error = coro->is_error;
-      vm->suspended_resume_kind = coro->is_error ? SV_RESUME_THROW : SV_RESUME_NEXT;
-      vm->suspended_resume_pending = true;
-      result = sv_resume_suspended(vm);
-    }
-
-    if (vm->suspended && vm->suspended_entry_fp >= 0) {
-    sv_activation_t *act = sv_activation_capture(vm, vm->suspended_entry_fp, coro->act);
-    
-    if (act) coro->act = act;
-    else {
-      sv_activation_discard(vm, vm->suspended_entry_fp);
-      result = js_mkerr(js, "out of memory capturing activation");
-    }}
+    } else result = coroutine_resume_and_recapture(js, vm, coro);
 
     bool suspended_again = coro->act && coro->act->frame_count > 0;
     coroutine_deactivate(js, coro);

--- a/src/sugar.c
+++ b/src/sugar.c
@@ -170,7 +170,7 @@ static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
     coroutine_deactivate(js, coro);
 
     if (suspended_again) {
-      if (generator_resume_pending_request(js, coro, result)) return;
+      generator_resume_pending_request(js, coro, result);
       coroutine_release(coro);
       return;
     }

--- a/src/sugar.c
+++ b/src/sugar.c
@@ -5,56 +5,11 @@
 #include "modules/timer.h"
 #include "silver/engine.h"
 
-coroutine_queue_t pending_coroutines = {NULL, NULL};
-static bool coro_stack_size_initialized = false;
 static coroutine_t *retired_coroutines = NULL;
-
-bool has_pending_coroutines(void) {
-  return pending_coroutines.head != NULL;
-}
-
-bool has_ready_coroutines(void) {
-  coroutine_t *temp = pending_coroutines.head;
-  while (temp) {
-    if (temp->is_ready) return true;
-    temp = temp->next;
-  }
-  return false;
-}
-
-void enqueue_coroutine(coroutine_t *coro) {
-  if (!coro) return;
-  if (coro->hold_bits & CORO_HOLD_PENDING) return;
-  coro->next = NULL;
-  coro->prev = pending_coroutines.tail;
-  
-  if (pending_coroutines.tail) {
-    pending_coroutines.tail->next = coro;
-  } else pending_coroutines.head = coro;
-  pending_coroutines.tail = coro;
-  coroutine_hold(coro, CORO_HOLD_PENDING);
-}
-
-void remove_coroutine(coroutine_t *coro) {
-  if (!coro || !(coro->hold_bits & CORO_HOLD_PENDING)) return;
-  
-  if (coro->prev) {
-    coro->prev->next = coro->next;
-  } else pending_coroutines.head = coro->next;
-  
-  if (coro->next) {
-    coro->next->prev = coro->prev;
-  } else pending_coroutines.tail = coro->prev;
-  
-  coro->prev = NULL;
-  coro->next = NULL;
-  coroutine_unhold(coro, CORO_HOLD_PENDING);
-}
 
 static void retire_coroutine_storage(coroutine_t *coro) {
   if (!coro) return;
   coro->next = retired_coroutines;
-  coro->prev = NULL;
   retired_coroutines = coro;
 }
 
@@ -79,7 +34,6 @@ static void destroy_coroutine_resources(coroutine_t *coro) {
 
   coro->js = NULL;
   coro->active_parent = NULL;
-  coro->materialized = false;
 }
 
 void coroutine_retain(coroutine_t *coro) {
@@ -170,31 +124,9 @@ static void coroutine_deactivate(ant_t *js, coroutine_t *coro) {
   coroutine_unhold(coro, CORO_HOLD_ACTIVE);
 }
 
-static bool coroutine_has_module_eval_ctx(coroutine_t *coro) {
-  return coro && coro->module_eval_ctx;
-}
-
-static size_t calculate_coro_stack_size(void) {
-  static size_t cached_size = 0;
-  if (coro_stack_size_initialized) return cached_size;
-  
-  coro_stack_size_initialized = true;
-  const char *env_stack = getenv("ANT_CORO_STACK_SIZE");
-  
-  if (env_stack) {
-  size_t size = (size_t)atoi(env_stack) * 1024;
-  if (size >= 32 * 1024 && size <= 8 * 1024 * 1024) { 
-    cached_size = size; return cached_size; 
-  }}
-  
-  return cached_size;
-}
-
 static inline void settle_coroutine(coroutine_t *coro, ant_value_t *args, int nargs, bool is_error) {
   coro->result = nargs > 0 ? args[0] : js_mkundef();
-  coro->is_settled = true;
   coro->is_error = is_error;
-  coro->is_ready = true;
 }
 
 static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
@@ -203,7 +135,6 @@ static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
 
   if (coro->act && coro->act->frame_count > 0) {
     sv_vm_t *vm = sv_vm_get_active(js);
-    coro->is_ready = false;
     coroutine_activate(js, coro);
 
     ant_value_t result;
@@ -218,8 +149,6 @@ static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
       vm->suspended_resume_pending = true;
       result = sv_resume_suspended(vm);
     }
-
-    coro->is_settled = false;
 
     if (vm->suspended && vm->suspended_entry_fp >= 0) {
     sv_activation_t *act = sv_activation_capture(vm, vm->suspended_entry_fp, coro->act);

--- a/src/sugar.c
+++ b/src/sugar.c
@@ -67,6 +67,7 @@ static void destroy_coroutine_resources(coroutine_t *coro) {
   }
 
   if (coro->act) {
+    sv_activation_seal(coro->js, coro->act);
     free(coro->act);
     coro->act = NULL;
   }
@@ -206,9 +207,11 @@ static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
     coroutine_activate(js, coro);
 
     ant_value_t result;
-    if (!sv_activation_install(vm, coro->act)) 
+    if (!sv_activation_install(vm, coro->act)) {
+      sv_activation_seal(js, coro->act);
+      coro->act->frame_count = 0;
       result = js_mkerr(js, "failed to install async activation");
-    else {
+    } else {
       vm->suspended_resume_value = coro->result;
       vm->suspended_resume_is_error = coro->is_error;
       vm->suspended_resume_kind = coro->is_error ? SV_RESUME_THROW : SV_RESUME_NEXT;

--- a/src/sugar.c
+++ b/src/sugar.c
@@ -5,12 +5,10 @@
 #include "modules/timer.h"
 #include "silver/engine.h"
 
-static coroutine_t *retired_coroutines = NULL;
-
 static void retire_coroutine_storage(coroutine_t *coro) {
-  if (!coro) return;
-  coro->next = retired_coroutines;
-  retired_coroutines = coro;
+  if (!coro || !coro->js) return;
+  coro->retired_next = coro->js->retired_coroutines;
+  coro->js->retired_coroutines = coro;
 }
 
 static void destroy_coroutine_resources(coroutine_t *coro) {
@@ -71,12 +69,14 @@ void coroutine_unhold(coroutine_t *coro, uint8_t hold) {
   coroutine_release(coro);
 }
 
-void reap_retired_coroutines(void) {
-  coroutine_t *coro = retired_coroutines;
-  retired_coroutines = NULL;
-  
+void reap_retired_coroutines(ant_t *js) {
+  if (!js) return;
+
+  coroutine_t *coro = js->retired_coroutines;
+  js->retired_coroutines = NULL;
+
   while (coro) {
-    coroutine_t *next = coro->next;
+    coroutine_t *next = coro->retired_next;
     destroy_coroutine_resources(coro);
     free(coro);
     coro = next;

--- a/src/sugar.c
+++ b/src/sugar.c
@@ -155,14 +155,7 @@ static void resume_coroutine_if_suspended(ant_t *js, coroutine_t *coro) {
     
     if (act) coro->act = act;
     else {
-      int efp = vm->suspended_entry_fp;
-      vm->fp = efp - 1;
-      vm->sp = vm->frames[efp].prev_sp;
-      vm->handler_depth = vm->frames[efp].handler_base;
-      vm->suspended = false;
-      vm->suspended_resume_pending = false;
-      vm->suspended_entry_fp = -1;
-      vm->suspended_saved_fp = -1;
+      sv_activation_discard(vm, vm->suspended_entry_fp);
       result = js_mkerr(js, "out of memory capturing activation");
     }}
 

--- a/tests/bench_churn.js
+++ b/tests/bench_churn.js
@@ -1,0 +1,30 @@
+async function step(n) {
+  let acc = 0;
+  for (let i = 0; i < n; i++) acc += await Promise.resolve(i);
+  return acc;
+}
+
+async function asyncChurn() {
+  const t0 = performance.now();
+  let total = 0;
+  for (let r = 0; r < 300; r++) {
+    const batch = [];
+    for (let i = 0; i < 100; i++) batch.push(step(10));
+    total += (await Promise.all(batch)).reduce((a, b) => a + b, 0);
+  }
+  console.log('async-churn:', (performance.now() - t0).toFixed(1) + 'ms', total);
+}
+
+function* gen(n) {
+  for (let i = 0; i < n; i++) yield i;
+}
+
+function genChurn() {
+  const t0 = performance.now();
+  let total = 0;
+  for (let r = 0; r < 200000; r++) for (const v of gen(10)) total += v;
+  console.log('gen-churn:', (performance.now() - t0).toFixed(1) + 'ms', total);
+}
+
+genChurn();
+asyncChurn();

--- a/tests/harness/harness.js
+++ b/tests/harness/harness.js
@@ -215,7 +215,12 @@ export async function runSpec(target, opts) {
 }
 
 export async function runTest(target, opts) {
-  const child = new Child(target.entry);
+  const child = target.mem
+    ? new Child('-e', [
+        `process.on('beforeExit', () => console.log('[mem] rss ' + Math.round(process.memoryUsage().rss / 1048576) + 'MB')); import('./${target.entry}');`
+      ])
+    : new Child(target.entry);
+
   const code = await child.waitExit(opts.targetTimeoutMs);
   if (code === 'timeout') {
     child.kill();
@@ -224,7 +229,9 @@ export async function runTest(target, opts) {
   const errs = scanForErrors(child.output);
   if (code !== 0) return { ok: false, detail: `exit ${code}`, output: child.output };
   if (errs.length) return { ok: false, detail: 'error markers in output', output: errs.join('\n') };
-  return { ok: true };
+
+  const mem = [...child.output.matchAll(/\[mem\] rss (\d+MB)/g)].pop();
+  return { ok: true, detail: mem ? `rss ${mem[1]}` : undefined };
 }
 
 export const runScript = runTest;

--- a/tests/harness/harness.js
+++ b/tests/harness/harness.js
@@ -230,8 +230,11 @@ export async function runTest(target, opts) {
   if (code !== 0) return { ok: false, detail: `exit ${code}`, output: child.output };
   if (errs.length) return { ok: false, detail: 'error markers in output', output: errs.join('\n') };
 
-  const mem = [...child.output.matchAll(/\[mem\] rss (\d+MB)/g)].pop();
-  return { ok: true, detail: mem ? `rss ${mem[1]}` : undefined };
+  const mem = [...child.output.matchAll(/\[mem\] rss (\d+)MB/g)].pop();
+  if (mem && target.maxRssMb && Number(mem[1]) > target.maxRssMb)
+    return { ok: false, detail: `rss ${mem[1]}MB exceeds max ${target.maxRssMb}MB` };
+
+  return { ok: true, detail: mem ? `rss ${mem[1]}MB / ${target.maxRssMb ?? '?'}MB max` : undefined };
 }
 
 export const runScript = runTest;

--- a/tests/harness/manifest.js
+++ b/tests/harness/manifest.js
@@ -24,8 +24,6 @@ export function targets() {
   ];
   for (const f of REGRESSION_TESTS) list.push({ group: 'tests', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });
 
-  // [file, max rss MB] — ceilings ~3x observed baseline; generous enough to
-  // absorb machine noise, tight enough to fail on genuine leaks
   const ASYNC_TESTS = [
     ['test_gc_async.js', 96],
     ['test_gc_coro.js', 96],
@@ -41,8 +39,7 @@ export function targets() {
     ['test_async_gen_leak.mjs', 48],
     ['test_upvalue_gc.cjs', 384]
   ];
-  for (const [f, maxRssMb] of ASYNC_TESTS)
-    list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}`, mem: true, maxRssMb });
+  for (const [f, maxRssMb] of ASYNC_TESTS) list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}`, mem: true, maxRssMb });
 
   list.push(
     { group: 'servers', type: 'server', name: 'hono', entry: 'examples/npm/hono/src/index.ts' },
@@ -188,13 +185,27 @@ export function targets() {
     }
   );
 
-  list.push({
-    group: 'perf',
-    type: 'demo',
-    name: 'bench_dec',
-    entry: 'tests/bench_dec.js',
-    checks: [ms('duration ms', /([\d.]+)ms/, 100, 600)]
-  });
+  list.push(
+    {
+      group: 'perf',
+      type: 'demo',
+      name: 'bench_dec',
+      entry: 'tests/bench_dec.js',
+      checks: [ms('duration ms', /([\d.]+)ms/, 100, 600)]
+    },
+    {
+      group: 'perf',
+      type: 'demo',
+      name: 'bench_churn',
+      entry: 'tests/bench_churn.js',
+      checks: [
+        ms('gen churn ms', /gen-churn: ([\d.]+)ms/, 100, 1300),
+        ms('async churn ms', /async-churn: ([\d.]+)ms/, 25, 400),
+        { name: 'gen total', re: /gen-churn: [\d.]+ms (\d+)/, min: 9000000, max: 9000000 },
+        { name: 'async total', re: /async-churn: [\d.]+ms (\d+)/, min: 1350000, max: 1350000 }
+      ]
+    }
+  );
 
   list.push(
     { group: 'oha', type: 'oha', name: 'hono rps', entry: 'examples/npm/hono/src/index.ts', refRps: 25000, minRps: 17500 },

--- a/tests/harness/manifest.js
+++ b/tests/harness/manifest.js
@@ -36,9 +36,10 @@ export function targets() {
     'test_minicoro_concurrent.cjs',
     'test_arguments_async.cjs',
     'test_arguments_escaped_coro.js',
+    'test_async_gen_leak.mjs',
     'test_upvalue_gc.cjs'
   ];
-  for (const f of ASYNC_TESTS) list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });
+  for (const f of ASYNC_TESTS) list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}`, mem: true });
 
   list.push(
     { group: 'servers', type: 'server', name: 'hono', entry: 'examples/npm/hono/src/index.ts' },

--- a/tests/harness/manifest.js
+++ b/tests/harness/manifest.js
@@ -35,6 +35,7 @@ export function targets() {
     'test_coro_this.js',
     'test_minicoro_concurrent.cjs',
     'test_arguments_async.cjs',
+    'test_arguments_escaped_coro.js',
     'test_upvalue_gc.cjs'
   ];
   for (const f of ASYNC_TESTS) list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });

--- a/tests/harness/manifest.js
+++ b/tests/harness/manifest.js
@@ -24,22 +24,25 @@ export function targets() {
   ];
   for (const f of REGRESSION_TESTS) list.push({ group: 'tests', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });
 
+  // [file, max rss MB] — ceilings ~3x observed baseline; generous enough to
+  // absorb machine noise, tight enough to fail on genuine leaks
   const ASYNC_TESTS = [
-    'test_gc_async.js',
-    'test_gc_coro.js',
-    'test_gc_in_coro.js',
-    'test_async_gc.js',
-    'test_async_coroutines.cjs',
-    'test_async_generator_gc_liveness.cjs',
-    'test_coro_resume_safety.js',
-    'test_coro_this.js',
-    'test_minicoro_concurrent.cjs',
-    'test_arguments_async.cjs',
-    'test_arguments_escaped_coro.js',
-    'test_async_gen_leak.mjs',
-    'test_upvalue_gc.cjs'
+    ['test_gc_async.js', 96],
+    ['test_gc_coro.js', 96],
+    ['test_gc_in_coro.js', 64],
+    ['test_async_gc.js', 48],
+    ['test_async_coroutines.cjs', 48],
+    ['test_async_generator_gc_liveness.cjs', 64],
+    ['test_coro_resume_safety.js', 48],
+    ['test_coro_this.js', 48],
+    ['test_minicoro_concurrent.cjs', 48],
+    ['test_arguments_async.cjs', 48],
+    ['test_arguments_escaped_coro.js', 64],
+    ['test_async_gen_leak.mjs', 48],
+    ['test_upvalue_gc.cjs', 384]
   ];
-  for (const f of ASYNC_TESTS) list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}`, mem: true });
+  for (const [f, maxRssMb] of ASYNC_TESTS)
+    list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}`, mem: true, maxRssMb });
 
   list.push(
     { group: 'servers', type: 'server', name: 'hono', entry: 'examples/npm/hono/src/index.ts' },

--- a/tests/harness/manifest.js
+++ b/tests/harness/manifest.js
@@ -13,8 +13,6 @@ export function targets() {
 
   const REGRESSION_TESTS = [
     'test_promise.cjs',
-    'test_arguments_async.cjs',
-    'test_upvalue_gc.cjs',
     'test_jit_derived_ctor.cjs',
     'test_jit_string_builder_snapshot.cjs',
     'test_template_self_append.cjs',
@@ -25,6 +23,21 @@ export function targets() {
     'test_stream_readable_to_web.cjs'
   ];
   for (const f of REGRESSION_TESTS) list.push({ group: 'tests', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });
+
+  const ASYNC_TESTS = [
+    'test_gc_async.js',
+    'test_gc_coro.js',
+    'test_gc_in_coro.js',
+    'test_async_gc.js',
+    'test_async_coroutines.cjs',
+    'test_async_generator_gc_liveness.cjs',
+    'test_coro_resume_safety.js',
+    'test_coro_this.js',
+    'test_minicoro_concurrent.cjs',
+    'test_arguments_async.cjs',
+    'test_upvalue_gc.cjs'
+  ];
+  for (const f of ASYNC_TESTS) list.push({ group: 'async', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });
 
   list.push(
     { group: 'servers', type: 'server', name: 'hono', entry: 'examples/npm/hono/src/index.ts' },

--- a/tests/test_arguments_escaped_coro.js
+++ b/tests/test_arguments_escaped_coro.js
@@ -1,0 +1,52 @@
+// escaped mapped-arguments objects must survive their coroutine's activation
+// being destroyed while suspended (detach-on-destroy, not use-after-free)
+let genLeak, asyncLeak;
+
+function abandonGenerator() {
+  function* g() { genLeak = arguments; yield 1; }
+  g("gen-held", 42).next();
+}
+
+function abandonAsync() {
+  async function f() { asyncLeak = arguments; await new Promise(() => {}); }
+  f("async-held", 7);
+}
+
+abandonGenerator();
+abandonAsync();
+
+let junk = [];
+for (let i = 0; i < 200000; i++) { junk.push({ a: i, b: [i, i + 1] }); if (junk.length > 1024) junk = []; }
+
+let pass = 0, fail = 0;
+function check(name, got, want) {
+  if (got === want) pass++;
+  else { fail++; console.log(`FAIL ${name}: got ${got}, want ${want}`); }
+}
+
+check("gen[0]", genLeak[0], "gen-held");
+check("gen[1]", genLeak[1], 42);
+check("gen.length", genLeak.length, 2);
+genLeak[0] = "rewritten";
+check("gen write", genLeak[0], "rewritten");
+
+check("async[0]", asyncLeak[0], "async-held");
+check("async[1]", asyncLeak[1], 7);
+
+
+// escaped closures over a dead suspended coroutine's locals must read the
+// frozen values through their (closed) upvalues, not the freed snapshot
+let closureLeak;
+function abandonWithClosure() {
+  function* g() { let x = 1234; closureLeak = () => x; yield 1; x = 9999; }
+  g().next();
+}
+abandonWithClosure();
+
+junk = [];
+for (let i = 0; i < 200000; i++) { junk.push({ a: i, b: [i, i + 1] }); if (junk.length > 1024) junk = []; }
+
+check("closure upvalue", closureLeak(), 1234);
+
+console.log(`passed: ${pass}, failed: ${fail}`);
+if (fail) throw new Error("escaped state regression");

--- a/tests/test_async_gen_leak.mjs
+++ b/tests/test_async_gen_leak.mjs
@@ -1,0 +1,15 @@
+async function* ag() {
+  for (let i = 0; i < 5000; i++) {
+    await Promise.resolve();
+    yield i;
+  }
+}
+let total = 0,
+  rounds = 0;
+for (let r = 0; r < 40; r++) {
+  let s = 0;
+  for await (const v of ag()) s += v;
+  total += s;
+  rounds++;
+}
+console.log('rounds:', rounds, 'total:', total, 'rss MB:', Math.round(process.memoryUsage().rss / 1048576));

--- a/vendor/minicoro.wrap
+++ b/vendor/minicoro.wrap
@@ -1,8 +1,0 @@
-[wrap-git]
-url = https://github.com/edubart/minicoro.git
-revision = 02dad0f8b7cbb12fe6e216ae7a76db15ca55cd7b
-patch_directory = minicoro
-depth = 1
-
-[provide]
-minicoro = minicoro_dep

--- a/vendor/packagefiles/minicoro/meson.build
+++ b/vendor/packagefiles/minicoro/meson.build
@@ -1,4 +1,0 @@
-project('minicoro', 'c')
-
-minicoro_inc = include_directories('.')
-minicoro_dep = declare_dependency(include_directories: minicoro_inc)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ant_create()` as the isolate/VM creation entry point.
* **Bug Fixes**
  * Improved suspend/resume reliability for async/generator activations.
  * Improved async iteration and promise handling for `{ done, value }`.
  * Refined coroutine/argument lifecycle cleanup during microtask processing.
* **Breaking Changes**
  * Removed legacy isolate creation entry points and VM “kind”-based configuration.
  * Removed the reactor poll-hook API.
* **Tests**
  * Added async regression coverage, async leak checks, and async/generator churn benchmarks; enhanced RSS-based test gating.
* **Chores**
  * Removed the legacy minicoro build dependency and updated version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->