### PR TITLE
improve node compat with self-resolve and modules

### DIFF
--- a/include/errors.h
+++ b/include/errors.h
@@ -57,6 +57,7 @@ ant_value_t js_make_error_silent(ant_t *js, js_err_type_t err_type, const char *
 ant_value_t js_capture_raw_stack(ant_t *js);
 ant_value_t js_build_callsite_array(ant_t *js);
 ant_value_t js_throw(ant_t *js, ant_value_t value);
+ant_value_t js_take_thrown(ant_t *js, ant_value_t fallback);
 
 #define js_mkerr(js, ...) js_create_error(js, JS_ERR_TYPE, js_mkundef(), __VA_ARGS__)
 #define js_mkerr_typed(js, err_type, ...) js_create_error(js, err_type, js_mkundef(), __VA_ARGS__)

--- a/include/esm/loader.h
+++ b/include/esm/loader.h
@@ -37,5 +37,6 @@ ant_value_t js_esm_import_sync_cstr_from(ant_t *js, const char *specifier, size_
 ant_value_t js_esm_import_dynamic(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t *out_tla_promise);
 ant_value_t js_esm_import_sync_cstr_from_require(ant_t *js, const char *specifier, size_t spec_len, const char *base_path);
 ant_value_t js_esm_eval_module_source(ant_t *js, const char *resolved_path, const char *js_code, size_t js_len, ant_value_t ns);
+ant_value_t js_esm_import_dynamic_ex(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t attrs, ant_value_t *out_tla_promise);
 
 #endif

--- a/include/esm/loader.h
+++ b/include/esm/loader.h
@@ -20,7 +20,7 @@ typedef struct ant_module_t {
   struct ant_module_t *prev;
 } ant_module_t;
 
-void js_esm_cleanup_module_cache(void);
+void js_esm_cleanup_module_cache(ant_t *js);
 
 ant_value_t js_esm_make_file_url(ant_t *js, const char *path);
 ant_value_t js_esm_import_sync(ant_t *js, ant_value_t specifier);
@@ -31,7 +31,7 @@ ant_value_t js_esm_resolve_specifier(ant_t *js, ant_value_t specifier, const cha
 
 ant_value_t js_esm_import_sync_from_require(ant_t *js, ant_value_t specifier, const char *base_path);
 ant_value_t js_esm_resolve_specifier_require(ant_t *js, ant_value_t specifier, const char *base_path);
-char *js_esm_resolve_path_for_watch(const char *specifier, const char *base_path, bool prefer_require);
+char *js_esm_resolve_path_for_watch(ant_t *js, const char *specifier, const char *base_path, bool prefer_require);
 
 ant_value_t js_esm_import_sync_cstr_from(ant_t *js, const char *specifier, size_t spec_len, const char *base_path);
 ant_value_t js_esm_import_dynamic(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t *out_tla_promise);

--- a/include/esm/remote.h
+++ b/include/esm/remote.h
@@ -1,6 +1,7 @@
 #ifndef ESM_REMOTE_H
 #define ESM_REMOTE_H
 
+#include "types.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -11,7 +12,7 @@ char *esm_parse_data_url(const char *url, size_t *out_len);
 char *esm_fetch_url(const char *url, size_t *out_len, char **out_error);
 char *esm_resolve_url(const char *specifier, const char *base_url);
 
-#define FILE_RESOLVER *(*file_resolver)(const char *, const char *)
-char *esm_resolve(const char *specifier, const char *base_path, char FILE_RESOLVER);
+#define FILE_RESOLVER *(*file_resolver)(ant_t *, const char *, const char *)
+char *esm_resolve(ant_t *js, const char *specifier, const char *base_path, char FILE_RESOLVER);
 
 #endif

--- a/include/gc.h
+++ b/include/gc.h
@@ -12,10 +12,10 @@
 #define GC_MAJOR_SCALE         2048u
 #define GC_POOL_PRESSURE_FLOOR (8u * 1024u * 1024u)
 
-#define GC_OBJ_TYPE_MASK (JS_TPFLG(T_OBJ) \
-  | JS_TPFLG(T_ARR)                       \
-  | JS_TPFLG(T_PROMISE)                   \
-  | JS_TPFLG(T_GENERATOR))
+#define GC_OBJ_TYPE_MASK (T_FLAG_FIND(T_OBJ) \
+  | T_FLAG_FIND(T_ARR)                       \
+  | T_FLAG_FIND(T_PROMISE)                   \
+  | T_FLAG_FIND(T_GENERATOR))
 
 typedef struct gc_func_mark_profile {
   bool enabled;

--- a/include/internal.h
+++ b/include/internal.h
@@ -180,6 +180,11 @@ struct ant_isolate_t {
   ant_value_t length_str;
   
   struct {
+    ant_value_t hooks;
+    ant_value_t import_attributes;
+  } esm;
+  
+  struct {
     const char *length;
     const char *buffer;
     const char *prototype;

--- a/include/internal.h
+++ b/include/internal.h
@@ -147,7 +147,6 @@ typedef struct {
 struct ant_isolate_t {
   sv_vm_t *vm;
 
-  ant_module_t *module;
   ant_object_t *objects;
   ant_object_t *permanent_objects;
   ant_process_state_t *process_state;
@@ -181,7 +180,9 @@ struct ant_isolate_t {
   
   struct {
     ant_value_t hooks;
-    ant_value_t import_attributes;
+    ant_value_t import_meta;
+    ant_esm_state_t *state;
+    ant_module_t *module_stack;
   } esm;
   
   struct {
@@ -634,7 +635,7 @@ static inline ant_value_t js_current_func_module_ns(ant_t *js) {
 }
 
 static inline ant_value_t js_module_eval_active_ns(ant_t *js) {
-  ant_module_t *ctx = js->module;
+  ant_module_t *ctx = js->esm.module_stack;
   if (ctx) return ctx->module_ns;
   ctx = js->active_async_coro ? js_active_tla_module_ctx(js) : NULL;
   if (ctx) return ctx->module_ns;
@@ -642,7 +643,7 @@ static inline ant_value_t js_module_eval_active_ns(ant_t *js) {
 }
 
 static inline ant_value_t js_module_eval_active_ctx(ant_t *js) {
-  ant_module_t *ctx = js->module;
+  ant_module_t *ctx = js->esm.module_stack;
   if (ctx) return ctx->module_ctx;
   ctx = js->active_async_coro ? js_active_tla_module_ctx(js) : NULL;
   return ctx ? ctx->module_ctx : js_mkundef();
@@ -663,7 +664,7 @@ static inline const char *js_module_eval_active_filename(ant_t *js) {
 }
 
 static inline ant_module_format_t js_module_eval_active_format(ant_t *js) {
-  ant_module_t *ctx = js->module;
+  ant_module_t *ctx = js->esm.module_stack;
   if (ctx) return ctx->format;
   ctx = js->active_async_coro ? js_active_tla_module_ctx(js) : NULL;
   return ctx ? ctx->format : MODULE_EVAL_FORMAT_UNKNOWN;

--- a/include/internal.h
+++ b/include/internal.h
@@ -54,24 +54,21 @@
 //   vdata(v)          = v & 0x7FFFFFFFFFFF
 //   is_tagged(v)      = v > PREFIX
 
-#define NANBOX_TYPE_MASK   0x1F
-#define NANBOX_TYPE_SHIFT  0x2F
-#define NANBOX_HEAP_OFFSET 0x8
-#define NANBOX_PREFIX      0xFFF0000000000000ULL
-#define NANBOX_DATA_MASK   0x00007FFFFFFFFFFFULL
+static constexpr uint64_t NANBOX_TYPE_MASK  = 0x1F;
+static constexpr uint64_t NANBOX_TYPE_SHIFT = 0x2F;
+static constexpr uint64_t NANBOX_PREFIX     = 0xFFF0000000000000;
+static constexpr uint64_t NANBOX_DATA_MASK  = 0x00007FFFFFFFFFFF;
 
-#define JS_ERR_NO_STACK  (1 << 8)
-#define JS_TPFLG(t)      (1u << (t))
-#define ANT_RUNTIME_WEB  (1u << 0)
+static constexpr uint32_t ANT_RUNTIME_WEB = 1u << 0;
+static constexpr uint32_t PROTO_WALK_F_OBJECT_ONLY = 1u << 0;
+static constexpr uint32_t PROTO_WALK_F_LOOKUP      = 1u << 1;
 
-#define ROPE_MAX_DEPTH        4096
-#define MAX_STRINGIFY_DEPTH   64
-#define MAX_PROTO_CHAIN_DEPTH 256
-#define MAX_MULTIREF_OBJS     128
-#define MAX_DENSE_INITIAL_CAP 8
-
-#define PROTO_WALK_F_OBJECT_ONLY (1u << 0)
-#define PROTO_WALK_F_LOOKUP      (1u << 1)
+static constexpr int JS_ERR_NO_STACK       = 1 << 8;
+static constexpr int ROPE_MAX_DEPTH        = 4096;
+static constexpr int MAX_STRINGIFY_DEPTH   = 64;
+static constexpr int MAX_PROTO_CHAIN_DEPTH = 256;
+static constexpr int MAX_MULTIREF_OBJS     = 128;
+static constexpr int MAX_DENSE_INITIAL_CAP = 8;
 
 enum: uint64_t {
   STR_META_ASCII_SHIFT = 56,
@@ -91,11 +88,18 @@ enum: uint64_t {
   STR_UTF16_LEN_UNKNOWN = STR_META_UTF16_MASK,
 };
 
-#define T_EMPTY                (NANBOX_PREFIX | ((ant_value_t)T_SENTINEL << NANBOX_TYPE_SHIFT) | 0xDEADULL)
-#define T_SPECIAL_OBJECT_MASK  (JS_TPFLG(T_OBJ)  | JS_TPFLG(T_ARR))
-#define T_NEEDS_PROTO_FALLBACK (JS_TPFLG(T_FUNC) | JS_TPFLG(T_ARR) | JS_TPFLG(T_PROMISE) | JS_TPFLG(T_GENERATOR))
-#define T_OBJECT_MASK          (JS_TPFLG(T_OBJ)  | JS_TPFLG(T_ARR) | JS_TPFLG(T_FUNC) | JS_TPFLG(T_PROMISE) | JS_TPFLG(T_GENERATOR))
-#define T_NON_NUMERIC_MASK     (JS_TPFLG(T_STR)  | JS_TPFLG(T_ARR) | JS_TPFLG(T_FUNC) | JS_TPFLG(T_CFUNC) | JS_TPFLG(T_OBJ) | JS_TPFLG(T_GENERATOR))
+#define T_FLAG_FIND(t) (1u << (t))
+#define T_MASK_HOLD ()
+#define T_MASK_EXPAND(...) T_MASK_E1(T_MASK_E1(T_MASK_E1(T_MASK_E1(__VA_ARGS__))))
+#define T_MASK_E1(...)     T_MASK_E2(T_MASK_E2(T_MASK_E2(T_MASK_E2(__VA_ARGS__))))
+#define T_MASK_E2(...)     __VA_ARGS__
+#define T_MASK_STEP(a, ...) \
+  T_FLAG_FIND(a) __VA_OPT__(| T_MASK_AGAIN T_MASK_HOLD (__VA_ARGS__))
+#define T_MASK_AGAIN() T_MASK_STEP
+#define T_MASK(...) (T_MASK_EXPAND(T_MASK_STEP(__VA_ARGS__)))
+
+#define ANT_SENTINEL(payload) \
+  (NANBOX_PREFIX | ((ant_value_t)T_SENTINEL << NANBOX_TYPE_SHIFT) | (payload))
 
 #define is_non_numeric(v)    ((1u << vtype(v)) & T_NON_NUMERIC_MASK)
 #define is_object_type(v)    ((1u << vtype(v)) & T_OBJECT_MASK)
@@ -133,6 +137,33 @@ enum {
   T_WEAKSET,
 
   T_SENTINEL = NANBOX_TYPE_MASK
+};
+
+enum: uint32_t {
+  T_SPECIAL_OBJECT_MASK  = T_MASK(T_OBJ, T_ARR),
+  T_NEEDS_PROTO_FALLBACK = T_MASK(T_FUNC, T_ARR, T_PROMISE, T_GENERATOR),
+  T_OBJECT_MASK          = T_MASK(T_OBJ, T_ARR, T_FUNC, T_PROMISE, T_GENERATOR),
+  T_NON_NUMERIC_MASK     = T_MASK(T_STR, T_ARR, T_FUNC, T_CFUNC, T_OBJ, T_GENERATOR),
+};
+
+static_assert(T_MASK(T_OBJ) == T_FLAG_FIND(T_OBJ), "T_MASK single");
+
+static_assert(
+  T_NON_NUMERIC_MASK == (
+    T_FLAG_FIND(T_STR)   | 
+    T_FLAG_FIND(T_ARR)   | 
+    T_FLAG_FIND(T_FUNC)  | 
+    T_FLAG_FIND(T_CFUNC) |
+    T_FLAG_FIND(T_OBJ)   |
+    T_FLAG_FIND(T_GENERATOR)),
+  "T_MASK variadic expansion"
+);
+
+enum: ant_value_t {
+  T_EMPTY             = ANT_SENTINEL(0xDEADULL),  // empty slot / array hole / TDZ
+  SV_JIT_BAILOUT      = ANT_SENTINEL(0xBA110ULL), // JIT -> interpreter bailout
+  SV_AITER_ARRAY_TAG  = ANT_SENTINEL(0xFA1ULL),   // for-await plain-array mode
+  SV_AITER_AWAIT_MARK = ANT_SENTINEL(0xFA2ULL),   // for-await element await resume
 };
 
 typedef struct {
@@ -337,23 +368,23 @@ typedef struct {
   char bytes[];
 } ant_flat_string_t;
 
-_Static_assert(
+static_assert(
   sizeof(ant_flat_string_t) == 16,
   "flat string header must remain 16 bytes"
 );
 
-_Static_assert(
+static_assert(
   offsetof(ant_flat_string_t, bytes) == sizeof(ant_flat_string_t),
   "flat string bytes must follow packed metadata"
 );
 
-_Static_assert(
+static_assert(
   offsetof(ant_large_string_alloc_t, meta) - offsetof(ant_large_string_alloc_t, len) ==
     offsetof(ant_flat_string_t, meta),
   "large and pooled string metadata layouts must match"
 );
 
-_Static_assert(
+static_assert(
   offsetof(ant_large_string_alloc_t, bytes) - offsetof(ant_large_string_alloc_t, len) ==
     offsetof(ant_flat_string_t, bytes),
   "large and pooled string byte layouts must match"

--- a/include/object.h
+++ b/include/object.h
@@ -91,7 +91,7 @@ typedef struct {
   uint8_t flags;
 } ant_object_sidecar_t;
 
-_Static_assert(
+static_assert(
   _Alignof(ant_object_sidecar_t) > ant_sidecar, 
   "object sidecar pointer uses low-bit tag"
 );
@@ -114,7 +114,7 @@ typedef union ant_object_flags {
   uint8_t bytes[2];
 } ant_object_flags_t;
 
-_Static_assert(
+static_assert(
   sizeof(ant_object_flags_t) == 2,
   "ant_object_flags_t must cover the packed object bitfields"
 );

--- a/include/reactor.h
+++ b/include/reactor.h
@@ -4,25 +4,21 @@
 #include "types.h"
 #include <uv.h>
 
-#define UV_CHECK_ALIVE uv_loop_alive(uv_default_loop())
+typedef enum: uint8_t {
+  WORK_MICROTASKS  = 1u << 0,
+  WORK_TIMERS      = 1u << 1,
+  WORK_IMMEDIATES  = 1u << 2,
+  WORK_FETCHES     = 1u << 3,
+  WORK_FS_OPS      = 1u << 4,
+  WORK_CHILD_PROCS = 1u << 5,
+  WORK_READLINE    = 1u << 6,
+  WORK_STDIN       = 1u << 7,
 
-typedef enum {
-  WORK_MICROTASKS  = 1 << 0,
-  WORK_TIMERS      = 1 << 1,
-  WORK_IMMEDIATES  = 1 << 2,
-  WORK_FETCHES     = 1 << 3,
-  WORK_FS_OPS      = 1 << 4,
-  WORK_CHILD_PROCS = 1 << 5,
-  WORK_READLINE    = 1 << 6,
-  WORK_STDIN       = 1 << 7,
-} work_flags_t;
-
-enum {
+  WORK_BLOCKING = (WORK_MICROTASKS | WORK_IMMEDIATES),
   WORK_TASKS    = (WORK_MICROTASKS | WORK_TIMERS | WORK_IMMEDIATES | WORK_FETCHES),
   WORK_PENDING  = (WORK_TASKS | WORK_FS_OPS | WORK_CHILD_PROCS | WORK_READLINE | WORK_STDIN),
-  WORK_BLOCKING = (WORK_MICROTASKS | WORK_IMMEDIATES),
   WORK_ASYNC    = (WORK_READLINE | WORK_STDIN | WORK_TIMERS | WORK_FETCHES | WORK_FS_OPS | WORK_CHILD_PROCS),
-};
+} work_flags_t;
 
 void js_poll_events(ant_t *js);
 void js_run_event_loop(ant_t *js);

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -178,7 +178,7 @@ typedef struct {
   sv_ctor_prop_fb_t ctor_prop_fb;
 } sv_func_sidecar_t;
 
-_Static_assert(
+static_assert(
   _Alignof(sv_func_sidecar_t) > ant_sidecar,
   "function sidecar pointer uses low-bit tag"
 );
@@ -210,7 +210,7 @@ typedef struct {
   sv_type_info_t local_types[];
 } sv_func_metadata_t;
 
-_Static_assert(
+static_assert(
   _Alignof(sv_func_metadata_t) <= CODE_ARENA_ALIGNMENT,
   "function metadata alignment exceeds the code arena guarantee"
 );
@@ -501,7 +501,7 @@ typedef struct {
 #define SV_TDZ      T_EMPTY
 #define SV_HANDLER_MAX (SV_TRY_MAX * 2)
 
-_Static_assert(SV_HANDLER_MAX <= UINT16_MAX,
+static_assert(SV_HANDLER_MAX <= UINT16_MAX,
   "frame handler indexes must fit in uint16_t");
 
 #define SV_FRAMES_HARD_MAX 65536
@@ -1035,12 +1035,6 @@ static inline ant_value_t sv_call_closure(
 #define SV_CALL_FB_MISS_DISABLE 4
 
 #define SV_JIT_RETRY_INTERP    mkval(T_ERR, 1)
-#define SV_JIT_MAGIC           0xBA110ULL
-
-#define SV_JIT_BAILOUT \
-  (NANBOX_PREFIX \
-    | ((ant_value_t)T_SENTINEL << NANBOX_TYPE_SHIFT) \
-    | SV_JIT_MAGIC)
   
 extern const char *const sv_op_names[OP__COUNT];
   

--- a/include/types.h
+++ b/include/types.h
@@ -14,6 +14,7 @@ typedef struct ant_isolate_t      ant_t;
 typedef struct ant_pool_block     ant_pool_block_t;
 typedef struct ant_http_request_s ant_http_request_t;
 typedef struct ant_process_state  ant_process_state_t;
+typedef struct ant_esm_state      ant_esm_state_t;
 
 typedef struct ant_object ant_object_t;
 typedef struct ant_shape  ant_shape_t;

--- a/src/ant.c
+++ b/src/ant.c
@@ -15914,14 +15914,6 @@ ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
   return builtin_Promise_resolve(js, promise_args, 1);
 }
 
-static ant_value_t js_get_import_meta_prop(ant_t *js) {
-  return js->esm.import_meta;
-}
-
-static void js_set_import_meta_prop(ant_t *js, ant_value_t import_meta) {
-  js->esm.import_meta = import_meta;
-}
-
 static void js_set_import_module_ctx(ant_t *js, ant_value_t module_ctx) {
   if (!is_object_type(module_ctx)) return;
   ant_value_t import_fn = js_get_import_func(js);
@@ -15935,7 +15927,7 @@ static ant_value_t js_get_current_import_meta(ant_t *js) {
     js_get_execution_module_ctx(js)
   );
   if (vtype(import_meta) == T_OBJ) return import_meta;
-  return js_get_import_meta_prop(js);
+  return js->esm.import_meta;
 }
 
 static ant_value_t builtin_import_meta_resolve(ant_t *js, ant_value_t *args, int nargs) {
@@ -16123,25 +16115,25 @@ void js_setup_import_meta(ant_t *js, const char *filename) {
   if (is_err(import_meta) || vtype(import_meta) == T_UNDEF) return;
 
   js_set_import_module_ctx(js, module_ctx);
-  js_set_import_meta_prop(js, import_meta);
+  js->esm.import_meta = import_meta;
 }
 
 void js_module_eval_ctx_push(ant_t *js, ant_module_t *ctx) {
   if (!js || !ctx) return;
 
   ctx->prev = js->esm.module_stack;
-  ctx->prev_import_meta_prop = js_get_import_meta_prop(js);
+  ctx->prev_import_meta_prop = js->esm.import_meta;
   js->esm.module_stack = ctx;
 
   ant_value_t import_meta = js_get_module_ctx_import_meta(js, ctx->module_ctx);
-  if (vtype(import_meta) != T_UNDEF) js_set_import_meta_prop(js, import_meta);
+  if (vtype(import_meta) != T_UNDEF) js->esm.import_meta = import_meta;
 }
 
 void js_module_eval_ctx_pop(ant_t *js, ant_module_t *ctx) {
   if (!js || !ctx) return;
 
   if (js->esm.module_stack == ctx) {
-    js_set_import_meta_prop(js, ctx->prev_import_meta_prop);
+    js->esm.import_meta = ctx->prev_import_meta_prop;
     js->esm.module_stack = ctx->prev;
   }
 }

--- a/src/ant.c
+++ b/src/ant.c
@@ -15905,22 +15905,31 @@ ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
     }
 
     if (is_object_type(attrs)) {
+      GC_ROOT_SAVE(root_mark, js);
       ant_value_t keys = js_own_property_keys(js, attrs, false, true);
+      GC_ROOT_PIN(js, keys);
+
+      ant_value_t key = js_mkundef();
+      GC_ROOT_PIN(js, key);
+
       ant_offset_t key_count = js_arr_len(js, keys);
       for (ant_offset_t i = 0; i < key_count; i++) {
-        ant_value_t key = js_arr_get(js, keys, i);
+        key = js_arr_get(js, keys, i);
         if (vtype(key) != T_STR) continue;
 
         ant_value_t val = js_get(js, attrs, js_getstr(js, key, NULL));
         if (is_err(val)) {
           ant_value_t reject_val = js_take_thrown(js, val);
+          GC_ROOT_RESTORE(js, root_mark);
           return builtin_Promise_reject(js, &reject_val, 1);
         }
         if (vtype(val) != T_STR) {
           ant_value_t err = js_take_thrown(js, js_mkerr_typed(js, JS_ERR_TYPE, "Import attribute values must be strings"));
+          GC_ROOT_RESTORE(js, root_mark);
           return builtin_Promise_reject(js, &err, 1);
         }
       }
+      GC_ROOT_RESTORE(js, root_mark);
     }
   }
 

--- a/src/ant.c
+++ b/src/ant.c
@@ -73,9 +73,9 @@
 
 #define D(x) ((double)(x))
 
-_Static_assert(sizeof(double) == 8, "NaN-boxing requires 64-bit IEEE 754 doubles");
-_Static_assert(sizeof(uint64_t) == 8, "NaN-boxing requires 64-bit integers");
-_Static_assert(sizeof(double) == sizeof(uint64_t), "double and uint64_t must have same size");
+static_assert(sizeof(double) == 8, "NaN-boxing requires 64-bit IEEE 754 doubles");
+static_assert(sizeof(uint64_t) == 8, "NaN-boxing requires 64-bit integers");
+static_assert(sizeof(double) == sizeof(uint64_t), "double and uint64_t must have same size");
 
 #if defined(__STDC_IEC_559__) || defined(__GCC_IEC_559)
 #elif defined(__FAST_MATH__)
@@ -3544,7 +3544,7 @@ static inline bool proto_walk_next(ant_t *js, ant_value_t *cur, uint8_t *t, uint
     return true;
   }
 
-  if (JS_TPFLG(ct) & T_OBJECT_MASK) {
+  if (T_FLAG_FIND(ct) & T_OBJECT_MASK) {
     ant_value_t as_obj = js_as_obj(*cur);
     ant_value_t proto = get_slot(as_obj, SLOT_PROTO);
     
@@ -3555,7 +3555,7 @@ static inline bool proto_walk_next(ant_t *js, ant_value_t *cur, uint8_t *t, uint
       return true;
     }
     
-    if (JS_TPFLG(ct) & T_NEEDS_PROTO_FALLBACK) {
+    if (T_FLAG_FIND(ct) & T_NEEDS_PROTO_FALLBACK) {
       ant_value_t fallback = get_prototype_for_type(js, ct);
       uint8_t ft = vtype(fallback);
       if (ft == T_NULL || ft == T_UNDEF) return false;
@@ -15889,7 +15889,7 @@ ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
   ant_value_t attrs = js_mkundef();
   if (nargs >= 2 && vtype(args[1]) != T_UNDEF) {
     if (!is_object_type(args[1])) {
-      ant_value_t err = js_mkerr_typed(js, JS_ERR_TYPE, "The second argument to import() must be an object");
+      ant_value_t err = js_take_thrown(js, js_mkerr_typed(js, JS_ERR_TYPE, "The second argument to import() must be an object"));
       return builtin_Promise_reject(js, &err, 1);
     }
 
@@ -15900,8 +15900,27 @@ ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
     }
 
     if (vtype(attrs) != T_UNDEF && !is_object_type(attrs)) {
-      ant_value_t err = js_mkerr_typed(js, JS_ERR_TYPE, "The 'with' option must be an object");
+      ant_value_t err = js_take_thrown(js, js_mkerr_typed(js, JS_ERR_TYPE, "The 'with' option must be an object"));
       return builtin_Promise_reject(js, &err, 1);
+    }
+
+    if (is_object_type(attrs)) {
+      ant_value_t keys = js_own_property_keys(js, attrs, false, true);
+      ant_offset_t key_count = js_arr_len(js, keys);
+      for (ant_offset_t i = 0; i < key_count; i++) {
+        ant_value_t key = js_arr_get(js, keys, i);
+        if (vtype(key) != T_STR) continue;
+
+        ant_value_t val = js_get(js, attrs, js_getstr(js, key, NULL));
+        if (is_err(val)) {
+          ant_value_t reject_val = js_take_thrown(js, val);
+          return builtin_Promise_reject(js, &reject_val, 1);
+        }
+        if (vtype(val) != T_STR) {
+          ant_value_t err = js_take_thrown(js, js_mkerr_typed(js, JS_ERR_TYPE, "Import attribute values must be strings"));
+          return builtin_Promise_reject(js, &err, 1);
+        }
+      }
     }
   }
 

--- a/src/ant.c
+++ b/src/ant.c
@@ -15907,8 +15907,11 @@ ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
 
   ant_value_t tla_promise = js_mkundef();
   ant_value_t ns = js_esm_import_dynamic_ex(js, args[0], base_path, attrs, &tla_promise);
-  
-  if (is_err(ns)) return builtin_Promise_reject(js, &ns, 1);
+
+  if (is_err(ns)) {
+    ant_value_t reject_val = js_take_thrown(js, ns);
+    return builtin_Promise_reject(js, &reject_val, 1);
+  }
 
   if (vtype(tla_promise) == T_PROMISE) {
     ant_value_t resolve_fn = make_data_cfunc(js, ns, builtin_import_tla_resolve);

--- a/src/ant.c
+++ b/src/ant.c
@@ -15879,15 +15879,21 @@ static const char *js_get_execution_module_filename(ant_t *js) {
 
 ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
   if (nargs < 1) return js_mkerr(js, "import() requires a string specifier");
-  
+
   ant_value_t module_ctx = js_get_import_owner_module_ctx(js);
   const char *base_path = js_get_module_ctx_filename(js, module_ctx);
-  
+
   if (!js_has_module_filename(base_path))
     base_path = js_get_execution_module_filename(js);
-    
+
+  ant_value_t attrs = js_mkundef();
+  if (nargs >= 2 && is_object_type(args[1])) {
+    attrs = js_get(js, args[1], "with");
+    if (!is_object_type(attrs)) attrs = js_mkundef();
+  }
+
   ant_value_t tla_promise = js_mkundef();
-  ant_value_t ns = js_esm_import_dynamic(js, args[0], base_path, &tla_promise);
+  ant_value_t ns = js_esm_import_dynamic_ex(js, args[0], base_path, attrs, &tla_promise);
   
   if (is_err(ns)) return builtin_Promise_reject(js, &ns, 1);
 
@@ -17110,6 +17116,8 @@ static ant_t *isolate_init(void *buf, size_t len) {
   js->global = mkobj(js, 0);
   js->this_val = js->global;
   js->new_target = js_mkundef();
+  js->esm.hooks = js_mkundef();
+  js->esm.import_attributes = js_mkundef();
   js->length_str = ANT_STRING("length");
 
   ant_value_t glob = js->global;

--- a/src/ant.c
+++ b/src/ant.c
@@ -15887,9 +15887,22 @@ ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
     base_path = js_get_execution_module_filename(js);
 
   ant_value_t attrs = js_mkundef();
-  if (nargs >= 2 && is_object_type(args[1])) {
+  if (nargs >= 2 && vtype(args[1]) != T_UNDEF) {
+    if (!is_object_type(args[1])) {
+      ant_value_t err = js_mkerr_typed(js, JS_ERR_TYPE, "The second argument to import() must be an object");
+      return builtin_Promise_reject(js, &err, 1);
+    }
+
     attrs = js_get(js, args[1], "with");
-    if (!is_object_type(attrs)) attrs = js_mkundef();
+    if (is_err(attrs)) {
+      ant_value_t reject_val = js_take_thrown(js, attrs);
+      return builtin_Promise_reject(js, &reject_val, 1);
+    }
+
+    if (vtype(attrs) != T_UNDEF && !is_object_type(attrs)) {
+      ant_value_t err = js_mkerr_typed(js, JS_ERR_TYPE, "The 'with' option must be an object");
+      return builtin_Promise_reject(js, &err, 1);
+    }
   }
 
   ant_value_t tla_promise = js_mkundef();

--- a/src/ant.c
+++ b/src/ant.c
@@ -15915,15 +15915,11 @@ ant_value_t js_builtin_import(ant_t *js, ant_value_t *args, int nargs) {
 }
 
 static ant_value_t js_get_import_meta_prop(ant_t *js) {
-  ant_value_t import_fn = js_get_import_func(js);
-  if (vtype(import_fn) != T_FUNC) return js_mkundef();
-  return js_get(js, js_func_obj(import_fn), "meta");
+  return js->esm.import_meta;
 }
 
 static void js_set_import_meta_prop(ant_t *js, ant_value_t import_meta) {
-  ant_value_t import_fn = js_get_import_func(js);
-  if (vtype(import_fn) != T_FUNC) return;
-  setprop_cstr(js, js_func_obj(import_fn), "meta", 4, import_meta);
+  js->esm.import_meta = import_meta;
 }
 
 static void js_set_import_module_ctx(ant_t *js, ant_value_t module_ctx) {
@@ -16133,9 +16129,9 @@ void js_setup_import_meta(ant_t *js, const char *filename) {
 void js_module_eval_ctx_push(ant_t *js, ant_module_t *ctx) {
   if (!js || !ctx) return;
 
-  ctx->prev = js->module;
+  ctx->prev = js->esm.module_stack;
   ctx->prev_import_meta_prop = js_get_import_meta_prop(js);
-  js->module = ctx;
+  js->esm.module_stack = ctx;
 
   ant_value_t import_meta = js_get_module_ctx_import_meta(js, ctx->module_ctx);
   if (vtype(import_meta) != T_UNDEF) js_set_import_meta_prop(js, import_meta);
@@ -16144,9 +16140,9 @@ void js_module_eval_ctx_push(ant_t *js, ant_module_t *ctx) {
 void js_module_eval_ctx_pop(ant_t *js, ant_module_t *ctx) {
   if (!js || !ctx) return;
 
-  if (js->module == ctx) {
+  if (js->esm.module_stack == ctx) {
     js_set_import_meta_prop(js, ctx->prev_import_meta_prop);
-    js->module = ctx->prev;
+    js->esm.module_stack = ctx->prev;
   }
 }
 
@@ -17117,7 +17113,8 @@ static ant_t *isolate_init(void *buf, size_t len) {
   js->this_val = js->global;
   js->new_target = js_mkundef();
   js->esm.hooks = js_mkundef();
-  js->esm.import_attributes = js_mkundef();
+  js->esm.import_meta = js_mkundef();
+  js->esm.state = NULL;
   js->length_str = ANT_STRING("length");
 
   ant_value_t glob = js->global;
@@ -17632,7 +17629,7 @@ void js_destroy(ant_t *js) {
     js->vm = NULL;
   }
   
-  js_esm_cleanup_module_cache();
+  js_esm_cleanup_module_cache(js);
   code_arena_reset();
   cleanup_rpc_module();
   cleanup_lmdb_module();

--- a/src/errors.c
+++ b/src/errors.c
@@ -832,14 +832,13 @@ ant_value_t js_create_error(ant_t *js, js_err_type_t err_type, ant_value_t props
   js_set_slot(err_obj, SLOT_ERR_TYPE, js_mknum((double)err_type));
 
   int props_type = vtype(props);
-  if ((JS_TPFLG(props_type) & T_SPECIAL_OBJECT_MASK) != 0) {
+  if ((T_FLAG_FIND(props_type) & T_SPECIAL_OBJECT_MASK) != 0)
     js_merge_obj(js, err_obj, props);
-  }
+
   ant_value_t proto = js_get_ctor_proto(js, err_name, err_name_len);
   int proto_type = vtype(proto);
-  if ((JS_TPFLG(proto_type) & T_SPECIAL_OBJECT_MASK) != 0) {
+  if ((T_FLAG_FIND(proto_type) & T_SPECIAL_OBJECT_MASK) != 0)
     js_set_proto_init(err_obj, proto);
-  }
 
   js->thrown_exists = true;
   js->thrown_value = err_obj;

--- a/src/errors.c
+++ b/src/errors.c
@@ -61,14 +61,20 @@ void print_error_value(ant_t *js, ant_value_t value, ant_value_t fallback_stack,
   ant_output_stream_flush(out);
 }
 
-bool print_uncaught_throw(ant_t *js) {
-  if (!js->thrown_exists) return false;
-  print_error_value(js, js->thrown_value, js->thrown_stack, NULL);
-  
+ant_value_t js_take_thrown(ant_t *js, ant_value_t fallback) {
+  ant_value_t value = js->thrown_exists ? js->thrown_value : fallback;
+
   js->thrown_exists = false;
   js->thrown_value = js_mkundef();
   js->thrown_stack = js_mkundef();
-  
+
+  return value;
+}
+
+bool print_uncaught_throw(ant_t *js) {
+  if (!js->thrown_exists) return false;
+  print_error_value(js, js->thrown_value, js->thrown_stack, NULL);
+  js_take_thrown(js, js_mkundef());
   return true;
 }
 

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -165,7 +165,7 @@ static char *esm_file_url_to_path(ant_t *js, const char *specifier) {
   if (p_len == 0) return NULL;
 
   ant_value_t encoded = js_mkstr(js, p, p_len);
-  ant_value_t decoded = js_decodeURI(js, &encoded, 1);
+  ant_value_t decoded = js_decodeURIComponent(js, &encoded, 1);
 
   size_t len = 0;
   char *str = js_getstr(js, decoded, &len);

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -68,11 +68,6 @@ typedef struct esm_module {
 } esm_module_t;
 
 typedef struct {
-  esm_module_t *modules;
-  int count;
-} esm_module_cache_t;
-
-typedef struct {
   char *data;
   size_t size;
 } esm_file_data_t;
@@ -91,9 +86,7 @@ typedef enum {
   ESM_PACKAGE_TYPE_COMMONJS,
 } esm_package_type_t;
 
-static int esm_dynamic_import_depth = 0;
-static esm_module_cache_t global_module_cache = {NULL, 0};
-static char *esm_resolve_node_module(const char *specifier, const char *base_path);
+static char *esm_resolve_node_module(ant_t *js, const char *specifier, const char *base_path);
 static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod);
 
 static bool esm_is_path_sep(char ch) {
@@ -371,19 +364,19 @@ static bool esm_is_relative_specifier(const char *specifier) {
     strncmp(specifier, "..\\", 3) == 0;
 }
 
-static char *esm_try_resolve(const char *dir, const char *spec, const char *suffix) {
+static char *esm_try_resolve(ant_t *js, const char *dir, const char *spec, const char *suffix) {
   char path[PATH_MAX];
   if (!dir || !dir[0]) snprintf(path, PATH_MAX, "%s%s", spec, suffix);
   else snprintf(path, PATH_MAX, "%s/%s%s", dir, spec, suffix);
 
   char *cached = NULL;
-  if (esm_path_resolve_cache_get(path, &cached)) return cached;
+  if (esm_path_resolve_cache_get(js, path, &cached)) return cached;
 
   char *resolved = esm_resolve_existing_regular_path(path);
   if (resolved) {
-    esm_path_resolve_cache_put(path, resolved);
+    esm_path_resolve_cache_put(js, path, resolved);
     return resolved;
-  } esm_path_resolve_cache_put(path, NULL);
+  } esm_path_resolve_cache_put(js, path, NULL);
   
   return NULL;
 }
@@ -401,26 +394,27 @@ static bool esm_has_extension(const char *spec) {
   return false;
 }
 
-static char *esm_try_resolve_with_exts(const char *dir, const char *spec, bool has_ext) {
+static char *esm_try_resolve_with_exts(ant_t *js, const char *dir, const char *spec, bool has_ext) {
   const char *const *exts = module_resolve_extensions;
   char *result = NULL;
 
-  if ((result = esm_try_resolve(dir, spec, ""))) return result;
+  if ((result = esm_try_resolve(js, dir, spec, ""))) return result;
   if (has_ext) return NULL;
 
   for (int i = 0; exts[i]; i++) {
-    if ((result = esm_try_resolve(dir, spec, exts[i]))) return result;
+    if ((result = esm_try_resolve(js, dir, spec, exts[i]))) return result;
   }
   return NULL;
 }
 
-static char *esm_try_resolve_index_with_exts(const char *dir, const char *spec) {
+static char *esm_try_resolve_index_with_exts(ant_t *js, const char *dir, const char *spec) {
   char idx[PATH_MAX];
   snprintf(idx, sizeof(idx), "%s/index", spec);
-  return esm_try_resolve_with_exts(dir, idx, false);
+  return esm_try_resolve_with_exts(js, dir, idx, false);
 }
 
 static char *esm_try_resolve_relative_typescript_source_fallback(
+  ant_t *js,
   const char *dir,
   const char *spec,
   const char *base_path
@@ -430,7 +424,7 @@ static char *esm_try_resolve_relative_typescript_source_fallback(
   char *ts_spec = resolve_typescript_source_fallback(spec);
   if (!ts_spec) return NULL;
 
-  char *resolved = esm_try_resolve(dir, ts_spec, "");
+  char *resolved = esm_try_resolve(js, dir, ts_spec, "");
   free(ts_spec);
   return resolved;
 }
@@ -511,6 +505,7 @@ static ant_value_t esm_prepare_eval_ctx(
 }
 
 static char *esm_try_resolve_from_extension_list(
+  ant_t *js,
   const char *dir,
   const char *spec,
   const char *first_ext,
@@ -518,28 +513,28 @@ static char *esm_try_resolve_from_extension_list(
 ) {
   char *result = NULL;
   if (first_ext && first_ext[0]) {
-    if ((result = esm_try_resolve(dir, spec, first_ext))) return result;
+    if ((result = esm_try_resolve(js, dir, spec, first_ext))) return result;
   }
 
   const char *const *exts = module_resolve_extensions;
   for (int i = 0; exts[i]; i++) {
     if (skip_ext && strcmp(skip_ext, exts[i]) == 0) continue;
-    if ((result = esm_try_resolve(dir, spec, exts[i]))) return result;
+    if ((result = esm_try_resolve(js, dir, spec, exts[i]))) return result;
   }
   return NULL;
 }
 
-static char *esm_resolve_absolute(const char *specifier) {
-  char *result = esm_try_resolve_with_exts("", specifier, esm_has_extension(specifier));
+static char *esm_resolve_absolute(ant_t *js, const char *specifier) {
+  char *result = esm_try_resolve_with_exts(js, "", specifier, esm_has_extension(specifier));
   if (result) return result;
-  return esm_try_resolve_index_with_exts("", specifier);
+  return esm_try_resolve_index_with_exts(js, "", specifier);
 }
 
-static char *esm_get_base_dir(const char *base_path) {
+static char *esm_get_base_dir(ant_t *js, const char *base_path) {
   bool can_cache = base_path && base_path[0];
   if (can_cache) {
     char *cached = NULL;
-    if (esm_base_dir_cache_get(base_path, &cached)) return cached;
+    if (esm_base_dir_cache_get(js, base_path, &cached)) return cached;
   }
 
   if (!base_path || !base_path[0]) {
@@ -565,7 +560,7 @@ static char *esm_get_base_dir(const char *base_path) {
     char *out = realpath(resolved_or_candidate, NULL);
     if (!out) out = strdup(resolved_or_candidate);
     if (resolved) free(resolved);
-    if (can_cache && out) esm_base_dir_cache_put(base_path, out);
+    if (can_cache && out) esm_base_dir_cache_put(js, base_path, out);
     return out;
   }
 
@@ -578,7 +573,7 @@ static char *esm_get_base_dir(const char *base_path) {
   if (!out) out = strdup(dir);
   
   free(tmp);
-  if (can_cache && out) esm_base_dir_cache_put(base_path, out);
+  if (can_cache && out) esm_base_dir_cache_put(js, base_path, out);
   return out;
 }
 
@@ -616,19 +611,19 @@ static bool esm_split_package_specifier(
   return true;
 }
 
-static char *esm_find_node_module_dir(const char *start_dir, const char *package_name) {
+static char *esm_find_node_module_dir(ant_t *js, const char *start_dir, const char *package_name) {
   if (!start_dir || !package_name) return NULL;
 
   char *cached_initial = NULL;
-  if (esm_package_dir_cache_get(start_dir, package_name, &cached_initial)) return cached_initial;
+  if (esm_package_dir_cache_get(js, start_dir, package_name, &cached_initial)) return cached_initial;
 
   char current[PATH_MAX];
   snprintf(current, sizeof(current), "%s", start_dir);
 
   while (true) {
     char *cached_dir = NULL;
-    if (esm_package_dir_cache_get(current, package_name, &cached_dir)) {
-      esm_package_dir_cache_put(start_dir, package_name, cached_dir);
+    if (esm_package_dir_cache_get(js, current, package_name, &cached_dir)) {
+      esm_package_dir_cache_put(js, start_dir, package_name, cached_dir);
       return cached_dir;
     }
 
@@ -637,15 +632,15 @@ static char *esm_find_node_module_dir(const char *start_dir, const char *package
 
     char *package_dir = esm_resolve_existing_directory_path(candidate);
     if (package_dir) {
-      esm_package_dir_cache_put(current, package_name, package_dir);
-      esm_package_dir_cache_put(start_dir, package_name, package_dir);
+      esm_package_dir_cache_put(js, current, package_name, package_dir);
+      esm_package_dir_cache_put(js, start_dir, package_name, package_dir);
       return package_dir;
     }
 
     if (!esm_path_ascend(current)) break;
   }
-  
-  esm_package_dir_cache_put(start_dir, package_name, NULL);
+
+  esm_package_dir_cache_put(js, start_dir, package_name, NULL);
   return NULL;
 }
 
@@ -687,6 +682,7 @@ static char *esm_replace_star(const char *pattern, const char *capture, size_t c
 }
 
 static char *esm_resolve_exports_target(
+  ant_t *js,
   yyjson_val *target,
   const char *package_dir,
   const char *capture,
@@ -705,15 +701,15 @@ static char *esm_resolve_exports_target(
       char *mapped = esm_replace_star(target_str + 2, capture, capture_len);
       if (!mapped) return NULL;
 
-      char *resolved = esm_try_resolve_with_exts(package_dir, mapped, esm_has_extension(mapped));
-      if (!resolved) resolved = esm_try_resolve_index_with_exts(package_dir, mapped);
+      char *resolved = esm_try_resolve_with_exts(js, package_dir, mapped, esm_has_extension(mapped));
+      if (!resolved) resolved = esm_try_resolve_index_with_exts(js, package_dir, mapped);
       free(mapped);
       return resolved;
     }
 
     if (!allow_bare_specifiers) return NULL;
     if (target_str[0] == '#') return NULL;
-    return esm_resolve_node_module(target_str, base_path);
+    return esm_resolve_node_module(js, target_str, base_path);
   }
 
   if (yyjson_is_arr(target)) {
@@ -721,7 +717,7 @@ static char *esm_resolve_exports_target(
     yyjson_val *item;
     yyjson_arr_foreach(target, idx, max, item) {
       char *resolved = esm_resolve_exports_target(
-        item, package_dir, capture,
+        js, item, package_dir, capture,
         capture_len, base_path, allow_bare_specifiers, prefer_require
       );
       if (resolved) return resolved;
@@ -745,7 +741,7 @@ static char *esm_resolve_exports_target(
       yyjson_val *cond_target = yyjson_obj_get(target, conditions[i]);
       if (!cond_target) continue;
       char *resolved = esm_resolve_exports_target(
-        cond_target, package_dir, capture,
+        js, cond_target, package_dir, capture,
         capture_len, base_path, allow_bare_specifiers, prefer_require
       );
       if (resolved) return resolved;
@@ -756,6 +752,7 @@ static char *esm_resolve_exports_target(
 }
 
 static char *esm_resolve_package_map(
+  ant_t *js,
   yyjson_val *map_obj,
   const char *request_key,
   const char *package_dir,
@@ -767,7 +764,7 @@ static char *esm_resolve_package_map(
 
   yyjson_val *exact = yyjson_obj_get(map_obj, request_key);
   if (exact) return esm_resolve_exports_target(
-    exact, package_dir, "", 0, 
+    js, exact, package_dir, "", 0,
     base_path, allow_bare_specifiers, prefer_require
   );
 
@@ -801,12 +798,12 @@ static char *esm_resolve_package_map(
 
   if (!best_target) return NULL;
   return esm_resolve_exports_target(
-    best_target, package_dir, best_capture,
+    js, best_target, package_dir, best_capture,
     best_capture_len, base_path, allow_bare_specifiers, prefer_require
   );
 }
 
-static char *esm_resolve_package_main_entry(yyjson_val *root, const char *package_dir) {
+static char *esm_resolve_package_main_entry(ant_t *js, yyjson_val *root, const char *package_dir) {
   if (!root || !yyjson_is_obj(root)) return NULL;
 
   yyjson_val *main = yyjson_obj_get(root, "main");
@@ -815,16 +812,16 @@ static char *esm_resolve_package_main_entry(yyjson_val *root, const char *packag
   const char *main_str = yyjson_get_str(main);
   if (!main_str || !main_str[0]) return NULL;
 
-  char *resolved = esm_try_resolve_with_exts(package_dir, main_str, esm_has_extension(main_str));
-  if (!resolved) resolved = esm_try_resolve_index_with_exts(package_dir, main_str);
+  char *resolved = esm_try_resolve_with_exts(js, package_dir, main_str, esm_has_extension(main_str));
+  if (!resolved) resolved = esm_try_resolve_index_with_exts(js, package_dir, main_str);
   return resolved;
 }
 
-static char *esm_resolve_package_entrypoint(const char *package_dir, const char *subpath, const char *base_path, bool prefer_require) {
+static char *esm_resolve_package_entrypoint(ant_t *js, const char *package_dir, const char *subpath, const char *base_path, bool prefer_require) {
   char pkg_json_path[PATH_MAX];
   snprintf(pkg_json_path, sizeof(pkg_json_path), "%s/package.json", package_dir);
 
-  yyjson_doc *doc = esm_package_json_cache_read(pkg_json_path);
+  yyjson_doc *doc = esm_package_json_cache_read(js, pkg_json_path);
   yyjson_val *root = doc ? yyjson_doc_get_root(doc) : NULL;
   yyjson_val *exports = (root && yyjson_is_obj(root)) ? yyjson_obj_get(root, "exports") : NULL;
 
@@ -843,25 +840,25 @@ static char *esm_resolve_package_entrypoint(const char *package_dir, const char 
         const char *key = yyjson_get_str(k);
         if (key && key[0] == '.') { has_subpath_keys = true; break; }
       }
-      if (has_subpath_keys) resolved = esm_resolve_package_map(exports, subpath_key, package_dir, base_path, false, prefer_require);
-      else if (!subpath || !subpath[0]) resolved = esm_resolve_exports_target(exports, package_dir, "", 0, base_path, false, prefer_require);
-    } else if (!subpath || !subpath[0]) resolved = esm_resolve_exports_target(exports, package_dir, "", 0, base_path, false, prefer_require);
+      if (has_subpath_keys) resolved = esm_resolve_package_map(js, exports, subpath_key, package_dir, base_path, false, prefer_require);
+      else if (!subpath || !subpath[0]) resolved = esm_resolve_exports_target(js, exports, package_dir, "", 0, base_path, false, prefer_require);
+    } else if (!subpath || !subpath[0]) resolved = esm_resolve_exports_target(js, exports, package_dir, "", 0, base_path, false, prefer_require);
 
     return resolved;
   }
 
   if (!subpath || !subpath[0]) {
-    char *resolved = esm_resolve_package_main_entry(root, package_dir);
+    char *resolved = esm_resolve_package_main_entry(js, root, package_dir);
     if (resolved) return resolved;
-    return esm_try_resolve_index_with_exts(package_dir, ".");
+    return esm_try_resolve_index_with_exts(js, package_dir, ".");
   }
 
-  char *resolved = esm_try_resolve_with_exts(package_dir, subpath, esm_has_extension(subpath));
-  if (!resolved) resolved = esm_try_resolve_index_with_exts(package_dir, subpath);
+  char *resolved = esm_try_resolve_with_exts(js, package_dir, subpath, esm_has_extension(subpath));
+  if (!resolved) resolved = esm_try_resolve_index_with_exts(js, package_dir, subpath);
   return resolved;
 }
 
-static yyjson_doc *esm_find_nearest_package_json(const char *start_dir, char *scope_dir, size_t scope_dir_size, bool stop_at_node_modules) {
+static yyjson_doc *esm_find_nearest_package_json(ant_t *js, const char *start_dir, char *scope_dir, size_t scope_dir_size, bool stop_at_node_modules) {
   if (!start_dir || !start_dir[0]) return NULL;
 
   char current[PATH_MAX];
@@ -877,7 +874,7 @@ static yyjson_doc *esm_find_nearest_package_json(const char *start_dir, char *sc
     char pkg_json_path[PATH_MAX];
     snprintf(pkg_json_path, sizeof(pkg_json_path), "%s/package.json", current);
 
-    yyjson_doc *doc = esm_package_json_cache_read(pkg_json_path);
+    yyjson_doc *doc = esm_package_json_cache_read(js, pkg_json_path);
     if (doc) {
       if (scope_dir && scope_dir_size) snprintf(scope_dir, scope_dir_size, "%s", current);
       return doc;
@@ -889,12 +886,12 @@ static yyjson_doc *esm_find_nearest_package_json(const char *start_dir, char *sc
   return NULL;
 }
 
-static char *esm_resolve_package_imports(const char *specifier, const char *base_path, bool prefer_require) {
-  char *start_dir = esm_get_base_dir(base_path);
+static char *esm_resolve_package_imports(ant_t *js, const char *specifier, const char *base_path, bool prefer_require) {
+  char *start_dir = esm_get_base_dir(js, base_path);
   if (!start_dir) return NULL;
 
   char scope_dir[PATH_MAX];
-  yyjson_doc *doc = esm_find_nearest_package_json(start_dir, scope_dir, sizeof(scope_dir), false);
+  yyjson_doc *doc = esm_find_nearest_package_json(js, start_dir, scope_dir, sizeof(scope_dir), false);
   free(start_dir);
   if (!doc) return NULL;
 
@@ -902,10 +899,11 @@ static char *esm_resolve_package_imports(const char *specifier, const char *base
   yyjson_val *imports = (root && yyjson_is_obj(root)) ? yyjson_obj_get(root, "imports") : NULL;
   if (!imports || !yyjson_is_obj(imports)) return NULL;
 
-  return esm_resolve_package_map(imports, specifier, scope_dir, base_path, true, prefer_require);
+  return esm_resolve_package_map(js, imports, specifier, scope_dir, base_path, true, prefer_require);
 }
 
 static char *esm_resolve_package_self_reference(
+  ant_t *js,
   const char *start_dir,
   const char *package_name,
   const char *subpath,
@@ -916,7 +914,7 @@ static char *esm_resolve_package_self_reference(
   *matched = false;
 
   char scope_dir[PATH_MAX];
-  yyjson_doc *doc = esm_find_nearest_package_json(start_dir, scope_dir, sizeof(scope_dir), true);
+  yyjson_doc *doc = esm_find_nearest_package_json(js, start_dir, scope_dir, sizeof(scope_dir), true);
   if (!doc) return NULL;
 
   yyjson_val *root = yyjson_doc_get_root(doc);
@@ -928,26 +926,26 @@ static char *esm_resolve_package_self_reference(
   if (!yyjson_obj_get(root, "exports")) return NULL;
 
   *matched = true;
-  return esm_resolve_package_entrypoint(scope_dir, subpath, base_path, prefer_require);
+  return esm_resolve_package_entrypoint(js, scope_dir, subpath, base_path, prefer_require);
 }
 
-static char *esm_resolve_node_module_cond(const char *specifier, const char *base_path, bool prefer_require) {
+static char *esm_resolve_node_module_cond(ant_t *js, const char *specifier, const char *base_path, bool prefer_require) {
   char package_name[PATH_MAX];
   const char *subpath = NULL;
   if (!esm_split_package_specifier(specifier, package_name, sizeof(package_name), &subpath)) {
     return NULL;
   }
 
-  char *start_dir = esm_get_base_dir(base_path);
+  char *start_dir = esm_get_base_dir(js, base_path);
   if (!start_dir) return NULL;
 
   bool self_matched = false;
-  char *resolved = esm_resolve_package_self_reference(start_dir, package_name, subpath, base_path, prefer_require, &self_matched);
-  
+  char *resolved = esm_resolve_package_self_reference(js, start_dir, package_name, subpath, base_path, prefer_require, &self_matched);
+
   if (!resolved && !self_matched) {
-    char *package_dir = esm_find_node_module_dir(start_dir, package_name);
+    char *package_dir = esm_find_node_module_dir(js, start_dir, package_name);
     if (package_dir) {
-      resolved = esm_resolve_package_entrypoint(package_dir, subpath, base_path, prefer_require);
+      resolved = esm_resolve_package_entrypoint(js, package_dir, subpath, base_path, prefer_require);
       free(package_dir);
     }
   }
@@ -956,11 +954,11 @@ static char *esm_resolve_node_module_cond(const char *specifier, const char *bas
   return resolved;
 }
 
-static char *esm_resolve_node_module(const char *specifier, const char *base_path) {
-  return esm_resolve_node_module_cond(specifier, base_path, false);
+static char *esm_resolve_node_module(ant_t *js, const char *specifier, const char *base_path) {
+  return esm_resolve_node_module_cond(js, specifier, base_path, false);
 }
 
-static char *esm_resolve_relative_path(const char *specifier, const char *base_path) {
+static char *esm_resolve_relative_path(ant_t *js, const char *specifier, const char *base_path) {
   char *base_copy = strdup(base_path);
   if (!base_copy) return NULL;
   char *dir = dirname(base_copy);
@@ -970,24 +968,24 @@ static char *esm_resolve_relative_path(const char *specifier, const char *base_p
   if (strncmp(specifier, "./", 2) == 0) spec = specifier + 2;
   
   bool has_ext = esm_has_extension(spec);
-  if ((result = esm_try_resolve(dir, spec, ""))) goto cleanup;
-  
+  if ((result = esm_try_resolve(js, dir, spec, ""))) goto cleanup;
+
   if (has_ext) {
-    result = esm_try_resolve_relative_typescript_source_fallback(dir, spec, base_path);
+    result = esm_try_resolve_relative_typescript_source_fallback(js, dir, spec, base_path);
     goto cleanup;
   }
 
   char *base_ext = esm_get_extension(base_path);
   if (!base_ext) goto cleanup;
 
-  if ((result = esm_try_resolve_from_extension_list(dir, spec, base_ext, base_ext))) goto cleanup_ext;
+  if ((result = esm_try_resolve_from_extension_list(js, dir, spec, base_ext, base_ext))) goto cleanup_ext;
 
   char idx[PATH_MAX];
   snprintf(idx, sizeof(idx), "%s/index%s", spec, base_ext);
-  if ((result = esm_try_resolve(dir, idx, ""))) goto cleanup_ext;
+  if ((result = esm_try_resolve(js, dir, idx, ""))) goto cleanup_ext;
 
   snprintf(idx, sizeof(idx), "%s/index", spec);
-  if ((result = esm_try_resolve_from_extension_list(dir, idx, base_ext, base_ext))) goto cleanup_ext;
+  if ((result = esm_try_resolve_from_extension_list(js, dir, idx, base_ext, base_ext))) goto cleanup_ext;
 
   cleanup_ext: {
     free(base_ext);
@@ -999,56 +997,56 @@ static char *esm_resolve_relative_path(const char *specifier, const char *base_p
   }
 }
 
-static char *esm_resolve_path_cond_uncached(const char *specifier, const char *base_path, bool prefer_require) {
+static char *esm_resolve_path_cond_uncached(ant_t *js, const char *specifier, const char *base_path, bool prefer_require) {
   if (!specifier || !specifier[0]) return NULL;
 
   if (esm_path_is_absolute(specifier)) {
-    return esm_resolve_absolute(specifier);
+    return esm_resolve_absolute(js, specifier);
   }
 
   if (esm_is_relative_specifier(specifier)) {
-    return esm_resolve_relative_path(specifier, base_path);
+    return esm_resolve_relative_path(js, specifier, base_path);
   }
 
   if (specifier[0] == '#') {
-    return esm_resolve_package_imports(specifier, base_path, prefer_require);
+    return esm_resolve_package_imports(js, specifier, base_path, prefer_require);
   }
 
-  return esm_resolve_node_module_cond(specifier, base_path, prefer_require);
+  return esm_resolve_node_module_cond(js, specifier, base_path, prefer_require);
 }
 
-static char *esm_resolve_path_cond(const char *specifier, const char *base_path, bool prefer_require) {
+static char *esm_resolve_path_cond(ant_t *js, const char *specifier, const char *base_path, bool prefer_require) {
   char *key = esm_make_resolve_cache_key(specifier, base_path, prefer_require);
-  if (!key) return esm_resolve_path_cond_uncached(specifier, base_path, prefer_require);
+  if (!key) return esm_resolve_path_cond_uncached(js, specifier, base_path, prefer_require);
 
-  char *cached = esm_resolve_cache_get(key);
+  char *cached = esm_resolve_cache_get(js, key);
   if (cached) {
     free(key);
     return cached;
   }
 
-  char *resolved = esm_resolve_path_cond_uncached(specifier, base_path, prefer_require);
+  char *resolved = esm_resolve_path_cond_uncached(js, specifier, base_path, prefer_require);
   if (!resolved) {
     free(key);
     return NULL;
   }
 
-  esm_resolve_cache_put(key, resolved);
+  esm_resolve_cache_put(js, key, resolved);
   free(key);
-  
+
   return resolved;
 }
 
-static char *esm_resolve_path(const char *specifier, const char *base_path) {
-  return esm_resolve_path_cond(specifier, base_path, false);
+static char *esm_resolve_path(ant_t *js, const char *specifier, const char *base_path) {
+  return esm_resolve_path_cond(js, specifier, base_path, false);
 }
 
-static char *esm_resolve_path_require(const char *specifier, const char *base_path) {
-  return esm_resolve_path_cond(specifier, base_path, true);
+static char *esm_resolve_path_require(ant_t *js, const char *specifier, const char *base_path) {
+  return esm_resolve_path_cond(js, specifier, base_path, true);
 }
 
-char *js_esm_resolve_path_for_watch(const char *specifier, const char *base_path, bool prefer_require) {
-  return esm_resolve(specifier, base_path, prefer_require ? esm_resolve_path_require : esm_resolve_path);
+char *js_esm_resolve_path_for_watch(ant_t *js, const char *specifier, const char *base_path, bool prefer_require) {
+  return esm_resolve(js, specifier, base_path, prefer_require ? esm_resolve_path_require : esm_resolve_path);
 }
 
 static bool esm_has_suffix(const char *path, const char *ext) {
@@ -1101,7 +1099,7 @@ static bool esm_path_contains_node_modules(const char *path) {
   return strstr(path, "\\node_modules\\") != NULL;
 }
 
-static bool esm_lookup_package_type(const char *resolved_path, esm_package_type_t *out_type) {
+static bool esm_lookup_package_type(ant_t *js, const char *resolved_path, esm_package_type_t *out_type) {
   if (out_type) *out_type = ESM_PACKAGE_TYPE_NONE;
   if (!resolved_path || !resolved_path[0]) return false;
 
@@ -1110,7 +1108,7 @@ static bool esm_lookup_package_type(const char *resolved_path, esm_package_type_
   char *dir = dirname(path_copy);
   if (!dir || !dir[0]) return false;
 
-  yyjson_doc *doc = esm_find_nearest_package_json(dir, NULL, 0, false);
+  yyjson_doc *doc = esm_find_nearest_package_json(js, dir, NULL, 0, false);
   if (!doc) return false;
 
   yyjson_val *root = yyjson_doc_get_root(doc);
@@ -1128,14 +1126,14 @@ static bool esm_lookup_package_type(const char *resolved_path, esm_package_type_
   return true;
 }
 
-static ant_module_format_t esm_decide_module_format(const char *resolved_path) {
+static ant_module_format_t esm_decide_module_format(ant_t *js, const char *resolved_path) {
   if (!resolved_path || !resolved_path[0]) return MODULE_EVAL_FORMAT_ESM;
   if (esm_is_cjs_extension(resolved_path)) return MODULE_EVAL_FORMAT_CJS;
   if (esm_is_esm_extension(resolved_path)) return MODULE_EVAL_FORMAT_ESM;
 
   if (esm_has_suffix(resolved_path, ".js")) {
     esm_package_type_t pkg_type = ESM_PACKAGE_TYPE_NONE;
-    (void)esm_lookup_package_type(resolved_path, &pkg_type);
+    (void)esm_lookup_package_type(js, resolved_path, &pkg_type);
     if (pkg_type == ESM_PACKAGE_TYPE_MODULE) return MODULE_EVAL_FORMAT_ESM;
     if (pkg_type == ESM_PACKAGE_TYPE_COMMONJS) return MODULE_EVAL_FORMAT_CJS;
     return MODULE_EVAL_FORMAT_UNKNOWN;
@@ -1161,13 +1159,13 @@ static ant_value_t esm_eval_ambiguous_js_source(
     js->thrown_value = saved_thrown_value;
     js->thrown_stack = saved_thrown_stack;
     *format = MODULE_EVAL_FORMAT_CJS;
-    if (js->module) js->module->format = *format;
+    if (js->esm.module_stack) js->esm.module_stack->format = *format;
     return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns);
   }
 
   if (program->flags & FN_MODULE_SYNTAX) {
     *format = MODULE_EVAL_FORMAT_ESM;
-    if (js->module) js->module->format = *format;
+    if (js->esm.module_stack) js->esm.module_stack->format = *format;
     
     sv_func_t *func = js_compile_parsed_bytecode(
       js, program, js_code, 
@@ -1184,7 +1182,7 @@ static ant_value_t esm_eval_ambiguous_js_source(
 
   parse_arena_rewind(parse_mark);
   *format = MODULE_EVAL_FORMAT_CJS;
-  if (js->module) js->module->format = *format;
+  if (js->esm.module_stack) js->esm.module_stack->format = *format;
   return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns);
 }
 
@@ -1207,12 +1205,12 @@ ant_value_t js_esm_eval_module_source(
   const char *resolved_path, const char *js_code,
   size_t js_len, ant_value_t ns
 ) {
-  ant_module_format_t format = esm_decide_module_format(resolved_path);
+  ant_module_format_t format = esm_decide_module_format(js, resolved_path);
   ant_module_t eval_ctx;
   
   ant_value_t prep_res = esm_prepare_eval_ctx(
     js, resolved_path, ns, format, 
-    js->module == NULL, NULL, &eval_ctx
+    js->esm.module_stack == NULL, NULL, &eval_ctx
   );
   
   if (is_err(prep_res)) return prep_res;
@@ -1237,18 +1235,22 @@ static esm_module_kind_t esm_classify_module_kind(const char *resolved_path) {
   return ESM_MODULE_KIND_CODE;
 }
 
-static esm_module_t *esm_find_module(const char *module_key) {
+static esm_module_t *esm_find_module(ant_t *js, const char *module_key) {
+  ant_esm_state_t *st = js->esm.state;
+  if (!st) return NULL;
+
   char *cache_key = esm_make_cache_key(module_key);
   if (!cache_key) return NULL;
 
   esm_module_t *mod = NULL;
-  HASH_FIND_STR(global_module_cache.modules, cache_key, mod);
+  HASH_FIND_STR(st->modules, cache_key, mod);
 
   free(cache_key);
   return mod;
 }
 
 static esm_module_t *esm_create_module(
+  ant_t *js,
   const char *path,
   const char *resolved_path,
   const char *module_key,
@@ -1256,11 +1258,14 @@ static esm_module_t *esm_create_module(
   const uint8_t *embedded_code,
   size_t embedded_code_len
 ) {
+  ant_esm_state_t *st = esm_state(js);
+  if (!st) return NULL;
+
   char *cache_key = esm_make_cache_key(module_key);
   if (!cache_key) return NULL;
 
   esm_module_t *existing_mod = NULL;
-  HASH_FIND_STR(global_module_cache.modules, cache_key, existing_mod);
+  HASH_FIND_STR(st->modules, cache_key, existing_mod);
   if (existing_mod) {
     free(cache_key);
     return existing_mod;
@@ -1298,25 +1303,28 @@ static esm_module_t *esm_create_module(
     return NULL;
   }
   
-  HASH_ADD_STR(global_module_cache.modules, cache_key, mod);
-  global_module_cache.count++;
+  HASH_ADD_STR(st->modules, cache_key, mod);
+  st->module_count++;
 
   return mod;
 }
 
-void js_esm_cleanup_module_cache(void) {
-  esm_module_t *current, *tmp;
-  HASH_ITER(hh, global_module_cache.modules, current, tmp) {
-    HASH_DEL(global_module_cache.modules, current);
-    if (current->path) free(current->path);
-    if (current->cache_key) free(current->cache_key);
-    if (current->resolved_path) free(current->resolved_path);
-    if (current->url_content) free(current->url_content);
-    free(current);
+void js_esm_cleanup_module_cache(ant_t *js) {
+  ant_esm_state_t *st = js ? js->esm.state : NULL;
+  if (st) {
+    esm_module_t *current, *tmp;
+    HASH_ITER(hh, st->modules, current, tmp) {
+      HASH_DEL(st->modules, current);
+      if (current->path) free(current->path);
+      if (current->cache_key) free(current->cache_key);
+      if (current->resolved_path) free(current->resolved_path);
+      if (current->url_content) free(current->url_content);
+      free(current);
+    }
+    st->module_count = 0;
   }
-  global_module_cache.count = 0;
 
-  esm_loader_cache_cleanup();
+  esm_loader_cache_cleanup(js);
 }
 
 static ant_value_t esm_read_file(ant_t *js, const char *path, const char *kind, esm_file_data_t *out) {
@@ -1493,9 +1501,10 @@ static ant_value_t esm_load_static_dependency(
       return js_mkerr(js, "Invalid builtin module id");
     }
 
-    esm_module_t *dep = esm_find_module(bundle->source_name);
+    esm_module_t *dep = esm_find_module(js, bundle->source_name);
     if (!dep) {
       dep = esm_create_module(
+        js,
         specifier,
         bundle->source_name,
         bundle->source_name,
@@ -1519,16 +1528,17 @@ static ant_value_t esm_load_static_dependency(
     return js_mkundef();
   }
 
-  char *resolved_path = esm_resolve(specifier, parent->resolved_path, esm_resolve_path);
+  char *resolved_path = esm_resolve(js, specifier, parent->resolved_path, esm_resolve_path);
   if (!resolved_path) {
     ant_value_t err = js_mkerr(js, "Cannot resolve module: %s", specifier);
     free(specifier);
     return err;
   }
 
-  esm_module_t *dep = esm_find_module(resolved_path);
+  esm_module_t *dep = esm_find_module(js, resolved_path);
   if (!dep) {
     dep = esm_create_module(
+      js,
       specifier,
       resolved_path,
       resolved_path,
@@ -1680,7 +1690,7 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
   
   char *js_code = content;
   if (mod->format == MODULE_EVAL_FORMAT_UNKNOWN)
-    mod->format = esm_decide_module_format(mod->resolved_path);
+    mod->format = esm_decide_module_format(js, mod->resolved_path);
 
   esm_module_record_t record;
   ant_value_t parse_res = esm_parse_module_record(
@@ -1732,7 +1742,7 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
   
   free(content);
   if (vtype(result) == T_PROMISE) {
-  if (esm_dynamic_import_depth > 0) {
+  if (js->esm.state && js->esm.state->dynamic_import_depth > 0) {
     mod->has_tla = true;
     mod->tla_promise = result;
   } else js_run_event_loop(js); }
@@ -1756,9 +1766,10 @@ static ant_value_t esm_get_or_load(
   const uint8_t *embedded_code,
   size_t embedded_code_len
 ) {
-  esm_module_t *mod = esm_find_module(module_key);
+  esm_module_t *mod = esm_find_module(js, module_key);
   if (!mod) {
     mod = esm_create_module(
+      js,
       specifier,
       resolved_path,
       module_key,
@@ -1852,7 +1863,7 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
   ant_value_t out = js_mkobj(js);
   if (!esm_lookup_builtin_alias(spec_copy, strlen(spec_copy))) {
     if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
-    char *resolved = esm_resolve(spec_copy, base_path, esm_resolve_path);
+    char *resolved = esm_resolve(js, spec_copy, base_path, esm_resolve_path);
 
     if (resolved) {
       size_t url_len = strlen(resolved) + 8;
@@ -1918,7 +1929,7 @@ static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant
   js_set(js, out, "source", js_mkstr(js, file.data, file.size));
 
   if (esm_is_json(path)) js_set(js, out, "format", js_mkstr(js, "json", 4));
-  else js_set(js, out, "format", esm_decide_module_format(path) == MODULE_EVAL_FORMAT_CJS
+  else js_set(js, out, "format", esm_decide_module_format(js, path) == MODULE_EVAL_FORMAT_CJS
     ? js_mkstr(js, "commonjs", 8)
     : js_mkstr(js, "module", 6));
 
@@ -1933,6 +1944,7 @@ static ant_value_t esm_import_via_hooks(
   size_t spec_len,
   const char *base_path,
   ant_value_t attrs,
+  bool is_require,
   bool *handled
 ) {
   *handled = false;
@@ -1954,7 +1966,8 @@ static ant_value_t esm_import_via_hooks(
   }
 
   ant_value_t conditions = js_mkarr(js);
-  js_arr_push(js, conditions, js_mkstr(js, "import", 6));
+  if (is_require) js_arr_push(js, conditions, js_mkstr(js, "require", 7));
+  else js_arr_push(js, conditions, js_mkstr(js, "import", 6));
   js_arr_push(js, conditions, js_mkstr(js, "node", 4));
   js_arr_push(js, conditions, js_mkstr(js, "default", 7));
   js_set(js, ctx, "conditions", conditions);
@@ -2004,7 +2017,7 @@ static ant_value_t esm_import_via_hooks(
     if (strcmp(fmt_str, "commonjs") == 0) format = MODULE_EVAL_FORMAT_CJS;
     else if (strcmp(fmt_str, "module") == 0) format = MODULE_EVAL_FORMAT_ESM;
   }
-  if (format == MODULE_EVAL_FORMAT_UNKNOWN) format = esm_decide_module_format(fs_path);
+  if (format == MODULE_EVAL_FORMAT_UNKNOWN) format = esm_decide_module_format(js, fs_path);
 
   const uint8_t *source = NULL;
   size_t source_len = 0;
@@ -2032,18 +2045,16 @@ static ant_value_t esm_import_via_hooks(
   return ns;
 }
 
-ant_value_t js_esm_import_sync_cstr_from(
+static ant_value_t esm_import_cstr_attrs(
   ant_t *js,
   const char *specifier,
   size_t spec_len,
-  const char *base_path
+  const char *base_path,
+  ant_value_t attrs
 ) {
   if (esm_hooks_present(js)) {
-    ant_value_t attrs = js->esm.import_attributes;
-    js->esm.import_attributes = js_mkundef();
-
     bool handled = false;
-    ant_value_t ns = esm_import_via_hooks(js, specifier, spec_len, base_path, attrs, &handled);
+    ant_value_t ns = esm_import_via_hooks(js, specifier, spec_len, base_path, attrs, false, &handled);
     if (handled) return ns;
   }
   const ant_builtin_bundle_alias_t *bundle = NULL;
@@ -2088,7 +2099,7 @@ ant_value_t js_esm_import_sync_cstr_from(
   }
 
   if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
-  char *resolved_path = esm_resolve(spec_copy, base_path, esm_resolve_path);
+  char *resolved_path = esm_resolve(js, spec_copy, base_path, esm_resolve_path);
   if (!resolved_path) {
     ant_value_t err = js_mkerr(js, "Cannot resolve module: %s", spec_copy);
     free(spec_copy);
@@ -2107,6 +2118,15 @@ ant_value_t js_esm_import_sync_cstr_from(
   free(resolved_path);
   free(spec_copy);
   return ns;
+}
+
+ant_value_t js_esm_import_sync_cstr_from(
+  ant_t *js,
+  const char *specifier,
+  size_t spec_len,
+  const char *base_path
+) {
+  return esm_import_cstr_attrs(js, specifier, spec_len, base_path, js_mkundef());
 }
 
 static ant_value_t esm_module_not_found_error(
@@ -2129,6 +2149,11 @@ ant_value_t js_esm_import_sync_cstr_from_require(
   size_t spec_len,
   const char *base_path
 ) {
+  if (esm_hooks_present(js)) {
+    bool handled = false;
+    ant_value_t ns = esm_import_via_hooks(js, specifier, spec_len, base_path, js_mkundef(), true, &handled);
+    if (handled) return ns;
+  }
   const ant_builtin_bundle_alias_t *bundle = NULL;
   const ant_builtin_bundle_module_t *module = NULL;
 
@@ -2171,7 +2196,7 @@ ant_value_t js_esm_import_sync_cstr_from_require(
   }
 
   if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
-  char *resolved_path = esm_resolve(spec_copy, base_path, esm_resolve_path_require);
+  char *resolved_path = esm_resolve(js, spec_copy, base_path, esm_resolve_path_require);
   if (!resolved_path) {
     ant_value_t err = esm_module_not_found_error(js, spec_copy);
     free(spec_copy);
@@ -2196,7 +2221,7 @@ ant_value_t js_esm_import_sync_cstr(ant_t *js, const char *specifier, size_t spe
   return js_esm_import_sync_cstr_from(js, specifier, spec_len, NULL);
 }
 
-ant_value_t js_esm_import_sync_from(ant_t *js, ant_value_t specifier, const char *base_path) {
+static ant_value_t esm_import_from_attrs(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t attrs) {
   if (vtype(specifier) != T_STR)
     return js_mkerr(js, "import() requires a string specifier");
 
@@ -2204,7 +2229,11 @@ ant_value_t js_esm_import_sync_from(ant_t *js, ant_value_t specifier, const char
   ant_offset_t spec_off = vstr(js, specifier, &spec_len);
   const char *spec_str = (const char *)(uintptr_t)(spec_off);
 
-  return js_esm_import_sync_cstr_from(js, spec_str, (size_t)spec_len, base_path);
+  return esm_import_cstr_attrs(js, spec_str, (size_t)spec_len, base_path, attrs);
+}
+
+ant_value_t js_esm_import_sync_from(ant_t *js, ant_value_t specifier, const char *base_path) {
+  return esm_import_from_attrs(js, specifier, base_path, js_mkundef());
 }
 
 ant_value_t js_esm_import_sync_from_require(ant_t *js, ant_value_t specifier, const char *base_path) {
@@ -2222,30 +2251,28 @@ ant_value_t js_esm_import_sync(ant_t *js, ant_value_t specifier) {
   return js_esm_import_sync_from(js, specifier, NULL);
 }
 
-ant_value_t js_esm_import_dynamic_ex(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t attrs, ant_value_t *out_tla_promise) {
-  js->esm.import_attributes = attrs;
-  ant_value_t ns = js_esm_import_dynamic(js, specifier, base_path, out_tla_promise);
-  js->esm.import_attributes = js_mkundef();
-  return ns;
+ant_value_t js_esm_import_dynamic(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t *out_tla_promise) {
+  return js_esm_import_dynamic_ex(js, specifier, base_path, js_mkundef(), out_tla_promise);
 }
 
-ant_value_t js_esm_import_dynamic(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t *out_tla_promise) {
+ant_value_t js_esm_import_dynamic_ex(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t attrs, ant_value_t *out_tla_promise) {
   *out_tla_promise = js_mkundef();
-  esm_dynamic_import_depth++;
-  
-  ant_value_t ns = js_esm_import_sync_from(js, specifier, base_path);
-  esm_dynamic_import_depth--;
+  ant_esm_state_t *st = esm_state(js);
+  if (st) st->dynamic_import_depth++;
+
+  ant_value_t ns = esm_import_from_attrs(js, specifier, base_path, attrs);
+  if (st) st->dynamic_import_depth--;
   if (is_err(ns)) return ns;
 
   esm_module_t *mod = NULL, *tmp = NULL;
-  HASH_ITER(hh, global_module_cache.modules, mod, tmp) {
+  if (st) HASH_ITER(hh, st->modules, mod, tmp) {
   if (mod->has_tla && mod->namespace_obj == ns) {
     *out_tla_promise = mod->tla_promise;
     mod->has_tla = false;
     mod->tla_promise = js_mkundef();
     break;
   }}
-  
+
   return ns;
 }
 
@@ -2290,8 +2317,11 @@ ant_value_t js_esm_make_file_url(ant_t *js, const char *path) {
 }
 
 void gc_mark_esm(ant_t *js, gc_mark_fn mark) {
+ant_esm_state_t *st = js->esm.state;
+if (!st) return;
+
 esm_module_t *mod = NULL, *tmp = NULL;
-HASH_ITER(hh, global_module_cache.modules, mod, tmp) {
+HASH_ITER(hh, st->modules, mod, tmp) {
   mark(js, mod->namespace_obj);
   mark(js, mod->default_export);
   if (mod->has_tla) mark(js, mod->tla_promise);
@@ -2324,7 +2354,7 @@ ant_value_t js_esm_resolve_specifier(ant_t *js, ant_value_t specifier, const cha
   }
 
   if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
-  char *resolved_path = esm_resolve(spec_copy, base_path, esm_resolve_path);
+  char *resolved_path = esm_resolve(js, spec_copy, base_path, esm_resolve_path);
   free(spec_copy);
 
   if (!resolved_path) {
@@ -2369,7 +2399,7 @@ ant_value_t js_esm_resolve_specifier_require(ant_t *js, ant_value_t specifier, c
   }
 
   if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
-  char *resolved_path = esm_resolve(spec_copy, base_path, esm_resolve_path_require);
+  char *resolved_path = esm_resolve(js, spec_copy, base_path, esm_resolve_path_require);
 
   if (!resolved_path) {
     ant_value_t err = esm_module_not_found_error(js, spec_copy);

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -65,6 +65,7 @@ typedef struct esm_module {
   bool is_loaded;
   bool is_loading;
   bool has_tla;
+  bool owns_embedded;
 } esm_module_t;
 
 typedef struct {
@@ -447,20 +448,29 @@ static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_v
     return value;
   }
 
+  GC_ROOT_SAVE(root_mark, js);
+  GC_ROOT_PIN(js, value);
+
   ant_value_t ns = js_mkobj(js);
+  GC_ROOT_PIN(js, ns);
   js_set_slot(ns, SLOT_BRAND, js_mknum(BRAND_MODULE_NAMESPACE));
-  
+
   if (is_object_type(value)) {
     ant_value_t keys = js_own_property_keys(js, value, false, true);
+    GC_ROOT_PIN(js, keys);
+
+    ant_value_t key = js_mkundef();
+    GC_ROOT_PIN(js, key);
+
     ant_offset_t len = js_arr_len(js, keys);
     for (ant_offset_t i = 0; i < len; i++) {
-      ant_value_t key = js_arr_get(js, keys, i);
+      key = js_arr_get(js, keys, i);
       if (vtype(key) != T_STR) continue;
       const char *key_str = js_getstr(js, key, NULL);
       js_setprop(js, ns, key, js_get(js, value, key_str));
     }
   }
-  
+
   js_set(js, ns, "default", value);
   js_set_slot(ns, SLOT_DEFAULT, value);
 
@@ -468,7 +478,8 @@ static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_v
   mod->default_export = value;
   mod->is_loaded = true;
   mod->is_loading = false;
-  
+
+  GC_ROOT_RESTORE(js, root_mark);
   return ns;
 }
 
@@ -1258,7 +1269,9 @@ static esm_module_t *esm_create_module(
   const char *module_key,
   ant_module_format_t format,
   const uint8_t *embedded_code,
-  size_t embedded_code_len
+  size_t embedded_code_len,
+  bool copy_embedded,
+  int kind_hint
 ) {
   ant_esm_state_t *st = esm_state(js);
   if (!st) return NULL;
@@ -1279,6 +1292,19 @@ static esm_module_t *esm_create_module(
     return NULL;
   }
 
+  bool owns_embedded = false;
+  if (embedded_code && copy_embedded) {
+    uint8_t *copy = (uint8_t *)malloc(embedded_code_len);
+    if (!copy) {
+      free(cache_key);
+      free(mod);
+      return NULL;
+    }
+    memcpy(copy, embedded_code, embedded_code_len);
+    embedded_code = copy;
+    owns_embedded = true;
+  }
+
   *mod = (esm_module_t){
     .path = strdup(path),
     .cache_key = cache_key,
@@ -1287,7 +1313,7 @@ static esm_module_t *esm_create_module(
     .default_export = js_mkundef(),
     .is_loaded = false,
     .is_loading = false,
-    .kind = esm_classify_module_kind(resolved_path),
+    .kind = kind_hint >= 0 ? (esm_module_kind_t)kind_hint : esm_classify_module_kind(resolved_path),
     .format = format,
     .url_content = NULL,
     .url_content_len = 0,
@@ -1295,16 +1321,18 @@ static esm_module_t *esm_create_module(
     .embedded_code_len = embedded_code_len,
     .tla_promise = js_mkundef(),
     .has_tla = false,
+    .owns_embedded = owns_embedded,
   };
-  
+
   if (!mod->path || !mod->resolved_path) {
+    if (owns_embedded) free((void *)mod->embedded_code);
     free(mod->path);
     free(mod->cache_key);
     free(mod->resolved_path);
     free(mod);
     return NULL;
   }
-  
+
   HASH_ADD_STR(st->modules, cache_key, mod);
   st->module_count++;
 
@@ -1321,6 +1349,7 @@ void js_esm_cleanup_module_cache(ant_t *js) {
       if (current->cache_key) free(current->cache_key);
       if (current->resolved_path) free(current->resolved_path);
       if (current->url_content) free(current->url_content);
+      if (current->owns_embedded) free((void *)current->embedded_code);
       free(current);
     }
     st->module_count = 0;
@@ -1541,7 +1570,8 @@ static ant_value_t esm_load_static_dependency(
         bundle->source_name,
         module->format,
         module->code,
-        module->code_len
+        module->code_len,
+        false, -1
       );
       if (!dep) {
         free(specifier);
@@ -1574,7 +1604,8 @@ static ant_value_t esm_load_static_dependency(
       resolved_path,
       resolved_path,
       MODULE_EVAL_FORMAT_UNKNOWN,
-      NULL, 0
+      NULL, 0,
+      false, -1
     );
     if (!dep) {
       free(resolved_path);
@@ -1780,14 +1811,16 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
   return esm_complete_namespace_module(js, mod, ns);
 }
 
-static ant_value_t esm_get_or_load(
+static ant_value_t esm_get_or_load_ex(
   ant_t *js,
   const char *specifier,
   const char *resolved_path,
   const char *module_key,
   ant_module_format_t format,
   const uint8_t *embedded_code,
-  size_t embedded_code_len
+  size_t embedded_code_len,
+  bool copy_embedded,
+  int kind_hint
 ) {
   esm_module_t *mod = esm_find_module(js, module_key);
   if (!mod) {
@@ -1798,11 +1831,29 @@ static ant_value_t esm_get_or_load(
       module_key,
       format,
       embedded_code,
-      embedded_code_len
+      embedded_code_len,
+      copy_embedded,
+      kind_hint
     );
     if (!mod) return js_mkerr(js, "Cannot create module");
   }
   return esm_load_module(js, mod);
+}
+
+static ant_value_t esm_get_or_load(
+  ant_t *js,
+  const char *specifier,
+  const char *resolved_path,
+  const char *module_key,
+  ant_module_format_t format,
+  const uint8_t *embedded_code,
+  size_t embedded_code_len
+) {
+  return esm_get_or_load_ex(
+    js, specifier, resolved_path, module_key,
+    format, embedded_code, embedded_code_len,
+    false, -1
+  );
 }
 
 static const char *esm_default_base_path(ant_t *js) {
@@ -1818,19 +1869,32 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
 static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant_value_t ctx);
 
 static ant_value_t esm_hook_make_next(ant_t *js, ant_value_t next_fn, int level, ant_value_t ctx, const char *base_path) {
+  GC_ROOT_SAVE(root_mark, js);
+
   ant_value_t data = js_mkobj(js);
+  GC_ROOT_PIN(js, data);
   js_set(js, data, "level", js_mknum((double)level));
   js_set(js, data, "ctx", ctx);
   js_set(js, data, "base", base_path ? js_mkstr(js, base_path, strlen(base_path)) : js_mkundef());
 
   ant_value_t obj = js_mkobj(js);
+  GC_ROOT_PIN(js, obj);
   js_set_slot(obj, SLOT_CFUNC, next_fn);
   js_set_slot(obj, SLOT_DATA, data);
-  return js_obj_to_func(js, obj);
+
+  ant_value_t fn = js_obj_to_func(js, obj);
+  GC_ROOT_RESTORE(js, root_mark);
+  return fn;
+}
+
+static bool esm_hook_next_was_called(ant_t *js, ant_value_t next) {
+  ant_value_t data = js_get_slot(next, SLOT_DATA);
+  return js_truthy(js, js_get(js, data, "called"));
 }
 
 static ant_value_t builtin_esm_next_resolve(ant_t *js, ant_value_t *args, int nargs) {
   ant_value_t data = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  js_set(js, data, "called", js_true);
   int level = (int)js_getnum(js_get(js, data, "level"));
 
   ant_value_t base_val = js_get(js, data, "base");
@@ -1843,6 +1907,7 @@ static ant_value_t builtin_esm_next_resolve(ant_t *js, ant_value_t *args, int na
 
 static ant_value_t builtin_esm_next_load(ant_t *js, ant_value_t *args, int nargs) {
   ant_value_t data = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  js_set(js, data, "called", js_true);
   int level = (int)js_getnum(js_get(js, data, "level"));
 
   ant_value_t url = nargs > 0 ? args[0] : js_mkundef();
@@ -1861,13 +1926,22 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
     ant_value_t fn = js_get(js, hook, "resolve");
     if (vtype(fn) != T_FUNC && vtype(fn) != T_CFUNC) continue;
 
+    GC_ROOT_SAVE(root_mark, js);
     ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_resolve), level - 1, ctx, base_path);
+    GC_ROOT_PIN(js, next);
+
     ant_value_t call_args[3] = { spec, ctx, next };
     ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), call_args, 3, NULL, false);
+    GC_ROOT_PIN(js, result);
 
-    if (is_err(result)) return result;
-    if (!is_object_type(result))
-      return js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook must return an object");
+    if (!is_err(result)) {
+      if (!is_object_type(result))
+        result = js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook must return an object");
+      else if (!esm_hook_next_was_called(js, next) && !js_truthy(js, js_get(js, result, "shortCircuit")))
+        result = js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook must call nextResolve() or set shortCircuit: true");
+    }
+
+    GC_ROOT_RESTORE(js, root_mark);
     return result;
   }
 
@@ -1877,8 +1951,11 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
   char *spec_copy = strndup((const char *)(uintptr_t)soff, (size_t)slen);
   if (!spec_copy) return js_mkerr(js, "oom");
 
+  char *url_suffix = NULL;
   char *file_url_path = esm_file_url_to_path(js, spec_copy);
   if (file_url_path) {
+    const char *suffix = spec_copy + strcspn(spec_copy, "?#");
+    if (*suffix) url_suffix = strdup(suffix);
     free(spec_copy);
     spec_copy = file_url_path;
   }
@@ -1893,24 +1970,27 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
     char *resolved = esm_resolve(js, spec_copy, base_path, esm_resolve_path);
 
     if (resolved) {
-      size_t url_len = strlen(resolved) + 8;
+      size_t url_len = strlen(resolved) + (url_suffix ? strlen(url_suffix) : 0) + 8;
       char *url = malloc(url_len);
       if (!url) {
         free(resolved);
         free(spec_copy);
+        free(url_suffix);
         return js_mkerr(js, "oom");
       }
-      snprintf(url, url_len, "file://%s", resolved);
+      snprintf(url, url_len, "file://%s%s", resolved, url_suffix ? url_suffix : "");
       js_set(js, out, "url", js_mkstr(js, url, strlen(url)));
       free(url);
       free(resolved);
       free(spec_copy);
+      free(url_suffix);
       return out;
     }
   }
 
   js_set(js, out, "url", spec);
   free(spec_copy);
+  free(url_suffix);
   return out;
 }
 
@@ -1925,13 +2005,22 @@ static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant
     ant_value_t fn = js_get(js, hook, "load");
     if (vtype(fn) != T_FUNC && vtype(fn) != T_CFUNC) continue;
 
+    GC_ROOT_SAVE(root_mark, js);
     ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_load), level - 1, ctx, NULL);
+    GC_ROOT_PIN(js, next);
+
     ant_value_t call_args[3] = { url, ctx, next };
     ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), call_args, 3, NULL, false);
+    GC_ROOT_PIN(js, result);
 
-    if (is_err(result)) return result;
-    if (!is_object_type(result))
-      return js_mkerr_typed(js, JS_ERR_TYPE, "load hook must return an object");
+    if (!is_err(result)) {
+      if (!is_object_type(result))
+        result = js_mkerr_typed(js, JS_ERR_TYPE, "load hook must return an object");
+      else if (!esm_hook_next_was_called(js, next) && !js_truthy(js, js_get(js, result, "shortCircuit")))
+        result = js_mkerr_typed(js, JS_ERR_TYPE, "load hook must call nextLoad() or set shortCircuit: true");
+    }
+
+    GC_ROOT_RESTORE(js, root_mark);
     return result;
   }
 
@@ -1943,7 +2032,7 @@ static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant
 
   char *path = esm_file_url_to_path(js, url_copy);
   free(url_copy);
-  if (!path) return js_mkerr(js, "load hook: unsupported url");
+  if (!path) return js_mkobj(js);
 
   esm_file_data_t file = {0};
   ant_value_t err = esm_read_file(js, path, "module source", &file);
@@ -1965,6 +2054,7 @@ static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant
   return out;
 }
 
+
 static ant_value_t esm_import_via_hooks(
   ant_t *js,
   const char *specifier,
@@ -1983,12 +2073,16 @@ static ant_value_t esm_import_via_hooks(
   GC_ROOT_PIN(js, ctx);
 
   if (base_path && base_path[0]) {
-    size_t purl_len = strlen(base_path) + 8;
-    char *purl = malloc(purl_len);
-    if (purl) {
-      snprintf(purl, purl_len, "file://%s", base_path);
-      js_set(js, ctx, "parentURL", js_mkstr(js, purl, strlen(purl)));
-      free(purl);
+    if (esm_is_url(base_path) || strncmp(base_path, "file://", 7) == 0) {
+      js_set(js, ctx, "parentURL", js_mkstr(js, base_path, strlen(base_path)));
+    } else {
+      size_t purl_len = strlen(base_path) + 8;
+      char *purl = malloc(purl_len);
+      if (purl) {
+        snprintf(purl, purl_len, "file://%s", base_path);
+        js_set(js, ctx, "parentURL", js_mkstr(js, purl, strlen(purl)));
+        free(purl);
+      }
     }
   }
 
@@ -2021,28 +2115,23 @@ static ant_value_t esm_import_via_hooks(
     return js_mkundef();
   }
 
-  bool is_file_url = strncmp(js_getstr(js, url_val, NULL), "file://", 7) == 0;
-
   ant_value_t loaded = esm_run_load_chain(js, top, url_val, ctx);
   GC_ROOT_PIN(js, loaded);
 
   if (is_err(loaded)) {
-    if (!is_file_url) {
-      js_take_thrown(js, js_mkundef());
-      GC_ROOT_RESTORE(js, root_mark);
-      return js_mkundef();
-    }
     *handled = true;
     GC_ROOT_RESTORE(js, root_mark);
     return loaded;
   }
 
   ant_module_format_t format = MODULE_EVAL_FORMAT_UNKNOWN;
+  int kind_hint = -1;
   ant_value_t fmt_val = js_get(js, loaded, "format");
   if (vtype(fmt_val) == T_STR) {
     const char *fmt_str = js_getstr(js, fmt_val, NULL);
     if (strcmp(fmt_str, "commonjs") == 0) format = MODULE_EVAL_FORMAT_CJS;
     else if (strcmp(fmt_str, "module") == 0) format = MODULE_EVAL_FORMAT_ESM;
+    else if (strcmp(fmt_str, "json") == 0) kind_hint = ESM_MODULE_KIND_JSON;
   }
 
   const uint8_t *source = NULL;
@@ -2064,18 +2153,18 @@ static ant_value_t esm_import_via_hooks(
       return js_mkundef();
     }
     *handled = true;
-    ant_value_t ns = esm_get_or_load(js, specifier, url, url, format, source, source_len);
+    ant_value_t ns = esm_get_or_load_ex(js, specifier, url, url, format, source, source_len, true, kind_hint);
     GC_ROOT_RESTORE(js, root_mark);
     return ns;
   }
 
-  if (esm_is_json(fs_path)) format = MODULE_EVAL_FORMAT_UNKNOWN;
+  if (kind_hint == ESM_MODULE_KIND_JSON || esm_is_json(fs_path)) format = MODULE_EVAL_FORMAT_UNKNOWN;
   else if (format == MODULE_EVAL_FORMAT_UNKNOWN) format = esm_decide_module_format(js, fs_path);
 
   const char *cache_key = (strchr(url, '?') || strchr(url, '#')) ? url : fs_path;
   *handled = true;
 
-  ant_value_t ns = esm_get_or_load(js, specifier, fs_path, cache_key, format, source, source_len);
+  ant_value_t ns = esm_get_or_load_ex(js, specifier, fs_path, cache_key, format, source, source_len, true, kind_hint);
   free(fs_path);
   GC_ROOT_RESTORE(js, root_mark);
 

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -20,6 +20,8 @@
 #include "internal.h"
 #include "reactor.h"
 #include "runtime.h"
+#include "silver/engine.h"
+#include "gc/roots.h"
 #include "utils.h"
 
 #include <ctype.h>
@@ -143,6 +145,18 @@ static const char *esm_path_last_sep_const(const char *path) {
   return backslash > slash ? backslash : slash;
 }
 
+static bool esm_path_ascend(char *path) {
+  if (esm_path_is_root(path)) return false;
+
+  char *slash = esm_path_last_sep(path);
+  if (!slash) return false;
+
+  if (slash == path) path[1] = '\0';
+  else if (esm_has_windows_drive_letter(path) && slash == path + 2) slash[1] = '\0';
+  else *slash = '\0';
+  return true;
+}
+
 static char *esm_file_url_to_path(ant_t *js, const char *specifier) {
   if (!specifier || strncmp(specifier, "file:", 5) != 0) return NULL;
 
@@ -152,10 +166,10 @@ static char *esm_file_url_to_path(ant_t *js, const char *specifier) {
 #ifdef _WIN32
   else if (strncmp(p, "//", 2) == 0 && esm_has_windows_drive_letter(p + 2)) p += 2;
 #endif
+  size_t p_len = strcspn(p, "?#");
+  if (p_len == 0) return NULL;
 
-  if (*p == '\0') return NULL;
-
-  ant_value_t encoded = js_mkstr(js, p, strlen(p));
+  ant_value_t encoded = js_mkstr(js, p, p_len);
   ant_value_t decoded = js_decodeURI(js, &encoded, 1);
 
   size_t len = 0;
@@ -433,16 +447,33 @@ static ant_value_t esm_make_namespace_object(ant_t *js) {
   return ns;
 }
 
-static ant_value_t esm_complete_value_module(esm_module_t *mod, ant_value_t value) {
+static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_value_t value) {
   if (is_err(value)) {
     mod->is_loading = false;
     return value;
   }
-  mod->namespace_obj = value;
+
+  ant_value_t ns = js_mkobj(js);
+  if (is_object_type(value)) {
+    ant_value_t keys = js_own_property_keys(js, value, false, true);
+    ant_offset_t len = js_arr_len(js, keys);
+    for (ant_offset_t i = 0; i < len; i++) {
+      ant_value_t key = js_arr_get(js, keys, i);
+      if (vtype(key) != T_STR) continue;
+      const char *key_str = js_getstr(js, key, NULL);
+      js_setprop(js, ns, key, js_get(js, value, key_str));
+    }
+  }
+  
+  js_set(js, ns, "default", value);
+  js_set_slot(ns, SLOT_DEFAULT, value);
+
+  mod->namespace_obj = ns;
   mod->default_export = value;
   mod->is_loaded = true;
   mod->is_loading = false;
-  return value;
+  
+  return ns;
 }
 
 static ant_value_t esm_complete_namespace_module(ant_t *js, esm_module_t *mod, ant_value_t ns) {
@@ -611,13 +642,7 @@ static char *esm_find_node_module_dir(const char *start_dir, const char *package
       return package_dir;
     }
 
-    if (esm_path_is_root(current)) break;
-    char *slash = esm_path_last_sep(current);
-    
-    if (!slash) break;
-    if (slash == current) current[1] = '\0';
-    else if (esm_has_windows_drive_letter(current) && slash == current + 2) slash[1] = '\0';
-    else *slash = '\0';
+    if (!esm_path_ascend(current)) break;
   }
   
   esm_package_dir_cache_put(start_dir, package_name, NULL);
@@ -836,29 +861,29 @@ static char *esm_resolve_package_entrypoint(const char *package_dir, const char 
   return resolved;
 }
 
-static yyjson_doc *esm_find_nearest_package_json(const char *start_dir, char *scope_dir, size_t scope_dir_size) {
+static yyjson_doc *esm_find_nearest_package_json(const char *start_dir, char *scope_dir, size_t scope_dir_size, bool stop_at_node_modules) {
   if (!start_dir || !start_dir[0]) return NULL;
 
   char current[PATH_MAX];
   snprintf(current, sizeof(current), "%s", start_dir);
 
   while (true) {
+    if (stop_at_node_modules) {
+      char *sep = esm_path_last_sep(current);
+      const char *base = sep ? sep + 1 : current;
+      if (strcmp(base, "node_modules") == 0) return NULL;
+    }
+
     char pkg_json_path[PATH_MAX];
     snprintf(pkg_json_path, sizeof(pkg_json_path), "%s/package.json", current);
 
     yyjson_doc *doc = esm_package_json_cache_read(pkg_json_path);
     if (doc) {
-      snprintf(scope_dir, scope_dir_size, "%s", current);
+      if (scope_dir && scope_dir_size) snprintf(scope_dir, scope_dir_size, "%s", current);
       return doc;
     }
 
-    if (esm_path_is_root(current)) break;
-    char *slash = esm_path_last_sep(current);
-
-    if (!slash) break;
-    if (slash == current) current[1] = '\0';
-    else if (esm_has_windows_drive_letter(current) && slash == current + 2) slash[1] = '\0';
-    else *slash = '\0';
+    if (!esm_path_ascend(current)) break;
   }
 
   return NULL;
@@ -869,7 +894,7 @@ static char *esm_resolve_package_imports(const char *specifier, const char *base
   if (!start_dir) return NULL;
 
   char scope_dir[PATH_MAX];
-  yyjson_doc *doc = esm_find_nearest_package_json(start_dir, scope_dir, sizeof(scope_dir));
+  yyjson_doc *doc = esm_find_nearest_package_json(start_dir, scope_dir, sizeof(scope_dir), false);
   free(start_dir);
   if (!doc) return NULL;
 
@@ -885,10 +910,13 @@ static char *esm_resolve_package_self_reference(
   const char *package_name,
   const char *subpath,
   const char *base_path,
-  bool prefer_require
+  bool prefer_require,
+  bool *matched
 ) {
+  *matched = false;
+
   char scope_dir[PATH_MAX];
-  yyjson_doc *doc = esm_find_nearest_package_json(start_dir, scope_dir, sizeof(scope_dir));
+  yyjson_doc *doc = esm_find_nearest_package_json(start_dir, scope_dir, sizeof(scope_dir), true);
   if (!doc) return NULL;
 
   yyjson_val *root = yyjson_doc_get_root(doc);
@@ -899,6 +927,7 @@ static char *esm_resolve_package_self_reference(
   if (!name_str || strcmp(name_str, package_name) != 0) return NULL;
   if (!yyjson_obj_get(root, "exports")) return NULL;
 
+  *matched = true;
   return esm_resolve_package_entrypoint(scope_dir, subpath, base_path, prefer_require);
 }
 
@@ -912,8 +941,10 @@ static char *esm_resolve_node_module_cond(const char *specifier, const char *bas
   char *start_dir = esm_get_base_dir(base_path);
   if (!start_dir) return NULL;
 
-  char *resolved = esm_resolve_package_self_reference(start_dir, package_name, subpath, base_path, prefer_require);
-  if (!resolved) {
+  bool self_matched = false;
+  char *resolved = esm_resolve_package_self_reference(start_dir, package_name, subpath, base_path, prefer_require, &self_matched);
+  
+  if (!resolved && !self_matched) {
     char *package_dir = esm_find_node_module_dir(start_dir, package_name);
     if (package_dir) {
       resolved = esm_resolve_package_entrypoint(package_dir, subpath, base_path, prefer_require);
@@ -1079,8 +1110,7 @@ static bool esm_lookup_package_type(const char *resolved_path, esm_package_type_
   char *dir = dirname(path_copy);
   if (!dir || !dir[0]) return false;
 
-  char scope_dir[PATH_MAX];
-  yyjson_doc *doc = esm_find_nearest_package_json(dir, scope_dir, sizeof(scope_dir));
+  yyjson_doc *doc = esm_find_nearest_package_json(dir, NULL, 0, false);
   if (!doc) return false;
 
   yyjson_val *root = yyjson_doc_get_root(doc);
@@ -1548,15 +1578,15 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
   switch (mod->kind) {
     case ESM_MODULE_KIND_JSON: {
       ant_value_t json_val = esm_load_json(js, mod->resolved_path);
-      return esm_complete_value_module(mod, json_val);
+      return esm_complete_value_module(js, mod, json_val);
     }
     case ESM_MODULE_KIND_TEXT: {
       ant_value_t text_val = esm_load_text(js, mod->resolved_path);
-      return esm_complete_value_module(mod, text_val);
+      return esm_complete_value_module(js, mod, text_val);
     }
     case ESM_MODULE_KIND_IMAGE: {
       ant_value_t img_val = esm_load_image(js, mod->resolved_path);
-      return esm_complete_value_module(mod, img_val);
+      return esm_complete_value_module(js, mod, img_val);
     }
     case ESM_MODULE_KIND_NATIVE: {
       ant_value_t ns = esm_make_namespace_object(js);
@@ -1746,12 +1776,276 @@ static const char *esm_default_base_path(ant_t *js) {
   return (active && active[0]) ? active : ".";
 }
 
+static bool esm_hooks_present(ant_t *js) {
+  return vtype(js->esm.hooks) == T_ARR && js_arr_len(js, js->esm.hooks) > 0;
+}
+
+static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec, ant_value_t ctx, const char *base_path);
+static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant_value_t ctx);
+
+static ant_value_t esm_hook_make_next(ant_t *js, ant_value_t next_fn, int level, ant_value_t ctx, const char *base_path) {
+  ant_value_t data = js_mkobj(js);
+  js_set(js, data, "level", js_mknum((double)level));
+  js_set(js, data, "ctx", ctx);
+  js_set(js, data, "base", base_path ? js_mkstr(js, base_path, strlen(base_path)) : js_mkundef());
+
+  ant_value_t obj = js_mkobj(js);
+  js_set_slot(obj, SLOT_CFUNC, next_fn);
+  js_set_slot(obj, SLOT_DATA, data);
+  return js_obj_to_func(js, obj);
+}
+
+static ant_value_t builtin_esm_next_resolve(ant_t *js, ant_value_t *args, int nargs) {
+  ant_value_t data = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  int level = (int)js_getnum(js_get(js, data, "level"));
+
+  ant_value_t base_val = js_get(js, data, "base");
+  const char *base = vtype(base_val) == T_STR ? js_getstr(js, base_val, NULL) : NULL;
+
+  ant_value_t spec = nargs > 0 ? args[0] : js_mkundef();
+  ant_value_t ctx = nargs > 1 && is_object_type(args[1]) ? args[1] : js_get(js, data, "ctx");
+  return esm_run_resolve_chain(js, level, spec, ctx, base);
+}
+
+static ant_value_t builtin_esm_next_load(ant_t *js, ant_value_t *args, int nargs) {
+  ant_value_t data = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  int level = (int)js_getnum(js_get(js, data, "level"));
+
+  ant_value_t url = nargs > 0 ? args[0] : js_mkundef();
+  ant_value_t ctx = nargs > 1 && is_object_type(args[1]) ? args[1] : js_get(js, data, "ctx");
+  return esm_run_load_chain(js, level, url, ctx);
+}
+
+static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec, ant_value_t ctx, const char *base_path) {
+  if (vtype(spec) != T_STR)
+    return js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook requires a string specifier");
+
+  for (; level >= 0; level--) {
+    ant_value_t hook = js_arr_get(js, js->esm.hooks, (ant_offset_t)level);
+    if (!is_object_type(hook)) continue;
+
+    ant_value_t fn = js_get(js, hook, "resolve");
+    if (vtype(fn) != T_FUNC && vtype(fn) != T_CFUNC) continue;
+
+    ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_resolve), level - 1, ctx, base_path);
+    ant_value_t call_args[3] = { spec, ctx, next };
+    ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), call_args, 3, NULL, false);
+
+    if (is_err(result)) return result;
+    if (!is_object_type(result))
+      return js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook must return an object");
+    return result;
+  }
+
+  ant_offset_t slen = 0;
+  ant_offset_t soff = vstr(js, spec, &slen);
+
+  char *spec_copy = strndup((const char *)(uintptr_t)soff, (size_t)slen);
+  if (!spec_copy) return js_mkerr(js, "oom");
+
+  char *file_url_path = esm_file_url_to_path(js, spec_copy);
+  if (file_url_path) {
+    free(spec_copy);
+    spec_copy = file_url_path;
+  }
+
+  ant_value_t out = js_mkobj(js);
+  if (!esm_lookup_builtin_alias(spec_copy, strlen(spec_copy))) {
+    if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
+    char *resolved = esm_resolve(spec_copy, base_path, esm_resolve_path);
+
+    if (resolved) {
+      size_t url_len = strlen(resolved) + 8;
+      char *url = malloc(url_len);
+      if (!url) {
+        free(resolved);
+        free(spec_copy);
+        return js_mkerr(js, "oom");
+      }
+      snprintf(url, url_len, "file://%s", resolved);
+      js_set(js, out, "url", js_mkstr(js, url, strlen(url)));
+      free(url);
+      free(resolved);
+      free(spec_copy);
+      return out;
+    }
+  }
+
+  js_set(js, out, "url", spec);
+  free(spec_copy);
+  return out;
+}
+
+static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant_value_t ctx) {
+  if (vtype(url) != T_STR)
+    return js_mkerr_typed(js, JS_ERR_TYPE, "load hook requires a string url");
+
+  for (; level >= 0; level--) {
+    ant_value_t hook = js_arr_get(js, js->esm.hooks, (ant_offset_t)level);
+    if (!is_object_type(hook)) continue;
+
+    ant_value_t fn = js_get(js, hook, "load");
+    if (vtype(fn) != T_FUNC && vtype(fn) != T_CFUNC) continue;
+
+    ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_load), level - 1, ctx, NULL);
+    ant_value_t call_args[3] = { url, ctx, next };
+    ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), call_args, 3, NULL, false);
+
+    if (is_err(result)) return result;
+    if (!is_object_type(result))
+      return js_mkerr_typed(js, JS_ERR_TYPE, "load hook must return an object");
+    return result;
+  }
+
+  ant_offset_t ulen = 0;
+  ant_offset_t uoff = vstr(js, url, &ulen);
+
+  char *url_copy = strndup((const char *)(uintptr_t)uoff, (size_t)ulen);
+  if (!url_copy) return js_mkerr(js, "oom");
+
+  char *path = esm_file_url_to_path(js, url_copy);
+  free(url_copy);
+  if (!path) return js_mkerr(js, "load hook: unsupported url");
+
+  esm_file_data_t file = {0};
+  ant_value_t err = esm_read_file(js, path, "module source", &file);
+  if (is_err(err)) {
+    free(path);
+    return err;
+  }
+
+  ant_value_t out = js_mkobj(js);
+  js_set(js, out, "source", js_mkstr(js, file.data, file.size));
+
+  if (esm_is_json(path)) js_set(js, out, "format", js_mkstr(js, "json", 4));
+  else js_set(js, out, "format", esm_decide_module_format(path) == MODULE_EVAL_FORMAT_CJS
+    ? js_mkstr(js, "commonjs", 8)
+    : js_mkstr(js, "module", 6));
+
+  free(path);
+  free(file.data);
+  return out;
+}
+
+static ant_value_t esm_import_via_hooks(
+  ant_t *js,
+  const char *specifier,
+  size_t spec_len,
+  const char *base_path,
+  ant_value_t attrs,
+  bool *handled
+) {
+  *handled = false;
+  GC_ROOT_SAVE(root_mark, js);
+
+  if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
+
+  ant_value_t ctx = js_mkobj(js);
+  GC_ROOT_PIN(js, ctx);
+
+  if (base_path && base_path[0]) {
+    size_t purl_len = strlen(base_path) + 8;
+    char *purl = malloc(purl_len);
+    if (purl) {
+      snprintf(purl, purl_len, "file://%s", base_path);
+      js_set(js, ctx, "parentURL", js_mkstr(js, purl, strlen(purl)));
+      free(purl);
+    }
+  }
+
+  ant_value_t conditions = js_mkarr(js);
+  js_arr_push(js, conditions, js_mkstr(js, "import", 6));
+  js_arr_push(js, conditions, js_mkstr(js, "node", 4));
+  js_arr_push(js, conditions, js_mkstr(js, "default", 7));
+  js_set(js, ctx, "conditions", conditions);
+  js_set(js, ctx, "importAttributes", is_object_type(attrs) ? attrs : js_mkobj(js));
+
+  int top = (int)js_arr_len(js, js->esm.hooks) - 1;
+  ant_value_t spec_val = js_mkstr(js, specifier, spec_len);
+  GC_ROOT_PIN(js, spec_val);
+
+  ant_value_t resolved = esm_run_resolve_chain(js, top, spec_val, ctx, base_path);
+  GC_ROOT_PIN(js, resolved);
+
+  if (is_err(resolved)) {
+    *handled = true;
+    GC_ROOT_RESTORE(js, root_mark);
+    return resolved;
+  }
+
+  ant_value_t url_val = js_get(js, resolved, "url");
+  GC_ROOT_PIN(js, url_val);
+
+  if (vtype(url_val) != T_STR || strncmp(js_getstr(js, url_val, NULL), "file://", 7) != 0) {
+    GC_ROOT_RESTORE(js, root_mark);
+    return js_mkundef();
+  }
+
+  ant_value_t loaded = esm_run_load_chain(js, top, url_val, ctx);
+  GC_ROOT_PIN(js, loaded);
+
+  if (is_err(loaded)) {
+    *handled = true;
+    GC_ROOT_RESTORE(js, root_mark);
+    return loaded;
+  }
+
+  const char *url = js_getstr(js, url_val, NULL);
+  char *fs_path = esm_file_url_to_path(js, url);
+  if (!fs_path) {
+    GC_ROOT_RESTORE(js, root_mark);
+    return js_mkundef();
+  }
+
+  ant_module_format_t format = MODULE_EVAL_FORMAT_UNKNOWN;
+  ant_value_t fmt_val = js_get(js, loaded, "format");
+  if (vtype(fmt_val) == T_STR) {
+    const char *fmt_str = js_getstr(js, fmt_val, NULL);
+    if (strcmp(fmt_str, "commonjs") == 0) format = MODULE_EVAL_FORMAT_CJS;
+    else if (strcmp(fmt_str, "module") == 0) format = MODULE_EVAL_FORMAT_ESM;
+  }
+  if (format == MODULE_EVAL_FORMAT_UNKNOWN) format = esm_decide_module_format(fs_path);
+
+  const uint8_t *source = NULL;
+  size_t source_len = 0;
+  ant_value_t src_val = js_get(js, loaded, "source");
+  if (vtype(src_val) == T_STR) {
+    ant_offset_t sl = 0;
+    ant_offset_t so = vstr(js, src_val, &sl);
+    source = (const uint8_t *)(uintptr_t)so;
+    source_len = (size_t)sl;
+  }
+
+  if (esm_is_json(fs_path)) {
+    format = MODULE_EVAL_FORMAT_UNKNOWN;
+    source = NULL;
+    source_len = 0;
+  }
+
+  const char *cache_key = strchr(url, '?') ? url : fs_path;
+  *handled = true;
+  
+  ant_value_t ns = esm_get_or_load(js, specifier, fs_path, cache_key, format, source, source_len);
+  free(fs_path);
+  GC_ROOT_RESTORE(js, root_mark);
+  
+  return ns;
+}
+
 ant_value_t js_esm_import_sync_cstr_from(
   ant_t *js,
   const char *specifier,
   size_t spec_len,
   const char *base_path
 ) {
+  if (esm_hooks_present(js)) {
+    ant_value_t attrs = js->esm.import_attributes;
+    js->esm.import_attributes = js_mkundef();
+
+    bool handled = false;
+    ant_value_t ns = esm_import_via_hooks(js, specifier, spec_len, base_path, attrs, &handled);
+    if (handled) return ns;
+  }
   const ant_builtin_bundle_alias_t *bundle = NULL;
   const ant_builtin_bundle_module_t *module = NULL;
   
@@ -1926,6 +2220,13 @@ ant_value_t js_esm_import_sync_from_require(ant_t *js, ant_value_t specifier, co
 
 ant_value_t js_esm_import_sync(ant_t *js, ant_value_t specifier) {
   return js_esm_import_sync_from(js, specifier, NULL);
+}
+
+ant_value_t js_esm_import_dynamic_ex(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t attrs, ant_value_t *out_tla_promise) {
+  js->esm.import_attributes = attrs;
+  ant_value_t ns = js_esm_import_dynamic(js, specifier, base_path, out_tla_promise);
+  js->esm.import_attributes = js_mkundef();
+  return ns;
 }
 
 ant_value_t js_esm_import_dynamic(ant_t *js, ant_value_t specifier, const char *base_path, ant_value_t *out_tla_promise) {

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -37,6 +37,7 @@
 #include <yyjson.h>
 
 typedef enum {
+  ESM_MODULE_KIND_NONE = -1,
   ESM_MODULE_KIND_CODE = 0,
   ESM_MODULE_KIND_JSON,
   ESM_MODULE_KIND_TEXT,
@@ -178,6 +179,40 @@ static char *esm_file_url_to_path(ant_t *js, const char *specifier) {
 #endif
 
   return path;
+}
+
+static char *esm_path_to_file_url(const char *path) {
+  if (!path) return NULL;
+
+  size_t len = strlen(path);
+  char *out = malloc(len * 3 + 9);
+  if (!out) return NULL;
+
+  char *dst = out;
+  memcpy(dst, "file://", 7);
+  dst += 7;
+
+#ifdef _WIN32
+  *dst++ = '/';
+#endif
+
+  for (const char *p = path; *p; p++) {
+    unsigned char c = (unsigned char)*p;
+#ifdef _WIN32
+    if (c == '\\') {
+      *dst++ = '/';
+      continue;
+    }
+#endif
+    if (c == '%' || c == '#' || c == '?' || c == ' ' || c < 0x20 || c >= 0x80) {
+      dst += snprintf(dst, 4, "%%%02X", c);
+    } else {
+      *dst++ = (char)c;
+    }
+  }
+
+  *dst = '\0';
+  return out;
 }
 
 static char *esm_canonicalize_path(const char *path) {
@@ -834,16 +869,18 @@ static char *esm_resolve_package_entrypoint(ant_t *js, const char *package_dir, 
   char pkg_json_path[PATH_MAX];
   snprintf(pkg_json_path, sizeof(pkg_json_path), "%s/package.json", package_dir);
 
-  yyjson_doc *doc = esm_package_json_cache_read(js, pkg_json_path);
+  bool doc_owned = false;
+  yyjson_doc *doc = esm_package_json_cache_read(js, pkg_json_path, &doc_owned);
   yyjson_val *root = doc ? yyjson_doc_get_root(doc) : NULL;
   yyjson_val *exports = (root && yyjson_is_obj(root)) ? yyjson_obj_get(root, "exports") : NULL;
+
+  char *resolved = NULL;
 
   if (exports) {
     char subpath_key[PATH_MAX];
     if (subpath && subpath[0]) snprintf(subpath_key, sizeof(subpath_key), "./%s", subpath);
     else snprintf(subpath_key, sizeof(subpath_key), ".");
 
-    char *resolved = NULL;
     if (yyjson_is_obj(exports)) {
       bool has_subpath_keys = false;
       size_t idx, max;
@@ -856,22 +893,20 @@ static char *esm_resolve_package_entrypoint(ant_t *js, const char *package_dir, 
       if (has_subpath_keys) resolved = esm_resolve_package_map(js, exports, subpath_key, package_dir, base_path, false, prefer_require);
       else if (!subpath || !subpath[0]) resolved = esm_resolve_exports_target(js, exports, package_dir, "", 0, base_path, false, prefer_require);
     } else if (!subpath || !subpath[0]) resolved = esm_resolve_exports_target(js, exports, package_dir, "", 0, base_path, false, prefer_require);
-
-    return resolved;
+  } else if (!subpath || !subpath[0]) {
+    resolved = esm_resolve_package_main_entry(js, root, package_dir);
+    if (!resolved) resolved = esm_try_resolve_index_with_exts(js, package_dir, ".");
+  } else {
+    resolved = esm_try_resolve_with_exts(js, package_dir, subpath, esm_has_extension(subpath));
+    if (!resolved) resolved = esm_try_resolve_index_with_exts(js, package_dir, subpath);
   }
 
-  if (!subpath || !subpath[0]) {
-    char *resolved = esm_resolve_package_main_entry(js, root, package_dir);
-    if (resolved) return resolved;
-    return esm_try_resolve_index_with_exts(js, package_dir, ".");
-  }
-
-  char *resolved = esm_try_resolve_with_exts(js, package_dir, subpath, esm_has_extension(subpath));
-  if (!resolved) resolved = esm_try_resolve_index_with_exts(js, package_dir, subpath);
+  if (doc_owned && doc) yyjson_doc_free(doc);
   return resolved;
 }
 
-static yyjson_doc *esm_find_nearest_package_json(ant_t *js, const char *start_dir, char *scope_dir, size_t scope_dir_size, bool stop_at_node_modules) {
+static yyjson_doc *esm_find_nearest_package_json(ant_t *js, const char *start_dir, char *scope_dir, size_t scope_dir_size, bool stop_at_node_modules, bool *out_owned) {
+  *out_owned = false;
   if (!start_dir || !start_dir[0]) return NULL;
 
   char current[PATH_MAX];
@@ -887,7 +922,7 @@ static yyjson_doc *esm_find_nearest_package_json(ant_t *js, const char *start_di
     char pkg_json_path[PATH_MAX];
     snprintf(pkg_json_path, sizeof(pkg_json_path), "%s/package.json", current);
 
-    yyjson_doc *doc = esm_package_json_cache_read(js, pkg_json_path);
+    yyjson_doc *doc = esm_package_json_cache_read(js, pkg_json_path, out_owned);
     if (doc) {
       if (scope_dir && scope_dir_size) snprintf(scope_dir, scope_dir_size, "%s", current);
       return doc;
@@ -896,6 +931,7 @@ static yyjson_doc *esm_find_nearest_package_json(ant_t *js, const char *start_di
     if (!esm_path_ascend(current)) break;
   }
 
+  *out_owned = false;
   return NULL;
 }
 
@@ -904,15 +940,20 @@ static char *esm_resolve_package_imports(ant_t *js, const char *specifier, const
   if (!start_dir) return NULL;
 
   char scope_dir[PATH_MAX];
-  yyjson_doc *doc = esm_find_nearest_package_json(js, start_dir, scope_dir, sizeof(scope_dir), false);
+  bool doc_owned = false;
+  yyjson_doc *doc = esm_find_nearest_package_json(js, start_dir, scope_dir, sizeof(scope_dir), false, &doc_owned);
   free(start_dir);
   if (!doc) return NULL;
 
   yyjson_val *root = yyjson_doc_get_root(doc);
   yyjson_val *imports = (root && yyjson_is_obj(root)) ? yyjson_obj_get(root, "imports") : NULL;
-  if (!imports || !yyjson_is_obj(imports)) return NULL;
 
-  return esm_resolve_package_map(js, imports, specifier, scope_dir, base_path, true, prefer_require);
+  char *resolved = (imports && yyjson_is_obj(imports))
+    ? esm_resolve_package_map(js, imports, specifier, scope_dir, base_path, true, prefer_require)
+    : NULL;
+
+  if (doc_owned) yyjson_doc_free(doc);
+  return resolved;
 }
 
 static char *esm_resolve_package_self_reference(
@@ -927,16 +968,19 @@ static char *esm_resolve_package_self_reference(
   *matched = false;
 
   char scope_dir[PATH_MAX];
-  yyjson_doc *doc = esm_find_nearest_package_json(js, start_dir, scope_dir, sizeof(scope_dir), true);
+  bool doc_owned = false;
+  yyjson_doc *doc = esm_find_nearest_package_json(js, start_dir, scope_dir, sizeof(scope_dir), true, &doc_owned);
   if (!doc) return NULL;
 
   yyjson_val *root = yyjson_doc_get_root(doc);
-  if (!root || !yyjson_is_obj(root)) return NULL;
-
-  yyjson_val *name = yyjson_obj_get(root, "name");
+  yyjson_val *name = (root && yyjson_is_obj(root)) ? yyjson_obj_get(root, "name") : NULL;
   const char *name_str = (name && yyjson_is_str(name)) ? yyjson_get_str(name) : NULL;
-  if (!name_str || strcmp(name_str, package_name) != 0) return NULL;
-  if (!yyjson_obj_get(root, "exports")) return NULL;
+
+  bool is_self = name_str && strcmp(name_str, package_name) == 0
+    && root && yyjson_obj_get(root, "exports");
+
+  if (doc_owned) yyjson_doc_free(doc);
+  if (!is_self) return NULL;
 
   *matched = true;
   return esm_resolve_package_entrypoint(js, scope_dir, subpath, base_path, prefer_require);
@@ -1121,14 +1165,13 @@ static bool esm_lookup_package_type(ant_t *js, const char *resolved_path, esm_pa
   char *dir = dirname(path_copy);
   if (!dir || !dir[0]) return false;
 
-  yyjson_doc *doc = esm_find_nearest_package_json(js, dir, NULL, 0, false);
+  bool doc_owned = false;
+  yyjson_doc *doc = esm_find_nearest_package_json(js, dir, NULL, 0, false, &doc_owned);
   if (!doc) return false;
 
   yyjson_val *root = yyjson_doc_get_root(doc);
   yyjson_val *type = (root && yyjson_is_obj(root)) ? yyjson_obj_get(root, "type") : NULL;
-
-  if (!type || !yyjson_is_str(type)) return true;
-  const char *type_str = yyjson_get_str(type);
+  const char *type_str = (type && yyjson_is_str(type)) ? yyjson_get_str(type) : NULL;
 
   if (type_str && strcmp(type_str, "module") == 0) {
     if (out_type) *out_type = ESM_PACKAGE_TYPE_MODULE;
@@ -1136,6 +1179,7 @@ static bool esm_lookup_package_type(ant_t *js, const char *resolved_path, esm_pa
     if (out_type) *out_type = ESM_PACKAGE_TYPE_COMMONJS;
   }
 
+  if (doc_owned) yyjson_doc_free(doc);
   return true;
 }
 
@@ -1271,7 +1315,7 @@ static esm_module_t *esm_create_module(
   const uint8_t *embedded_code,
   size_t embedded_code_len,
   bool copy_embedded,
-  int kind_hint
+  esm_module_kind_t kind_hint
 ) {
   ant_esm_state_t *st = esm_state(js);
   if (!st) return NULL;
@@ -1313,7 +1357,7 @@ static esm_module_t *esm_create_module(
     .default_export = js_mkundef(),
     .is_loaded = false,
     .is_loading = false,
-    .kind = kind_hint >= 0 ? (esm_module_kind_t)kind_hint : esm_classify_module_kind(resolved_path),
+    .kind = kind_hint != ESM_MODULE_KIND_NONE ? kind_hint : esm_classify_module_kind(resolved_path),
     .format = format,
     .url_content = NULL,
     .url_content_len = 0,
@@ -1353,6 +1397,7 @@ void js_esm_cleanup_module_cache(ant_t *js) {
       free(current);
     }
     st->module_count = 0;
+    st->last_tla_module = NULL;
   }
 
   esm_loader_cache_cleanup(js);
@@ -1435,22 +1480,14 @@ static ant_value_t esm_load_value_module(ant_t *js, esm_module_t *mod) {
     }
   }
 
+  const char *src = (const char *)mod->embedded_code;
   size_t len = mod->embedded_code_len;
-  char *buf = (char *)malloc(len + 1);
-  if (!buf) return js_mkerr(js, "OOM loading module source");
 
-  memcpy(buf, mod->embedded_code, len);
-  buf[len] = '\0';
-
-  ant_value_t val;
   switch (mod->kind) {
-    case ESM_MODULE_KIND_JSON: val = json_parse_value(js, js_mkstr(js, buf, len)); break;
-    case ESM_MODULE_KIND_TEXT: val = js_mkstr(js, buf, len); break;
-    default: val = esm_image_value(js, (const unsigned char *)buf, len, mod->resolved_path); break;
+    case ESM_MODULE_KIND_JSON: return json_parse_value(js, js_mkstr(js, src, len));
+    case ESM_MODULE_KIND_TEXT: return js_mkstr(js, src, len);
+    default: return esm_image_value(js, (const unsigned char *)src, len, mod->resolved_path);
   }
-
-  free(buf);
-  return val;
 }
 
 static void esm_module_record_cleanup(esm_module_record_t *record) {
@@ -1571,7 +1608,7 @@ static ant_value_t esm_load_static_dependency(
         module->format,
         module->code,
         module->code_len,
-        false, -1
+        false, ESM_MODULE_KIND_NONE
       );
       if (!dep) {
         free(specifier);
@@ -1605,7 +1642,7 @@ static ant_value_t esm_load_static_dependency(
       resolved_path,
       MODULE_EVAL_FORMAT_UNKNOWN,
       NULL, 0,
-      false, -1
+      false, ESM_MODULE_KIND_NONE
     );
     if (!dep) {
       free(resolved_path);
@@ -1796,10 +1833,14 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
   
   free(content);
   if (vtype(result) == T_PROMISE) {
-  if (js->esm.state && js->esm.state->dynamic_import_depth > 0) {
-    mod->has_tla = true;
-    mod->tla_promise = result;
-  } else js_run_event_loop(js); }
+    if (js->esm.state && js->esm.state->dynamic_import_depth > 0) {
+      mod->has_tla = true;
+      mod->tla_promise = result;
+      js->esm.state->last_tla_module = mod;
+    } else {
+      js_run_event_loop(js);
+    }
+  }
 
   js_module_eval_ctx_pop(js, &eval_ctx);
   js_set_filename(js, prev_filename);
@@ -1820,7 +1861,7 @@ static ant_value_t esm_get_or_load_ex(
   const uint8_t *embedded_code,
   size_t embedded_code_len,
   bool copy_embedded,
-  int kind_hint
+  esm_module_kind_t kind_hint
 ) {
   esm_module_t *mod = esm_find_module(js, module_key);
   if (!mod) {
@@ -1852,7 +1893,7 @@ static ant_value_t esm_get_or_load(
   return esm_get_or_load_ex(
     js, specifier, resolved_path, module_key,
     format, embedded_code, embedded_code_len,
-    false, -1
+    false, ESM_MODULE_KIND_NONE
   );
 }
 
@@ -1865,17 +1906,27 @@ static bool esm_hooks_present(ant_t *js) {
   return vtype(js->esm.hooks) == T_ARR && js_arr_len(js, js->esm.hooks) > 0;
 }
 
-static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec, ant_value_t ctx, const char *base_path);
-static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant_value_t ctx);
+static ant_value_t esm_run_resolve_chain(ant_t *js, ant_value_t hooks, int level, ant_value_t spec, ant_value_t ctx, const char *base_path, bool is_require);
+static ant_value_t esm_run_load_chain(ant_t *js, ant_value_t hooks, int level, ant_value_t url, ant_value_t ctx);
 
-static ant_value_t esm_hook_make_next(ant_t *js, ant_value_t next_fn, int level, ant_value_t ctx, const char *base_path) {
+static ant_value_t esm_hook_make_next(
+  ant_t *js,
+  ant_value_t next_fn,
+  ant_value_t hooks,
+  int level,
+  ant_value_t ctx,
+  const char *base_path,
+  bool is_require
+) {
   GC_ROOT_SAVE(root_mark, js);
 
   ant_value_t data = js_mkobj(js);
   GC_ROOT_PIN(js, data);
+  js_set(js, data, "hooks", hooks);
   js_set(js, data, "level", js_mknum((double)level));
   js_set(js, data, "ctx", ctx);
   js_set(js, data, "base", base_path ? js_mkstr(js, base_path, strlen(base_path)) : js_mkundef());
+  js_set(js, data, "require", js_bool(is_require));
 
   ant_value_t obj = js_mkobj(js);
   GC_ROOT_PIN(js, obj);
@@ -1895,54 +1946,71 @@ static bool esm_hook_next_was_called(ant_t *js, ant_value_t next) {
 static ant_value_t builtin_esm_next_resolve(ant_t *js, ant_value_t *args, int nargs) {
   ant_value_t data = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
   js_set(js, data, "called", js_true);
+
+  ant_value_t hooks = js_get(js, data, "hooks");
   int level = (int)js_getnum(js_get(js, data, "level"));
+  bool is_require = js_truthy(js, js_get(js, data, "require"));
 
   ant_value_t base_val = js_get(js, data, "base");
   const char *base = vtype(base_val) == T_STR ? js_getstr(js, base_val, NULL) : NULL;
 
   ant_value_t spec = nargs > 0 ? args[0] : js_mkundef();
   ant_value_t ctx = nargs > 1 && is_object_type(args[1]) ? args[1] : js_get(js, data, "ctx");
-  return esm_run_resolve_chain(js, level, spec, ctx, base);
+  return esm_run_resolve_chain(js, hooks, level, spec, ctx, base, is_require);
 }
 
 static ant_value_t builtin_esm_next_load(ant_t *js, ant_value_t *args, int nargs) {
   ant_value_t data = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
   js_set(js, data, "called", js_true);
+
+  ant_value_t hooks = js_get(js, data, "hooks");
   int level = (int)js_getnum(js_get(js, data, "level"));
 
   ant_value_t url = nargs > 0 ? args[0] : js_mkundef();
   ant_value_t ctx = nargs > 1 && is_object_type(args[1]) ? args[1] : js_get(js, data, "ctx");
-  return esm_run_load_chain(js, level, url, ctx);
+  return esm_run_load_chain(js, hooks, level, url, ctx);
 }
 
-static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec, ant_value_t ctx, const char *base_path) {
+static ant_value_t esm_run_hook_level(
+  ant_t *js,
+  ant_value_t fn,
+  ant_value_t next,
+  ant_value_t arg0,
+  ant_value_t ctx,
+  const char *hook_name
+) {
+  GC_ROOT_SAVE(root_mark, js);
+  GC_ROOT_PIN(js, next);
+
+  ant_value_t call_args[3] = { arg0, ctx, next };
+  ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), call_args, 3, NULL, false);
+  GC_ROOT_PIN(js, result);
+
+  if (!is_err(result)) {
+    if (!is_object_type(result))
+      result = js_mkerr_typed(js, JS_ERR_TYPE, "%s hook must return an object", hook_name);
+    else if (!esm_hook_next_was_called(js, next) && !js_truthy(js, js_get(js, result, "shortCircuit")))
+      result = js_mkerr_typed(js, JS_ERR_TYPE, "%s hook must call next() or set shortCircuit: true", hook_name);
+  }
+
+  GC_ROOT_RESTORE(js, root_mark);
+  return result;
+}
+
+static ant_value_t esm_run_resolve_chain(ant_t *js, ant_value_t hooks, int level, ant_value_t spec, ant_value_t ctx, const char *base_path, bool is_require) {
   if (vtype(spec) != T_STR)
     return js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook requires a string specifier");
 
   for (; level >= 0; level--) {
-    ant_value_t hook = js_arr_get(js, js->esm.hooks, (ant_offset_t)level);
+    ant_value_t hook = js_arr_get(js, hooks, (ant_offset_t)level);
     if (!is_object_type(hook)) continue;
 
     ant_value_t fn = js_get(js, hook, "resolve");
+    if (is_err(fn)) return fn;
     if (vtype(fn) != T_FUNC && vtype(fn) != T_CFUNC) continue;
 
-    GC_ROOT_SAVE(root_mark, js);
-    ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_resolve), level - 1, ctx, base_path);
-    GC_ROOT_PIN(js, next);
-
-    ant_value_t call_args[3] = { spec, ctx, next };
-    ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), call_args, 3, NULL, false);
-    GC_ROOT_PIN(js, result);
-
-    if (!is_err(result)) {
-      if (!is_object_type(result))
-        result = js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook must return an object");
-      else if (!esm_hook_next_was_called(js, next) && !js_truthy(js, js_get(js, result, "shortCircuit")))
-        result = js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook must call nextResolve() or set shortCircuit: true");
-    }
-
-    GC_ROOT_RESTORE(js, root_mark);
-    return result;
+    ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_resolve), hooks, level - 1, ctx, base_path, is_require);
+    return esm_run_hook_level(js, fn, next, spec, ctx, "resolve");
   }
 
   ant_offset_t slen = 0;
@@ -1960,30 +2028,46 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
     spec_copy = file_url_path;
   }
 
+  GC_ROOT_SAVE(root_mark, js);
   ant_value_t out = js_mkobj(js);
+  GC_ROOT_PIN(js, out);
+
   bool scheme_passthrough = esm_has_builtin_scheme(spec_copy)
     || esm_is_data_url(spec_copy)
     || esm_is_url(spec_copy);
 
   if (!scheme_passthrough && !esm_lookup_builtin_alias(spec_copy, strlen(spec_copy))) {
     if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
-    char *resolved = esm_resolve(js, spec_copy, base_path, esm_resolve_path);
+    char *resolved = esm_resolve(js, spec_copy, base_path, is_require ? esm_resolve_path_require : esm_resolve_path);
 
     if (resolved) {
-      size_t url_len = strlen(resolved) + (url_suffix ? strlen(url_suffix) : 0) + 8;
-      char *url = malloc(url_len);
-      if (!url) {
-        free(resolved);
-        free(spec_copy);
-        free(url_suffix);
-        return js_mkerr(js, "oom");
-      }
-      snprintf(url, url_len, "file://%s%s", resolved, url_suffix ? url_suffix : "");
-      js_set(js, out, "url", js_mkstr(js, url, strlen(url)));
-      free(url);
+      char *url = esm_path_to_file_url(resolved);
       free(resolved);
       free(spec_copy);
+      if (!url) {
+        free(url_suffix);
+        GC_ROOT_RESTORE(js, root_mark);
+        return js_mkerr(js, "oom");
+      }
+
+      if (url_suffix) {
+        size_t url_len = strlen(url);
+        size_t suffix_len = strlen(url_suffix);
+        char *full = realloc(url, url_len + suffix_len + 1);
+        if (!full) {
+          free(url);
+          free(url_suffix);
+          GC_ROOT_RESTORE(js, root_mark);
+          return js_mkerr(js, "oom");
+        }
+        memcpy(full + url_len, url_suffix, suffix_len + 1);
+        url = full;
+      }
+      js_set(js, out, "url", js_mkstr(js, url, strlen(url)));
+
+      free(url);
       free(url_suffix);
+      GC_ROOT_RESTORE(js, root_mark);
       return out;
     }
   }
@@ -1991,37 +2075,24 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
   js_set(js, out, "url", spec);
   free(spec_copy);
   free(url_suffix);
+  GC_ROOT_RESTORE(js, root_mark);
   return out;
 }
 
-static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant_value_t ctx) {
+static ant_value_t esm_run_load_chain(ant_t *js, ant_value_t hooks, int level, ant_value_t url, ant_value_t ctx) {
   if (vtype(url) != T_STR)
     return js_mkerr_typed(js, JS_ERR_TYPE, "load hook requires a string url");
 
   for (; level >= 0; level--) {
-    ant_value_t hook = js_arr_get(js, js->esm.hooks, (ant_offset_t)level);
+    ant_value_t hook = js_arr_get(js, hooks, (ant_offset_t)level);
     if (!is_object_type(hook)) continue;
 
     ant_value_t fn = js_get(js, hook, "load");
+    if (is_err(fn)) return fn;
     if (vtype(fn) != T_FUNC && vtype(fn) != T_CFUNC) continue;
 
-    GC_ROOT_SAVE(root_mark, js);
-    ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_load), level - 1, ctx, NULL);
-    GC_ROOT_PIN(js, next);
-
-    ant_value_t call_args[3] = { url, ctx, next };
-    ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), call_args, 3, NULL, false);
-    GC_ROOT_PIN(js, result);
-
-    if (!is_err(result)) {
-      if (!is_object_type(result))
-        result = js_mkerr_typed(js, JS_ERR_TYPE, "load hook must return an object");
-      else if (!esm_hook_next_was_called(js, next) && !js_truthy(js, js_get(js, result, "shortCircuit")))
-        result = js_mkerr_typed(js, JS_ERR_TYPE, "load hook must call nextLoad() or set shortCircuit: true");
-    }
-
-    GC_ROOT_RESTORE(js, root_mark);
-    return result;
+    ant_value_t next = esm_hook_make_next(js, js_mkfun(builtin_esm_next_load), hooks, level - 1, ctx, NULL, false);
+    return esm_run_hook_level(js, fn, next, url, ctx, "load");
   }
 
   ant_offset_t ulen = 0;
@@ -2032,6 +2103,7 @@ static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant
 
   char *path = esm_file_url_to_path(js, url_copy);
   free(url_copy);
+
   if (!path) return js_mkobj(js);
 
   esm_file_data_t file = {0};
@@ -2041,7 +2113,10 @@ static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant
     return err;
   }
 
+  GC_ROOT_SAVE(root_mark, js);
   ant_value_t out = js_mkobj(js);
+  GC_ROOT_PIN(js, out);
+
   js_set(js, out, "source", js_mkstr(js, file.data, file.size));
 
   if (esm_is_json(path)) js_set(js, out, "format", js_mkstr(js, "json", 4));
@@ -2051,9 +2126,9 @@ static ant_value_t esm_run_load_chain(ant_t *js, int level, ant_value_t url, ant
 
   free(path);
   free(file.data);
+  GC_ROOT_RESTORE(js, root_mark);
   return out;
 }
-
 
 static ant_value_t esm_import_via_hooks(
   ant_t *js,
@@ -2072,21 +2147,20 @@ static ant_value_t esm_import_via_hooks(
   ant_value_t ctx = js_mkobj(js);
   GC_ROOT_PIN(js, ctx);
 
-  if (base_path && base_path[0]) {
-    if (esm_is_url(base_path) || strncmp(base_path, "file://", 7) == 0) {
-      js_set(js, ctx, "parentURL", js_mkstr(js, base_path, strlen(base_path)));
-    } else {
-      size_t purl_len = strlen(base_path) + 8;
-      char *purl = malloc(purl_len);
-      if (purl) {
-        snprintf(purl, purl_len, "file://%s", base_path);
-        js_set(js, ctx, "parentURL", js_mkstr(js, purl, strlen(purl)));
-        free(purl);
-      }
+  if (esm_is_url(base_path) || strncmp(base_path, "file://", 7) == 0) {
+    js_set(js, ctx, "parentURL", js_mkstr(js, base_path, strlen(base_path)));
+  } else {
+    char *abs = esm_make_absolute_path(base_path);
+    char *purl = esm_path_to_file_url(abs ? abs : base_path);
+    if (purl) {
+      js_set(js, ctx, "parentURL", js_mkstr(js, purl, strlen(purl)));
+      free(purl);
     }
+    free(abs);
   }
 
   ant_value_t conditions = js_mkarr(js);
+  GC_ROOT_PIN(js, conditions);
   if (is_require) js_arr_push(js, conditions, js_mkstr(js, "require", 7));
   else js_arr_push(js, conditions, js_mkstr(js, "import", 6));
   js_arr_push(js, conditions, js_mkstr(js, "node", 4));
@@ -2094,11 +2168,14 @@ static ant_value_t esm_import_via_hooks(
   js_set(js, ctx, "conditions", conditions);
   js_set(js, ctx, "importAttributes", is_object_type(attrs) ? attrs : js_mkobj(js));
 
-  int top = (int)js_arr_len(js, js->esm.hooks) - 1;
+  ant_value_t hooks = js->esm.hooks;
+  GC_ROOT_PIN(js, hooks);
+  int top = (int)js_arr_len(js, hooks) - 1;
+
   ant_value_t spec_val = js_mkstr(js, specifier, spec_len);
   GC_ROOT_PIN(js, spec_val);
 
-  ant_value_t resolved = esm_run_resolve_chain(js, top, spec_val, ctx, base_path);
+  ant_value_t resolved = esm_run_resolve_chain(js, hooks, top, spec_val, ctx, base_path, is_require);
   GC_ROOT_PIN(js, resolved);
 
   if (is_err(resolved)) {
@@ -2110,23 +2187,67 @@ static ant_value_t esm_import_via_hooks(
   ant_value_t url_val = js_get(js, resolved, "url");
   GC_ROOT_PIN(js, url_val);
 
-  if (vtype(url_val) != T_STR) {
+  if (is_err(url_val)) {
+    *handled = true;
     GC_ROOT_RESTORE(js, root_mark);
-    return js_mkundef();
+    return url_val;
+  }
+  if (vtype(url_val) != T_STR) {
+    *handled = true;
+    GC_ROOT_RESTORE(js, root_mark);
+    return js_mkerr_typed(js, JS_ERR_TYPE, "resolve hook result must include a string 'url'");
   }
 
-  ant_value_t loaded = esm_run_load_chain(js, top, url_val, ctx);
+  ant_value_t res_fmt = js_get(js, resolved, "format");
+  if (is_err(res_fmt)) {
+    *handled = true;
+    GC_ROOT_RESTORE(js, root_mark);
+    return res_fmt;
+  }
+  if (vtype(res_fmt) != T_UNDEF) js_set(js, ctx, "format", res_fmt);
+
+  ant_value_t res_attrs = js_get(js, resolved, "importAttributes");
+  if (is_err(res_attrs)) {
+    *handled = true;
+    GC_ROOT_RESTORE(js, root_mark);
+    return res_attrs;
+  }
+  if (is_object_type(res_attrs)) js_set(js, ctx, "importAttributes", res_attrs);
+
+  const char *url = js_getstr(js, url_val, NULL);
+  char *fs_path = esm_file_url_to_path(js, url);
+  const char *cache_key = fs_path
+    ? ((strchr(url, '?') || strchr(url, '#')) ? url : fs_path)
+    : url;
+
+  esm_module_t *cached = esm_find_module(js, cache_key);
+  if (cached && (cached->is_loaded || cached->is_loading)) {
+    *handled = true;
+    ant_value_t cached_ns = cached->namespace_obj;
+    free(fs_path);
+    GC_ROOT_RESTORE(js, root_mark);
+    return cached_ns;
+  }
+
+  ant_value_t loaded = esm_run_load_chain(js, hooks, top, url_val, ctx);
   GC_ROOT_PIN(js, loaded);
 
   if (is_err(loaded)) {
     *handled = true;
+    free(fs_path);
     GC_ROOT_RESTORE(js, root_mark);
     return loaded;
   }
 
   ant_module_format_t format = MODULE_EVAL_FORMAT_UNKNOWN;
-  int kind_hint = -1;
+  esm_module_kind_t kind_hint = ESM_MODULE_KIND_NONE;
   ant_value_t fmt_val = js_get(js, loaded, "format");
+  if (is_err(fmt_val)) {
+    *handled = true;
+    free(fs_path);
+    GC_ROOT_RESTORE(js, root_mark);
+    return fmt_val;
+  }
   if (vtype(fmt_val) == T_STR) {
     const char *fmt_str = js_getstr(js, fmt_val, NULL);
     if (strcmp(fmt_str, "commonjs") == 0) format = MODULE_EVAL_FORMAT_CJS;
@@ -2137,6 +2258,12 @@ static ant_value_t esm_import_via_hooks(
   const uint8_t *source = NULL;
   size_t source_len = 0;
   ant_value_t src_val = js_get(js, loaded, "source");
+  if (is_err(src_val)) {
+    *handled = true;
+    free(fs_path);
+    GC_ROOT_RESTORE(js, root_mark);
+    return src_val;
+  }
   if (vtype(src_val) == T_STR) {
     ant_offset_t sl = 0;
     ant_offset_t so = vstr(js, src_val, &sl);
@@ -2144,8 +2271,12 @@ static ant_value_t esm_import_via_hooks(
     source_len = (size_t)sl;
   }
 
-  const char *url = js_getstr(js, url_val, NULL);
-  char *fs_path = esm_file_url_to_path(js, url);
+  if (!source && format == MODULE_EVAL_FORMAT_ESM) {
+    *handled = true;
+    free(fs_path);
+    GC_ROOT_RESTORE(js, root_mark);
+    return js_mkerr_typed(js, JS_ERR_TYPE, "load hook returned format 'module' without a source");
+  }
 
   if (!fs_path) {
     if (!source) {
@@ -2161,7 +2292,6 @@ static ant_value_t esm_import_via_hooks(
   if (kind_hint == ESM_MODULE_KIND_JSON || esm_is_json(fs_path)) format = MODULE_EVAL_FORMAT_UNKNOWN;
   else if (format == MODULE_EVAL_FORMAT_UNKNOWN) format = esm_decide_module_format(js, fs_path);
 
-  const char *cache_key = (strchr(url, '?') || strchr(url, '#')) ? url : fs_path;
   *handled = true;
 
   ant_value_t ns = esm_get_or_load_ex(js, specifier, fs_path, cache_key, format, source, source_len, true, kind_hint);
@@ -2390,8 +2520,19 @@ ant_value_t js_esm_import_dynamic_ex(ant_t *js, ant_value_t specifier, const cha
   if (st) st->dynamic_import_depth--;
   if (is_err(ns)) return ns;
 
-  esm_module_t *mod = NULL, *tmp = NULL;
-  if (st) HASH_ITER(hh, st->modules, mod, tmp) {
+  if (!st) return ns;
+
+  esm_module_t *mod = st->last_tla_module;
+  if (mod && mod->has_tla && mod->namespace_obj == ns) {
+    *out_tla_promise = mod->tla_promise;
+    mod->has_tla = false;
+    mod->tla_promise = js_mkundef();
+    st->last_tla_module = NULL;
+    return ns;
+  }
+
+  esm_module_t *tmp = NULL;
+  HASH_ITER(hh, st->modules, mod, tmp) {
     if (mod->has_tla && mod->namespace_obj == ns) {
       *out_tla_promise = mod->tla_promise;
       mod->has_tla = false;

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -448,6 +448,8 @@ static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_v
   }
 
   ant_value_t ns = js_mkobj(js);
+  js_set_slot(ns, SLOT_BRAND, js_mknum(BRAND_MODULE_NAMESPACE));
+  
   if (is_object_type(value)) {
     ant_value_t keys = js_own_property_keys(js, value, false, true);
     ant_offset_t len = js_arr_len(js, keys);
@@ -1370,14 +1372,7 @@ static ant_value_t esm_load_text(ant_t *js, const char *path) {
   return result;
 }
 
-static ant_value_t esm_load_image(ant_t *js, const char *path) {
-  esm_file_data_t file;
-  ant_value_t err = esm_read_file(js, path, "image file", &file);
-  if (is_err(err)) return err;
-
-  unsigned char *content = (unsigned char *)file.data;
-  size_t size = file.size;
-
+static ant_value_t esm_image_value(ant_t *js, const unsigned char *content, size_t size, const char *path) {
   ant_value_t obj = js_mkobj(js);
   ant_value_t data_arr = js_mkarr(js);
 
@@ -1389,8 +1384,44 @@ static ant_value_t esm_load_image(ant_t *js, const char *path) {
   js_setprop(js, obj, js_mkstr(js, "path", 4), js_mkstr(js, path, strlen(path)));
   js_setprop(js, obj, js_mkstr(js, "size", 4), tov((double)size));
 
+  return obj;
+}
+
+static ant_value_t esm_load_image(ant_t *js, const char *path) {
+  esm_file_data_t file;
+  ant_value_t err = esm_read_file(js, path, "image file", &file);
+  if (is_err(err)) return err;
+
+  ant_value_t obj = esm_image_value(js, (const unsigned char *)file.data, file.size, path);
   free(file.data);
   return obj;
+}
+
+static ant_value_t esm_load_value_module(ant_t *js, esm_module_t *mod) {
+  if (!mod->embedded_code) {
+    switch (mod->kind) {
+      case ESM_MODULE_KIND_JSON: return esm_load_json(js, mod->resolved_path);
+      case ESM_MODULE_KIND_TEXT: return esm_load_text(js, mod->resolved_path);
+      default: return esm_load_image(js, mod->resolved_path);
+    }
+  }
+
+  size_t len = mod->embedded_code_len;
+  char *buf = (char *)malloc(len + 1);
+  if (!buf) return js_mkerr(js, "OOM loading module source");
+
+  memcpy(buf, mod->embedded_code, len);
+  buf[len] = '\0';
+
+  ant_value_t val;
+  switch (mod->kind) {
+    case ESM_MODULE_KIND_JSON: val = json_parse_value(js, js_mkstr(js, buf, len)); break;
+    case ESM_MODULE_KIND_TEXT: val = js_mkstr(js, buf, len); break;
+    default: val = esm_image_value(js, (const unsigned char *)buf, len, mod->resolved_path); break;
+  }
+
+  free(buf);
+  return val;
 }
 
 static void esm_module_record_cleanup(esm_module_record_t *record) {
@@ -1586,18 +1617,10 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
   mod->is_loading = true;
 
   switch (mod->kind) {
-    case ESM_MODULE_KIND_JSON: {
-      ant_value_t json_val = esm_load_json(js, mod->resolved_path);
-      return esm_complete_value_module(js, mod, json_val);
-    }
-    case ESM_MODULE_KIND_TEXT: {
-      ant_value_t text_val = esm_load_text(js, mod->resolved_path);
-      return esm_complete_value_module(js, mod, text_val);
-    }
-    case ESM_MODULE_KIND_IMAGE: {
-      ant_value_t img_val = esm_load_image(js, mod->resolved_path);
-      return esm_complete_value_module(js, mod, img_val);
-    }
+    case ESM_MODULE_KIND_JSON:
+    case ESM_MODULE_KIND_TEXT:
+    case ESM_MODULE_KIND_IMAGE:
+      return esm_complete_value_module(js, mod, esm_load_value_module(js, mod));
     case ESM_MODULE_KIND_NATIVE: {
       ant_value_t ns = esm_make_namespace_object(js);
       mod->namespace_obj = ns;
@@ -1861,7 +1884,11 @@ static ant_value_t esm_run_resolve_chain(ant_t *js, int level, ant_value_t spec,
   }
 
   ant_value_t out = js_mkobj(js);
-  if (!esm_lookup_builtin_alias(spec_copy, strlen(spec_copy))) {
+  bool scheme_passthrough = esm_has_builtin_scheme(spec_copy)
+    || esm_is_data_url(spec_copy)
+    || esm_is_url(spec_copy);
+
+  if (!scheme_passthrough && !esm_lookup_builtin_alias(spec_copy, strlen(spec_copy))) {
     if (!base_path || !base_path[0]) base_path = esm_default_base_path(js);
     char *resolved = esm_resolve(js, spec_copy, base_path, esm_resolve_path);
 
@@ -1989,25 +2016,25 @@ static ant_value_t esm_import_via_hooks(
   ant_value_t url_val = js_get(js, resolved, "url");
   GC_ROOT_PIN(js, url_val);
 
-  if (vtype(url_val) != T_STR || strncmp(js_getstr(js, url_val, NULL), "file://", 7) != 0) {
+  if (vtype(url_val) != T_STR) {
     GC_ROOT_RESTORE(js, root_mark);
     return js_mkundef();
   }
+
+  bool is_file_url = strncmp(js_getstr(js, url_val, NULL), "file://", 7) == 0;
 
   ant_value_t loaded = esm_run_load_chain(js, top, url_val, ctx);
   GC_ROOT_PIN(js, loaded);
 
   if (is_err(loaded)) {
+    if (!is_file_url) {
+      js_take_thrown(js, js_mkundef());
+      GC_ROOT_RESTORE(js, root_mark);
+      return js_mkundef();
+    }
     *handled = true;
     GC_ROOT_RESTORE(js, root_mark);
     return loaded;
-  }
-
-  const char *url = js_getstr(js, url_val, NULL);
-  char *fs_path = esm_file_url_to_path(js, url);
-  if (!fs_path) {
-    GC_ROOT_RESTORE(js, root_mark);
-    return js_mkundef();
   }
 
   ant_module_format_t format = MODULE_EVAL_FORMAT_UNKNOWN;
@@ -2017,7 +2044,6 @@ static ant_value_t esm_import_via_hooks(
     if (strcmp(fmt_str, "commonjs") == 0) format = MODULE_EVAL_FORMAT_CJS;
     else if (strcmp(fmt_str, "module") == 0) format = MODULE_EVAL_FORMAT_ESM;
   }
-  if (format == MODULE_EVAL_FORMAT_UNKNOWN) format = esm_decide_module_format(js, fs_path);
 
   const uint8_t *source = NULL;
   size_t source_len = 0;
@@ -2029,19 +2055,30 @@ static ant_value_t esm_import_via_hooks(
     source_len = (size_t)sl;
   }
 
-  if (esm_is_json(fs_path)) {
-    format = MODULE_EVAL_FORMAT_UNKNOWN;
-    source = NULL;
-    source_len = 0;
+  const char *url = js_getstr(js, url_val, NULL);
+  char *fs_path = esm_file_url_to_path(js, url);
+
+  if (!fs_path) {
+    if (!source) {
+      GC_ROOT_RESTORE(js, root_mark);
+      return js_mkundef();
+    }
+    *handled = true;
+    ant_value_t ns = esm_get_or_load(js, specifier, url, url, format, source, source_len);
+    GC_ROOT_RESTORE(js, root_mark);
+    return ns;
   }
 
-  const char *cache_key = strchr(url, '?') ? url : fs_path;
+  if (esm_is_json(fs_path)) format = MODULE_EVAL_FORMAT_UNKNOWN;
+  else if (format == MODULE_EVAL_FORMAT_UNKNOWN) format = esm_decide_module_format(js, fs_path);
+
+  const char *cache_key = (strchr(url, '?') || strchr(url, '#')) ? url : fs_path;
   *handled = true;
-  
+
   ant_value_t ns = esm_get_or_load(js, specifier, fs_path, cache_key, format, source, source_len);
   free(fs_path);
   GC_ROOT_RESTORE(js, root_mark);
-  
+
   return ns;
 }
 
@@ -2266,12 +2303,13 @@ ant_value_t js_esm_import_dynamic_ex(ant_t *js, ant_value_t specifier, const cha
 
   esm_module_t *mod = NULL, *tmp = NULL;
   if (st) HASH_ITER(hh, st->modules, mod, tmp) {
-  if (mod->has_tla && mod->namespace_obj == ns) {
-    *out_tla_promise = mod->tla_promise;
-    mod->has_tla = false;
-    mod->tla_promise = js_mkundef();
-    break;
-  }}
+    if (mod->has_tla && mod->namespace_obj == ns) {
+      *out_tla_promise = mod->tla_promise;
+      mod->has_tla = false;
+      mod->tla_promise = js_mkundef();
+      break;
+    }
+  }
 
   return ns;
 }

--- a/src/esm/loader_cache.c
+++ b/src/esm/loader_cache.c
@@ -233,12 +233,8 @@ yyjson_doc *esm_package_json_cache_read(const char *pkg_json_path) {
   }
 
   entry->doc = yyjson_read_file(pkg_json_path, 0, NULL, NULL);
-  if (!entry->doc) {
-    free(entry->path);
-    free(entry);
-    return NULL;
-  }
   HASH_ADD_STR(global_package_json_cache, path, entry);
+  
   return entry->doc;
 }
 

--- a/src/esm/loader_cache.c
+++ b/src/esm/loader_cache.c
@@ -1,6 +1,8 @@
 #include <compat.h> // IWYU pragma: keep
 #include "loader_cache.h"
 
+#include "internal.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,16 +40,21 @@ typedef struct esm_package_dir_cache_entry {
   UT_hash_handle hh;
 } esm_package_dir_cache_entry_t;
 
-static esm_resolve_cache_entry_t      *global_resolve_cache      = NULL;
-static esm_base_dir_cache_entry_t     *global_base_dir_cache     = NULL;
-static esm_package_dir_cache_entry_t  *global_package_dir_cache  = NULL;
-static esm_package_json_cache_entry_t *global_package_json_cache = NULL;
-static esm_path_resolve_cache_entry_t *global_path_resolve_cache = NULL;
+ant_esm_state_t *esm_state(ant_t *js) {
+  if (!js) return NULL;
+  if (js->esm.state) return js->esm.state;
+
+  ant_esm_state_t *st = calloc(1, sizeof(*st));
+  if (!st) return NULL;
+
+  js->esm.state = st;
+  return st;
+}
 
 static char *esm_make_pair_cache_key(const char *left, const char *right) {
   size_t left_len = left ? strlen(left) : 0;
   size_t right_len = right ? strlen(right) : 0;
-  
+
   size_t len = snprintf(
     NULL, 0, "%zu:%s:%zu:%s",
     left_len,
@@ -55,10 +62,10 @@ static char *esm_make_pair_cache_key(const char *left, const char *right) {
     right_len,
     right ? right : ""
   );
-  
+
   char *key = malloc(len + 1u);
   if (!key) return NULL;
-  
+
   snprintf(
     key, len + 1u, "%zu:%s:%zu:%s",
     left_len,
@@ -66,23 +73,25 @@ static char *esm_make_pair_cache_key(const char *left, const char *right) {
     right_len,
     right ? right : ""
   );
-  
+
   return key;
 }
 
-char *esm_resolve_cache_get(const char *key) {
-  if (!key) return NULL;
+char *esm_resolve_cache_get(ant_t *js, const char *key) {
+  ant_esm_state_t *st = esm_state(js);
+  if (!st || !key) return NULL;
 
   esm_resolve_cache_entry_t *entry = NULL;
-  HASH_FIND_STR(global_resolve_cache, key, entry);
+  HASH_FIND_STR(st->resolve_cache, key, entry);
   return entry ? strdup(entry->resolved_path) : NULL;
 }
 
-void esm_resolve_cache_put(const char *key, const char *resolved_path) {
-  if (!key || !resolved_path) return;
+void esm_resolve_cache_put(ant_t *js, const char *key, const char *resolved_path) {
+  ant_esm_state_t *st = esm_state(js);
+  if (!st || !key || !resolved_path) return;
 
   esm_resolve_cache_entry_t *existing = NULL;
-  HASH_FIND_STR(global_resolve_cache, key, existing);
+  HASH_FIND_STR(st->resolve_cache, key, existing);
   if (existing) return;
 
   esm_resolve_cache_entry_t *entry = (esm_resolve_cache_entry_t *)calloc(1, sizeof(*entry));
@@ -90,7 +99,7 @@ void esm_resolve_cache_put(const char *key, const char *resolved_path) {
 
   entry->key = strdup(key);
   entry->resolved_path = strdup(resolved_path);
-  
+
   if (!entry->key || !entry->resolved_path) {
     free(entry->key);
     free(entry->resolved_path);
@@ -98,26 +107,28 @@ void esm_resolve_cache_put(const char *key, const char *resolved_path) {
     return;
   }
 
-  HASH_ADD_STR(global_resolve_cache, key, entry);
+  HASH_ADD_STR(st->resolve_cache, key, entry);
 }
 
-bool esm_path_resolve_cache_get(const char *path, char **resolved_path_out) {
+bool esm_path_resolve_cache_get(ant_t *js, const char *path, char **resolved_path_out) {
   if (resolved_path_out) *resolved_path_out = NULL;
-  if (!path) return false;
+  ant_esm_state_t *st = esm_state(js);
+  if (!st || !path) return false;
 
   esm_path_resolve_cache_entry_t *entry = NULL;
-  HASH_FIND_STR(global_path_resolve_cache, path, entry);
+  HASH_FIND_STR(st->path_resolve_cache, path, entry);
   if (!entry) return false;
 
   if (resolved_path_out && entry->found) *resolved_path_out = strdup(entry->resolved_path);
   return true;
 }
 
-void esm_path_resolve_cache_put(const char *path, const char *resolved_path) {
-  if (!path) return;
+void esm_path_resolve_cache_put(ant_t *js, const char *path, const char *resolved_path) {
+  ant_esm_state_t *st = esm_state(js);
+  if (!st || !path) return;
 
   esm_path_resolve_cache_entry_t *existing = NULL;
-  HASH_FIND_STR(global_path_resolve_cache, path, existing);
+  HASH_FIND_STR(st->path_resolve_cache, path, existing);
   if (existing) return;
 
   esm_path_resolve_cache_entry_t *entry = (esm_path_resolve_cache_entry_t *)calloc(1, sizeof(*entry));
@@ -126,7 +137,7 @@ void esm_path_resolve_cache_put(const char *path, const char *resolved_path) {
   entry->key = strdup(path);
   entry->resolved_path = resolved_path ? strdup(resolved_path) : NULL;
   entry->found = resolved_path != NULL;
-  
+
   if (!entry->key || (resolved_path && !entry->resolved_path)) {
     free(entry->key);
     free(entry->resolved_path);
@@ -134,26 +145,28 @@ void esm_path_resolve_cache_put(const char *path, const char *resolved_path) {
     return;
   }
 
-  HASH_ADD_STR(global_path_resolve_cache, key, entry);
+  HASH_ADD_STR(st->path_resolve_cache, key, entry);
 }
 
-bool esm_base_dir_cache_get(const char *base_path, char **base_dir_out) {
+bool esm_base_dir_cache_get(ant_t *js, const char *base_path, char **base_dir_out) {
   if (base_dir_out) *base_dir_out = NULL;
-  if (!base_path) return false;
+  ant_esm_state_t *st = esm_state(js);
+  if (!st || !base_path) return false;
 
   esm_base_dir_cache_entry_t *entry = NULL;
-  HASH_FIND_STR(global_base_dir_cache, base_path, entry);
+  HASH_FIND_STR(st->base_dir_cache, base_path, entry);
   if (!entry) return false;
 
   if (base_dir_out) *base_dir_out = strdup(entry->base_dir);
   return true;
 }
 
-void esm_base_dir_cache_put(const char *base_path, const char *base_dir) {
-  if (!base_path || !base_dir) return;
+void esm_base_dir_cache_put(ant_t *js, const char *base_path, const char *base_dir) {
+  ant_esm_state_t *st = esm_state(js);
+  if (!st || !base_path || !base_dir) return;
 
   esm_base_dir_cache_entry_t *existing = NULL;
-  HASH_FIND_STR(global_base_dir_cache, base_path, existing);
+  HASH_FIND_STR(st->base_dir_cache, base_path, existing);
   if (existing) return;
 
   esm_base_dir_cache_entry_t *entry = (esm_base_dir_cache_entry_t *)calloc(1, sizeof(*entry));
@@ -161,7 +174,7 @@ void esm_base_dir_cache_put(const char *base_path, const char *base_dir) {
 
   entry->key = strdup(base_path);
   entry->base_dir = strdup(base_dir);
-  
+
   if (!entry->key || !entry->base_dir) {
     free(entry->key);
     free(entry->base_dir);
@@ -169,16 +182,19 @@ void esm_base_dir_cache_put(const char *base_path, const char *base_dir) {
     return;
   }
 
-  HASH_ADD_STR(global_base_dir_cache, key, entry);
+  HASH_ADD_STR(st->base_dir_cache, key, entry);
 }
 
-bool esm_package_dir_cache_get(const char *start_dir, const char *package_name, char **package_dir_out) {
+bool esm_package_dir_cache_get(ant_t *js, const char *start_dir, const char *package_name, char **package_dir_out) {
   if (package_dir_out) *package_dir_out = NULL;
+  ant_esm_state_t *st = esm_state(js);
+  if (!st) return false;
+
   char *key = esm_make_pair_cache_key(start_dir, package_name);
   if (!key) return false;
 
   esm_package_dir_cache_entry_t *entry = NULL;
-  HASH_FIND_STR(global_package_dir_cache, key, entry);
+  HASH_FIND_STR(st->package_dir_cache, key, entry);
   free(key);
   if (!entry) return false;
 
@@ -186,12 +202,15 @@ bool esm_package_dir_cache_get(const char *start_dir, const char *package_name, 
   return true;
 }
 
-void esm_package_dir_cache_put(const char *start_dir, const char *package_name, const char *package_dir) {
+void esm_package_dir_cache_put(ant_t *js, const char *start_dir, const char *package_name, const char *package_dir) {
+  ant_esm_state_t *st = esm_state(js);
+  if (!st) return;
+
   char *key = esm_make_pair_cache_key(start_dir, package_name);
   if (!key) return;
 
   esm_package_dir_cache_entry_t *existing = NULL;
-  HASH_FIND_STR(global_package_dir_cache, key, existing);
+  HASH_FIND_STR(st->package_dir_cache, key, existing);
   if (existing) {
     free(key);
     return;
@@ -206,21 +225,24 @@ void esm_package_dir_cache_put(const char *start_dir, const char *package_name, 
   entry->key = key;
   entry->package_dir = package_dir ? strdup(package_dir) : NULL;
   entry->found = package_dir != NULL;
-  
+
   if (package_dir && !entry->package_dir) {
     free(entry->key);
     free(entry);
     return;
   }
 
-  HASH_ADD_STR(global_package_dir_cache, key, entry);
+  HASH_ADD_STR(st->package_dir_cache, key, entry);
 }
 
-yyjson_doc *esm_package_json_cache_read(const char *pkg_json_path) {
+yyjson_doc *esm_package_json_cache_read(ant_t *js, const char *pkg_json_path) {
   if (!pkg_json_path || !pkg_json_path[0]) return NULL;
 
+  ant_esm_state_t *st = esm_state(js);
+  if (!st) return yyjson_read_file(pkg_json_path, 0, NULL, NULL);
+
   esm_package_json_cache_entry_t *entry = NULL;
-  HASH_FIND_STR(global_package_json_cache, pkg_json_path, entry);
+  HASH_FIND_STR(st->package_json_cache, pkg_json_path, entry);
   if (entry) return entry->doc;
 
   entry = (esm_package_json_cache_entry_t *)calloc(1, sizeof(*entry));
@@ -233,49 +255,55 @@ yyjson_doc *esm_package_json_cache_read(const char *pkg_json_path) {
   }
 
   entry->doc = yyjson_read_file(pkg_json_path, 0, NULL, NULL);
-  HASH_ADD_STR(global_package_json_cache, path, entry);
-  
+  HASH_ADD_STR(st->package_json_cache, path, entry);
+
   return entry->doc;
 }
 
-void esm_loader_cache_cleanup(void) {
+void esm_loader_cache_cleanup(ant_t *js) {
+  ant_esm_state_t *st = js ? js->esm.state : NULL;
+  if (!st) return;
+
   esm_package_json_cache_entry_t *pkg_current, *pkg_tmp;
-  HASH_ITER(hh, global_package_json_cache, pkg_current, pkg_tmp) {
-    HASH_DEL(global_package_json_cache, pkg_current);
+  HASH_ITER(hh, st->package_json_cache, pkg_current, pkg_tmp) {
+    HASH_DEL(st->package_json_cache, pkg_current);
     free(pkg_current->path);
     if (pkg_current->doc) yyjson_doc_free(pkg_current->doc);
     free(pkg_current);
   }
 
   esm_resolve_cache_entry_t *resolve_current, *resolve_tmp;
-  HASH_ITER(hh, global_resolve_cache, resolve_current, resolve_tmp) {
-    HASH_DEL(global_resolve_cache, resolve_current);
+  HASH_ITER(hh, st->resolve_cache, resolve_current, resolve_tmp) {
+    HASH_DEL(st->resolve_cache, resolve_current);
     free(resolve_current->key);
     free(resolve_current->resolved_path);
     free(resolve_current);
   }
 
   esm_path_resolve_cache_entry_t *path_current, *path_tmp;
-  HASH_ITER(hh, global_path_resolve_cache, path_current, path_tmp) {
-    HASH_DEL(global_path_resolve_cache, path_current);
+  HASH_ITER(hh, st->path_resolve_cache, path_current, path_tmp) {
+    HASH_DEL(st->path_resolve_cache, path_current);
     free(path_current->key);
     free(path_current->resolved_path);
     free(path_current);
   }
 
   esm_base_dir_cache_entry_t *base_current, *base_tmp;
-  HASH_ITER(hh, global_base_dir_cache, base_current, base_tmp) {
-    HASH_DEL(global_base_dir_cache, base_current);
+  HASH_ITER(hh, st->base_dir_cache, base_current, base_tmp) {
+    HASH_DEL(st->base_dir_cache, base_current);
     free(base_current->key);
     free(base_current->base_dir);
     free(base_current);
   }
 
   esm_package_dir_cache_entry_t *dir_current, *dir_tmp;
-  HASH_ITER(hh, global_package_dir_cache, dir_current, dir_tmp) {
-    HASH_DEL(global_package_dir_cache, dir_current);
+  HASH_ITER(hh, st->package_dir_cache, dir_current, dir_tmp) {
+    HASH_DEL(st->package_dir_cache, dir_current);
     free(dir_current->key);
     free(dir_current->package_dir);
     free(dir_current);
   }
+
+  free(st);
+  js->esm.state = NULL;
 }

--- a/src/esm/loader_cache.c
+++ b/src/esm/loader_cache.c
@@ -235,22 +235,30 @@ void esm_package_dir_cache_put(ant_t *js, const char *start_dir, const char *pac
   HASH_ADD_STR(st->package_dir_cache, key, entry);
 }
 
-yyjson_doc *esm_package_json_cache_read(ant_t *js, const char *pkg_json_path) {
+yyjson_doc *esm_package_json_cache_read(ant_t *js, const char *pkg_json_path, bool *out_owned) {
+  *out_owned = false;
   if (!pkg_json_path || !pkg_json_path[0]) return NULL;
 
   ant_esm_state_t *st = esm_state(js);
-  if (!st) return yyjson_read_file(pkg_json_path, 0, NULL, NULL);
+  if (!st) {
+    *out_owned = true;
+    return yyjson_read_file(pkg_json_path, 0, NULL, NULL);
+  }
 
   esm_package_json_cache_entry_t *entry = NULL;
   HASH_FIND_STR(st->package_json_cache, pkg_json_path, entry);
   if (entry) return entry->doc;
 
   entry = (esm_package_json_cache_entry_t *)calloc(1, sizeof(*entry));
-  if (!entry) return yyjson_read_file(pkg_json_path, 0, NULL, NULL);
+  if (!entry) {
+    *out_owned = true;
+    return yyjson_read_file(pkg_json_path, 0, NULL, NULL);
+  }
 
   entry->path = strdup(pkg_json_path);
   if (!entry->path) {
     free(entry);
+    *out_owned = true;
     return yyjson_read_file(pkg_json_path, 0, NULL, NULL);
   }
 

--- a/src/esm/loader_cache.h
+++ b/src/esm/loader_cache.h
@@ -1,19 +1,35 @@
 #pragma once
 
+#include "types.h"
+
 #include <stdbool.h>
 #include <yyjson.h>
 
-char *esm_resolve_cache_get(const char *key);
-void esm_resolve_cache_put(const char *key, const char *resolved_path);
+struct ant_esm_state {
+  struct esm_resolve_cache_entry      *resolve_cache;
+  struct esm_base_dir_cache_entry     *base_dir_cache;
+  struct esm_package_dir_cache_entry  *package_dir_cache;
+  struct esm_package_json_cache_entry *package_json_cache;
+  struct esm_path_resolve_cache_entry *path_resolve_cache;
 
-bool esm_path_resolve_cache_get(const char *path, char **resolved_path_out);
-void esm_path_resolve_cache_put(const char *path, const char *resolved_path);
+  struct esm_module *modules;
+  int module_count;
+  int dynamic_import_depth;
+};
 
-bool esm_base_dir_cache_get(const char *base_path, char **base_dir_out);
-void esm_base_dir_cache_put(const char *base_path, const char *base_dir);
+ant_esm_state_t *esm_state(ant_t *js);
 
-bool esm_package_dir_cache_get(const char *start_dir, const char *package_name, char **package_dir_out);
-void esm_package_dir_cache_put(const char *start_dir, const char *package_name, const char *package_dir);
+char *esm_resolve_cache_get(ant_t *js, const char *key);
+void esm_resolve_cache_put(ant_t *js, const char *key, const char *resolved_path);
 
-yyjson_doc *esm_package_json_cache_read(const char *pkg_json_path);
-void esm_loader_cache_cleanup(void);
+bool esm_path_resolve_cache_get(ant_t *js, const char *path, char **resolved_path_out);
+void esm_path_resolve_cache_put(ant_t *js, const char *path, const char *resolved_path);
+
+bool esm_base_dir_cache_get(ant_t *js, const char *base_path, char **base_dir_out);
+void esm_base_dir_cache_put(ant_t *js, const char *base_path, const char *base_dir);
+
+bool esm_package_dir_cache_get(ant_t *js, const char *start_dir, const char *package_name, char **package_dir_out);
+void esm_package_dir_cache_put(ant_t *js, const char *start_dir, const char *package_name, const char *package_dir);
+
+yyjson_doc *esm_package_json_cache_read(ant_t *js, const char *pkg_json_path);
+void esm_loader_cache_cleanup(ant_t *js);

--- a/src/esm/loader_cache.h
+++ b/src/esm/loader_cache.h
@@ -13,6 +13,7 @@ struct ant_esm_state {
   struct esm_path_resolve_cache_entry *path_resolve_cache;
 
   struct esm_module *modules;
+  struct esm_module *last_tla_module;
   int module_count;
   int dynamic_import_depth;
 };
@@ -31,5 +32,5 @@ void esm_base_dir_cache_put(ant_t *js, const char *base_path, const char *base_d
 bool esm_package_dir_cache_get(ant_t *js, const char *start_dir, const char *package_name, char **package_dir_out);
 void esm_package_dir_cache_put(ant_t *js, const char *start_dir, const char *package_name, const char *package_dir);
 
-yyjson_doc *esm_package_json_cache_read(ant_t *js, const char *pkg_json_path);
+yyjson_doc *esm_package_json_cache_read(ant_t *js, const char *pkg_json_path, bool *out_owned);
 void esm_loader_cache_cleanup(ant_t *js);

--- a/src/esm/remote.c
+++ b/src/esm/remote.c
@@ -397,8 +397,8 @@ char *esm_resolve_url(const char *specifier, const char *base_url) {
   return strdup(specifier);
 }
 
-char *esm_resolve(const char *specifier, const char *base_path, char FILE_RESOLVER) {
+char *esm_resolve(ant_t *js, const char *specifier, const char *base_path, char FILE_RESOLVER) {
   if (esm_is_data_url(specifier)) return strdup(specifier);
   if (esm_is_url(specifier) || esm_is_url(base_path)) return esm_resolve_url(specifier, base_path);
-  return file_resolver(specifier, base_path);
+  return file_resolver(js, specifier, base_path);
 }

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -580,6 +580,8 @@ static void gc_mark_roots(ant_t *js) {
 
   gc_mark_value(js, js->global);
   gc_mark_value(js, js->Ant);
+  gc_mark_value(js, js->esm.hooks);
+  gc_mark_value(js, js->esm.import_attributes);
   gc_mark_value(js, js->sym.object_proto);
   gc_mark_value(js, js->sym.array_proto);
   gc_mark_value(js, js->this_val);

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -581,7 +581,7 @@ static void gc_mark_roots(ant_t *js) {
   gc_mark_value(js, js->global);
   gc_mark_value(js, js->Ant);
   gc_mark_value(js, js->esm.hooks);
-  gc_mark_value(js, js->esm.import_attributes);
+  gc_mark_value(js, js->esm.import_meta);
   gc_mark_value(js, js->sym.object_proto);
   gc_mark_value(js, js->sym.array_proto);
   gc_mark_value(js, js->this_val);
@@ -591,7 +591,7 @@ static void gc_mark_roots(ant_t *js) {
   gc_mark_value(js, js->thrown_stack);
   gc_mark_value(js, js->length_str);
 
-  for (ant_module_t *ctx = js->module; ctx; ctx = ctx->prev) {
+  for (ant_module_t *ctx = js->esm.module_stack; ctx; ctx = ctx->prev) {
     gc_mark_value(js, ctx->module_ns);
     gc_mark_value(js, ctx->module_ctx);
     gc_mark_value(js, ctx->prev_import_meta_prop);

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -173,18 +173,26 @@ static ant_value_t builtin_module_isBuiltin(ant_t *js, ant_value_t *args, int na
 }
 
 static ant_value_t builtin_module_deregisterHooks(ant_t *js, ant_value_t *args, int nargs) {
-  ant_value_t hook = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
-  if (vtype(js->esm.hooks) != T_ARR) return js_mkundef();
+  ant_value_t self = js_getcurrentfunc(js);
+  ant_value_t hook = js_get_slot(self, SLOT_DATA);
+  if (vtype(hook) == T_UNDEF || vtype(js->esm.hooks) != T_ARR) return js_mkundef();
 
   ant_value_t remaining = js_mkarr(js);
   ant_offset_t len = js_arr_len(js, js->esm.hooks);
+  bool removed = false;
 
   for (ant_offset_t i = 0; i < len; i++) {
     ant_value_t entry = js_arr_get(js, js->esm.hooks, i);
-    if (entry != hook) js_arr_push(js, remaining, entry);
+    if (!removed && entry == hook) {
+      removed = true;
+      continue;
+    }
+    js_arr_push(js, remaining, entry);
   }
 
   js->esm.hooks = remaining;
+  js_set_slot(self, SLOT_DATA, js_mkundef());
+  
   return js_mkundef();
 }
 

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -166,9 +166,66 @@ static ant_value_t builtin_resolveFilename(ant_t *js, ant_value_t *args, int nar
   return resolved;
 }
 
+typedef struct { 
+  const char *name; 
+  bool found; 
+} builtin_lookup_ctx_t;
+
+static void match_builtin_name(const char *name, void *ud) {
+  builtin_lookup_ctx_t *ctx = (builtin_lookup_ctx_t *)ud;
+  if (!ctx->found && strcmp(name, ctx->name) == 0) ctx->found = true;
+}
+
+static ant_value_t builtin_module_isBuiltin(ant_t *js, ant_value_t *args, int nargs) {
+  if (nargs < 1 || vtype(args[0]) != T_STR) return js_false;
+
+  const char *name = js_getstr(js, args[0], NULL);
+  if (strncmp(name, "node:", 5) == 0) name += 5;
+
+  builtin_lookup_ctx_t ctx = { name, false };
+  ant_library_foreach(match_builtin_name, &ctx);
+  return js_bool(ctx.found);
+}
+
+static ant_value_t builtin_module_deregisterHooks(ant_t *js, ant_value_t *args, int nargs) {
+  ant_value_t hook = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  if (vtype(js->esm.hooks) != T_ARR) return js_mkundef();
+
+  ant_value_t remaining = js_mkarr(js);
+  ant_offset_t len = js_arr_len(js, js->esm.hooks);
+
+  for (ant_offset_t i = 0; i < len; i++) {
+    ant_value_t entry = js_arr_get(js, js->esm.hooks, i);
+    if (entry != hook) js_arr_push(js, remaining, entry);
+  }
+
+  js->esm.hooks = remaining;
+  return js_mkundef();
+}
+
+static ant_value_t builtin_module_registerHooks(ant_t *js, ant_value_t *args, int nargs) {
+  if (nargs < 1 || !is_object_type(args[0]))
+    return js_mkerr_typed(js, JS_ERR_TYPE, "registerHooks requires an options object");
+
+  if (vtype(js->esm.hooks) != T_ARR) js->esm.hooks = js_mkarr(js);
+  js_arr_push(js, js->esm.hooks, args[0]);
+
+  ant_value_t dereg_obj = js_mkobj(js);
+  js_set_slot(dereg_obj, SLOT_CFUNC, js_mkfun(builtin_module_deregisterHooks));
+  js_set_slot(dereg_obj, SLOT_DATA, args[0]);
+
+  ant_value_t out = js_mkobj(js);
+  js_set(js, out, "deregister", js_obj_to_func(js, dereg_obj));
+  
+  return out;
+}
+
 ant_value_t module_library(ant_t *js) {
   ant_value_t lib = js_mkobj(js);
+  
   js_set(js, lib, "createRequire", js_mkfun(builtin_createRequire));
+  js_set(js, lib, "registerHooks", js_mkfun(builtin_module_registerHooks));
+  js_set(js, lib, "isBuiltin", js_mkfun(builtin_module_isBuiltin));
 
   ant_value_t modules_arr = js_mkarr(js);
   builtin_iter_ctx_t ctx = { js, modules_arr };

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -10,6 +10,7 @@
 #include "internal.h"
 #include "esm/loader.h"
 #include "esm/library.h"
+#include "gc/roots.h"
 #include "modules/symbol.h"
 
 typedef struct { ant_t *js; ant_value_t arr; } builtin_iter_ctx_t;
@@ -179,7 +180,10 @@ static ant_value_t builtin_module_deregisterHooks(ant_t *js, ant_value_t *args, 
   ant_value_t hook = js_get_slot(self, SLOT_DATA);
   if (vtype(hook) == T_UNDEF || vtype(js->esm.hooks) != T_ARR) return js_mkundef();
 
+  GC_ROOT_SAVE(root_mark, js);
   ant_value_t remaining = js_mkarr(js);
+  GC_ROOT_PIN(js, remaining);
+
   ant_offset_t len = js_arr_len(js, js->esm.hooks);
   bool removed = false;
 
@@ -194,7 +198,8 @@ static ant_value_t builtin_module_deregisterHooks(ant_t *js, ant_value_t *args, 
 
   js->esm.hooks = remaining;
   js_set_slot(self, SLOT_DATA, js_mkundef());
-  
+
+  GC_ROOT_RESTORE(js, root_mark);
   return js_mkundef();
 }
 
@@ -219,13 +224,17 @@ static ant_value_t builtin_module_registerHooks(ant_t *js, ant_value_t *args, in
   if (vtype(js->esm.hooks) != T_ARR) js->esm.hooks = js_mkarr(js);
   js_arr_push(js, js->esm.hooks, args[0]);
 
+  GC_ROOT_SAVE(root_mark, js);
   ant_value_t dereg_obj = js_mkobj(js);
+  GC_ROOT_PIN(js, dereg_obj);
   js_set_slot(dereg_obj, SLOT_CFUNC, js_mkfun(builtin_module_deregisterHooks));
   js_set_slot(dereg_obj, SLOT_DATA, args[0]);
 
   ant_value_t out = js_mkobj(js);
+  GC_ROOT_PIN(js, out);
   js_set(js, out, "deregister", js_obj_to_func(js, dereg_obj));
-  
+
+  GC_ROOT_RESTORE(js, root_mark);
   return out;
 }
 

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -148,22 +148,7 @@ static ant_value_t builtin_resolveFilename(ant_t *js, ant_value_t *args, int nar
   }
 
   ant_value_t resolved = js_esm_resolve_specifier(js, args[0], base_path);
-  if (is_err(resolved)) return resolved;
-  if (vtype(resolved) != T_STR) return resolved;
-
-  ant_offset_t len = 0;
-  ant_offset_t off = vstr(js, resolved, &len);
-  
-  const char *s = (const char *)(uintptr_t)(off);
-  static const char *prefix = "file://";
-
-  if ((size_t)len >= strlen(prefix) && strncmp(s, prefix, strlen(prefix)) == 0) {
-    const char *path_part = s + strlen(prefix);
-    size_t plen = (size_t)len - strlen(prefix);
-    return js_mkstr(js, path_part, plen);
-  }
-
-  return resolved;
+  return resolve_strip_file_url(js, resolved);
 }
 
 typedef struct { 

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -164,7 +164,9 @@ static void match_builtin_name(const char *name, void *ud) {
 static ant_value_t builtin_module_isBuiltin(ant_t *js, ant_value_t *args, int nargs) {
   if (nargs < 1 || vtype(args[0]) != T_STR) return js_false;
 
-  const char *name = js_getstr(js, args[0], NULL);
+  size_t name_len = 0;
+  const char *name = js_getstr(js, args[0], &name_len);
+  if (!name || strlen(name) != name_len) return js_false;
   if (strncmp(name, "node:", 5) == 0) name += 5;
 
   builtin_lookup_ctx_t ctx = { name, false };
@@ -196,9 +198,23 @@ static ant_value_t builtin_module_deregisterHooks(ant_t *js, ant_value_t *args, 
   return js_mkundef();
 }
 
+static bool hook_member_invalid(ant_value_t fn) {
+  return vtype(fn) != T_UNDEF && vtype(fn) != T_FUNC && vtype(fn) != T_CFUNC;
+}
+
 static ant_value_t builtin_module_registerHooks(ant_t *js, ant_value_t *args, int nargs) {
   if (nargs < 1 || !is_object_type(args[0]))
     return js_mkerr_typed(js, JS_ERR_TYPE, "registerHooks requires an options object");
+
+  ant_value_t resolve_fn = js_get(js, args[0], "resolve");
+  if (is_err(resolve_fn)) return resolve_fn;
+  if (hook_member_invalid(resolve_fn))
+    return js_mkerr_typed(js, JS_ERR_TYPE, "The 'resolve' hook must be a function");
+
+  ant_value_t load_fn = js_get(js, args[0], "load");
+  if (is_err(load_fn)) return load_fn;
+  if (hook_member_invalid(load_fn))
+    return js_mkerr_typed(js, JS_ERR_TYPE, "The 'load' hook must be a function");
 
   if (vtype(js->esm.hooks) != T_ARR) js->esm.hooks = js_mkarr(js);
   js_arr_push(js, js->esm.hooks, args[0]);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -29,11 +29,11 @@ typedef struct code_block {
   char data[];
 } code_block_t;
 
-_Static_assert(
+static_assert(
   (CODE_ARENA_ALIGNMENT & (CODE_ARENA_ALIGNMENT - 1u)) == 0,
   "code arena alignment must be a power of two"
 );
-_Static_assert(
+static_assert(
   offsetof(code_block_t, data) % CODE_ARENA_ALIGNMENT == 0,
   "code arena block payload must satisfy the arena alignment"
 );

--- a/src/shapes.c
+++ b/src/shapes.c
@@ -26,7 +26,7 @@ typedef struct shape_child_entry {
   UT_hash_handle hh;
 } shape_child_entry_t;
 
-_Static_assert(
+static_assert(
   sizeof(shape_index_entry_t) == sizeof(shape_child_entry_t), 
   "entry pool requires index and child entries to be the same size"
 );

--- a/src/silver/ast.c
+++ b/src/silver/ast.c
@@ -834,7 +834,11 @@ static sv_ast_t *parse_primary(P) {
     if (NEXT() != TOK_LPAREN) return mk_ident("import", 6);
     CONSUME();
     sv_ast_t *n = mk(N_IMPORT);
-    n->right = parse_expr(p);
+    n->right = parse_assign(p);
+    if (NEXT() == TOK_COMMA && (CONSUME(), NEXT() != TOK_RPAREN)) {
+      n->left = parse_assign(p);
+      if (NEXT() == TOK_COMMA) CONSUME();
+    }
     expect(p, TOK_RPAREN);
     return n;
   }

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -2955,7 +2955,7 @@ void compile_typeof(sv_compiler_t *c, sv_ast_t *node) {
     if (local != -1) {
       uint8_t inferred = get_local_inferred_type(c, local);
       const char *known = typeof_name_for_type(inferred);
-      if (known && c->with_depth == 0) {
+      if (known && c->with_depth == 0 && c->locals[local].is_const) {
         emit_constant(c, js_mkstr_permanent(c->js, known, strlen(known)));
         return;
       }
@@ -4925,6 +4925,7 @@ static bool fold_static_typeof_compare(
   sv_ast_t *ident = typeof_node->right;
   int local = resolve_local(c, ident->str, ident->len);
   if (local < 0) return false;
+  if (!c->locals[local].is_const) return false;
   const char *known = typeof_name_for_type(get_local_inferred_type(c, local));
   if (!known) return false;
 

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -4925,7 +4925,7 @@ static bool fold_static_typeof_compare(
   sv_ast_t *ident = typeof_node->right;
   int local = resolve_local(c, ident->str, ident->len);
   if (local < 0) return false;
-  if (!c->locals[local].is_const) return false;
+  if (c->with_depth > 0 || !c->locals[local].is_const) return false;
   const char *known = typeof_name_for_type(get_local_inferred_type(c, local));
   if (!known) return false;
 

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -2462,13 +2462,19 @@ void compile_expr(sv_compiler_t *c, sv_ast_t *node) {
     }
 
     case N_IMPORT:
-      compile_expr(c, node->right);
       if (has_module_import_binding(c)) {
         emit_get_module_import_binding(c);
-        emit_op(c, OP_SWAP);
+        compile_expr(c, node->right);
+        if (node->left) compile_expr(c, node->left);
+        else emit_op(c, OP_UNDEF);
         emit_op(c, OP_CALL);
-        emit_u16(c, 1);
-      } else emit_op(c, OP_IMPORT);
+        emit_u16(c, 2);
+      } else {
+        compile_expr(c, node->right);
+        if (node->left) compile_expr(c, node->left);
+        else emit_op(c, OP_UNDEF);
+        emit_op(c, OP_IMPORT);
+      }
       break;
 
     case N_REGEXP:

--- a/src/silver/ops/async.h
+++ b/src/silver/ops/async.h
@@ -75,13 +75,13 @@ static inline void sv_async_init_activation(
 }
 
 static inline ant_value_t sv_capture_tla_module_ctx(ant_t *js, coroutine_t *coro) {
-  if (!js || !coro || !js->module || vtype(js->module->module_ns) != T_OBJ)
+  if (!js || !coro || !js->esm.module_stack || vtype(js->esm.module_stack->module_ns) != T_OBJ)
     return js_mkundef();
 
   ant_module_t *ctx = calloc(1, sizeof(ant_module_t));
   if (!ctx) return js_mkerr(js, "out of memory for TLA module context");
 
-  *ctx = *js->module;
+  *ctx = *js->esm.module_stack;
   ctx->prev = NULL;
   ctx->prev_import_meta_prop = js_mkundef();
   coro->module_eval_ctx = ctx;

--- a/src/silver/ops/coercion.h
+++ b/src/silver/ops/coercion.h
@@ -93,18 +93,20 @@ static inline void sv_op_is_null(sv_vm_t *vm) {
 }
 
 static inline ant_value_t sv_op_import(sv_vm_t *vm, ant_t *js) {
+  ant_value_t options = vm->stack[--vm->sp];
   ant_value_t specifier = vm->stack[--vm->sp];
   ant_value_t import_fn = js_get_module_import_binding(js);
-  
+
   if (vtype(import_fn) != T_FUNC && vtype(import_fn) != T_CFUNC)
     import_fn = js_getprop_fallback(js, js->global, "import");
-    
+
   if (vtype(import_fn) == T_FUNC || vtype(import_fn) == T_CFUNC) {
-    ant_value_t result = sv_vm_call(vm, js, import_fn, js->global, &specifier, 1, NULL, false);
+    ant_value_t call_args[2] = { specifier, options };
+    ant_value_t result = sv_vm_call(vm, js, import_fn, js->global, call_args, 2, NULL, false);
     if (!is_err(result)) vm->stack[vm->sp++] = result;
     return result;
   }
-  
+
   vm->stack[vm->sp++] = mkval(T_UNDEF, 0);
   return tov(0);
 }

--- a/src/silver/ops/iteration.h
+++ b/src/silver/ops/iteration.h
@@ -9,11 +9,13 @@
 #include "modules/symbol.h"
 #include "modules/collections.h"
 
-#define SV_ITER_GENERIC  0
-#define SV_ITER_ARRAY    1
-#define SV_ITER_MAP      2
-#define SV_ITER_SET      3
-#define SV_ITER_STRING   4
+enum: uint8_t {
+  SV_ITER_GENERIC = 0,
+  SV_ITER_ARRAY   = 1,
+  SV_ITER_MAP     = 2,
+  SV_ITER_SET     = 3,
+  SV_ITER_STRING  = 4,
+};
 
 static inline ant_value_t sv_op_for_in(sv_vm_t *vm, ant_t *js) {
   ant_value_t obj = vm->stack[--vm->sp];
@@ -131,6 +133,14 @@ static inline ant_value_t sv_op_for_of(sv_vm_t *vm, ant_t *js) {
 
 static inline ant_value_t sv_op_for_await_of(sv_vm_t *vm, ant_t *js) {
   ant_value_t iterable = vm->stack[--vm->sp];
+
+  if (vtype(iterable) == T_ARR) {
+    vm->stack[vm->sp++] = iterable;
+    vm->stack[vm->sp++] = tov(0);
+    vm->stack[vm->sp++] = SV_AITER_ARRAY_TAG;
+    return tov(0);
+  }
+
   GC_ROOT_SAVE(root_mark, js);
   GC_ROOT_PIN(js, iterable);
 
@@ -328,7 +338,13 @@ static inline void sv_op_iter_get_value(sv_vm_t *vm, ant_t *js) {
 }
 
 static inline void sv_op_iter_close(sv_vm_t *vm, ant_t *js) {
-  int tag = (int)js_getnum(vm->stack[vm->sp - 1]);
+  ant_value_t tag_val = vm->stack[vm->sp - 1];
+  if (vtype(tag_val) != T_NUM) {
+    vm->sp -= 3;
+    return;
+  }
+
+  int tag = (int)js_getnum(tag_val);
   if (tag == SV_ITER_GENERIC) {
     ant_value_t iterator = vm->stack[vm->sp - 3];
     ant_value_t return_fn = js_getprop_fallback(js, iterator, "return");
@@ -387,6 +403,48 @@ static inline sv_await_result_t sv_op_await_iter_next(sv_vm_t *vm, ant_t *js) {
     .state = SV_AWAIT_READY,
     .value = js_mkundef(),
   };
+
+  if (vm->sp >= 4 && vm->stack[vm->sp - 2] == SV_AITER_AWAIT_MARK) {
+    ant_value_t value = vm->stack[--vm->sp];
+    vm->stack[vm->sp - 1] = SV_AITER_ARRAY_TAG;
+    vm->stack[vm->sp++] = value;
+    vm->stack[vm->sp++] = mkval(T_BOOL, 0);
+    return out;
+  }
+
+  if (vm->sp >= 3 && vm->stack[vm->sp - 1] == SV_AITER_ARRAY_TAG) {
+    ant_value_t arr = vm->stack[vm->sp - 3];
+    int idx = (int)js_getnum(vm->stack[vm->sp - 2]);
+    ant_offset_t len = js_arr_len(js, arr);
+
+    if (idx >= (int)len) {
+      vm->stack[vm->sp++] = js_mkundef();
+      vm->stack[vm->sp++] = mkval(T_BOOL, 1);
+      return out;
+    }
+
+    ant_value_t value = js_arr_get(js, arr, (ant_offset_t)idx);
+    vm->stack[vm->sp - 2] = tov(idx + 1);
+
+    if (vtype(value) != T_PROMISE) {
+      vm->stack[vm->sp++] = value;
+      vm->stack[vm->sp++] = mkval(T_BOOL, 0);
+      return out;
+    }
+
+    vm->stack[vm->sp - 1] = SV_AITER_AWAIT_MARK;
+    vm->suspended_entry_fp = vm->fp;
+    vm->suspended_saved_fp = vm->fp - 1;
+    sv_await_result_t awaited = sv_await_value(vm, js, value);
+    vm->suspended_entry_fp = -1;
+    vm->suspended_saved_fp = -1;
+    if (awaited.state != SV_AWAIT_READY) return awaited;
+
+    vm->stack[vm->sp - 1] = SV_AITER_ARRAY_TAG;
+    vm->stack[vm->sp++] = awaited.value;
+    vm->stack[vm->sp++] = mkval(T_BOOL, 0);
+    return out;
+  }
 
   bool has_resumed_value = vm->sp >= 5 &&
     vtype(vm->stack[vm->sp - 2]) == T_BOOL &&

--- a/src/watch.c
+++ b/src/watch.c
@@ -491,7 +491,7 @@ static void watch_graph_add_specifier(const char *specifier, bool prefer_require
   watch_graph_context_t *ctx = (watch_graph_context_t *)data;
   if (!watch_is_local_specifier(specifier)) return;
 
-  char *resolved = js_esm_resolve_path_for_watch(specifier, ctx->base_path, prefer_require);
+  char *resolved = js_esm_resolve_path_for_watch(NULL, specifier, ctx->base_path, prefer_require);
   if (!resolved) return;
 
   if (esm_is_url(resolved)) {

--- a/tests/harness/manifest.js
+++ b/tests/harness/manifest.js
@@ -20,7 +20,8 @@ export function targets() {
     'test_jit_inline_call_errors.cjs',
     'test_string_length_accumulation.cjs',
     'test_node_http_incoming_message_readable.cjs',
-    'test_stream_readable_to_web.cjs'
+    'test_stream_readable_to_web.cjs',
+    'test_esm_package_self_reference.cjs'
   ];
   for (const f of REGRESSION_TESTS) list.push({ group: 'tests', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });
 

--- a/tests/harness/manifest.js
+++ b/tests/harness/manifest.js
@@ -21,7 +21,8 @@ export function targets() {
     'test_string_length_accumulation.cjs',
     'test_node_http_incoming_message_readable.cjs',
     'test_stream_readable_to_web.cjs',
-    'test_esm_package_self_reference.cjs'
+    'test_esm_package_self_reference.cjs',
+    'test_typeof_closure_assignment.mjs'
   ];
   for (const f of REGRESSION_TESTS) list.push({ group: 'tests', type: 'test', name: `tests/${f}`, entry: `tests/${f}` });
 

--- a/tests/test_esm_package_self_reference.cjs
+++ b/tests/test_esm_package_self_reference.cjs
@@ -8,8 +8,6 @@ const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ant-esm-self-reference-'));
 const ant = path.resolve(process.execPath);
 
 try {
-  // Physical package directory outside any node_modules hierarchy, like the
-  // package-manager cache targets that node_modules symlinks point at.
   const storeDir = path.join(tmp, 'store', 'selfref-fixture');
   fs.mkdirSync(storeDir, { recursive: true });
 
@@ -21,18 +19,12 @@ try {
         './find': { import: './find.mjs', require: './find.cjs' },
         './walk': { import: './walk.mjs' },
         './resolve': { import: './resolve.mjs', require: './resolve.cjs' },
-        './probe': './probe.mjs',
-      },
+        './probe': './probe.mjs'
+      }
     })
   );
-  fs.writeFileSync(
-    path.join(storeDir, 'find.mjs'),
-    'import { up } from "selfref-fixture/walk";\nexport const chain = `find->${up}`;\n'
-  );
-  fs.writeFileSync(
-    path.join(storeDir, 'walk.mjs'),
-    'import { leaf } from "selfref-fixture/resolve";\nexport const up = `walk->${leaf}`;\n'
-  );
+  fs.writeFileSync(path.join(storeDir, 'find.mjs'), 'import { up } from "selfref-fixture/walk";\nexport const chain = `find->${up}`;\n');
+  fs.writeFileSync(path.join(storeDir, 'walk.mjs'), 'import { leaf } from "selfref-fixture/resolve";\nexport const up = `walk->${leaf}`;\n');
   fs.writeFileSync(path.join(storeDir, 'resolve.mjs'), 'export const leaf = "resolve:import";\n');
   fs.writeFileSync(path.join(storeDir, 'resolve.cjs'), 'module.exports = { leaf: "resolve:require" };\n');
   fs.writeFileSync(
@@ -51,18 +43,25 @@ try {
   const appDir = path.join(tmp, 'app');
   const nodeModules = path.join(appDir, 'node_modules');
   fs.mkdirSync(nodeModules, { recursive: true });
-  fs.writeFileSync(
-    path.join(appDir, 'package.json'),
-    JSON.stringify({ name: 'app-fixture', type: 'module' })
-  );
+  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'app-fixture', type: 'module', exports: { '.': './main.mjs' } }));
   fs.symlinkSync(storeDir, path.join(nodeModules, 'selfref-fixture'), 'junction');
+
+  const shadowDir = path.join(nodeModules, 'app-fixture');
+  fs.mkdirSync(shadowDir, { recursive: true });
+  fs.writeFileSync(path.join(shadowDir, 'package.json'), JSON.stringify({ name: 'app-fixture', exports: { './hidden': './hidden.mjs' } }));
+  fs.writeFileSync(path.join(shadowDir, 'hidden.mjs'), 'export const hidden = "shadow";\n');
+
+  fs.writeFileSync(
+    path.join(nodeModules, 'loose.mjs'),
+    'export async function probeApp() {\n' +
+      '  try { await import("app-fixture"); return "resolved"; }\n' +
+      '  catch { return "rejected"; }\n' +
+      '}\n'
+  );
 
   const externalDir = path.join(nodeModules, 'external-pkg');
   fs.mkdirSync(externalDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(externalDir, 'package.json'),
-    JSON.stringify({ name: 'external-pkg', exports: { '.': { import: './index.mjs' } } })
-  );
+  fs.writeFileSync(path.join(externalDir, 'package.json'), JSON.stringify({ name: 'external-pkg', exports: { '.': { import: './index.mjs' } } }));
   fs.writeFileSync(path.join(externalDir, 'index.mjs'), 'export const external = "external-ok";\n');
 
   fs.writeFileSync(
@@ -84,22 +83,27 @@ try {
       'const secretResult = await probeSecret();',
       'if (secretResult !== "rejected") throw new Error(`unexported subpath should stay rejected, got ${secretResult}`);',
       '',
-      'console.log("self reference chain ok");',
+      'let shadowResult;',
+      'try { await import("app-fixture/hidden"); shadowResult = "resolved"; }',
+      'catch { shadowResult = "rejected"; }',
+      'if (shadowResult !== "rejected") throw new Error(`self reference must not fall back to shadow package, got ${shadowResult}`);',
       '',
+      'const { probeApp } = await import("./node_modules/loose.mjs");',
+      'const looseResult = await probeApp();',
+      'if (looseResult !== "rejected") throw new Error(`node_modules boundary should block self reference, got ${looseResult}`);',
+      '',
+      'console.log("self reference chain ok");',
+      ''
     ].join('\n')
   );
 
   const result = spawnSync(ant, ['--no-color', path.join(appDir, 'main.mjs')], {
     cwd: appDir,
-    encoding: 'utf8',
+    encoding: 'utf8'
   });
   if (result.error) throw result.error;
 
-  assert.strictEqual(
-    result.status,
-    0,
-    `self reference fixture failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
-  );
+  assert.strictEqual(result.status, 0, `self reference fixture failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
   assert.match(result.stdout, /self reference chain ok/);
 
   console.log('esm package self reference ok');

--- a/tests/test_typeof_closure_assignment.mjs
+++ b/tests/test_typeof_closure_assignment.mjs
@@ -1,0 +1,37 @@
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`FAIL: ${msg}`);
+    process.exit(1);
+  }
+}
+
+
+let viaExpr;
+(function () { viaExpr = "hi"; })();
+assert(typeof viaExpr === "string", `typeof after closure write: ${typeof viaExpr}`);
+
+let viaHoisted;
+setHoisted();
+assert(typeof viaHoisted === "number", `typeof after hoisted fn write: ${typeof viaHoisted}`);
+function setHoisted() { viaHoisted = 1; }
+
+let viaAsync;
+await Promise.resolve().then(() => { viaAsync = true; });
+assert(typeof viaAsync === "boolean", `typeof after async write: ${typeof viaAsync}`);
+
+let branchy;
+setBranchy();
+let took = "wrong";
+if (typeof branchy === "string") took = "right";
+assert(took === "right", `typeof branch elimination: took ${took}`);
+function setBranchy() { branchy = "s"; }
+
+let initialized = 0;
+bump();
+assert(typeof initialized === "number" && initialized === 1, "typed let after closure write");
+function bump() { initialized += 1; }
+
+const stable = 5;
+assert(typeof stable === "number", "typeof const still works");
+
+console.log("test_typeof_closure_assignment: OK");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ESM loader hooks with registration and deregistration.
  * Added built-in module helpers (`isBuiltin`, `registerHooks`).
  * Dynamic `import()` now supports an options object (including import attributes).
* **Bug Fixes**
  * Improved `import.meta` and more accurate ESM module-context tracking, including async/TLA behavior.
  * Isolated ESM resolution and caching per runtime instance; improved `file:` URL handling (query/fragment stripping).
  * Improved uncaught-throw state handling during error reporting.
* **Tests**
  * Added `test_typeof_closure_assignment.mjs`.
  * Expanded ESM package self-reference coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->