### PR TITLE
initialize derived class fields after super()

### DIFF
--- a/include/silver/compiler.h
+++ b/include/silver/compiler.h
@@ -162,6 +162,7 @@ typedef struct sv_compiler {
   int loop_cap;
 
   struct sv_compiler *enclosing;
+  struct sv_compiler *derived_field_owner;
   sv_ast_t **field_inits;
 
   int field_init_count;

--- a/packages/nix/vendor.nix
+++ b/packages/nix/vendor.nix
@@ -44,5 +44,5 @@ stdenvNoCC.mkDerivation {
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "sha256-WrnRj4llYGRoTh1JiARh4iArfkIwnTnmdJEpWhh1sxw=";
+  outputHash = "sha256-DjbXYLyqCh3NZr4Iv+ymAg81xe40zfujBRYSzym1bCQ=";
 }

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -3291,6 +3291,64 @@ static bool member_call_needs_optional_base_guard(const sv_ast_t *member) {
     sv_node_has_optional_base(member->left);
 }
 
+static inline bool is_class_method_def(const sv_ast_t *m) {
+  return
+    m && m->right && m->right->type == N_FUNC &&
+    (m->right->flags & FN_METHOD);
+}
+
+static int capture_field_key(sv_compiler_t *c, sv_compiler_t *owner, int local) {
+  if (c->enclosing == owner) {
+    owner->locals[local].captured = true;
+    return add_upvalue(c, (uint16_t)local_to_frame_slot(owner, local), true, false);
+  }
+  int uv = capture_field_key(c->enclosing, owner, local);
+  return add_upvalue(c, (uint16_t)uv, false, false);
+}
+
+static void emit_field_inits(
+  sv_compiler_t *c, sv_compiler_t *owner, sv_ast_t **fields, int count
+) {
+  for (int i = 0; i < count; i++) {
+    sv_ast_t *m = fields[i];
+    bool is_fn = is_class_method_def(m);
+    if (is_private_name_node(m->left)) {
+      emit_op(c, OP_THIS);
+      emit_private_token(c, m->left);
+      if (is_fn) compile_func_expr(c, m->right);
+      else if (m->right) compile_expr(c, m->right);
+      else emit_op(c, OP_UNDEF);
+      emit_op(c, OP_DEF_PRIVATE);
+      if (m->flags & FN_GETTER) emit(c, SV_COMP_PRIVATE_GETTER);
+      else if (m->flags & FN_SETTER) emit(c, SV_COMP_PRIVATE_SETTER);
+      else emit(c, is_fn ? SV_COMP_PRIVATE_METHOD : SV_COMP_PRIVATE_FIELD);
+      emit_op(c, OP_POP);
+      continue;
+    }
+
+    emit_op(c, OP_THIS);
+    if (m->right) compile_expr(c, m->right);
+    else emit_op(c, OP_UNDEF);
+    if (m->flags & FN_COMPUTED) {
+      int uv = capture_field_key(c, owner, owner->computed_key_locals[i]);
+      emit_op(c, OP_GET_UPVAL);
+      emit_u16(c, (uint16_t)uv);
+    } else {
+      compile_static_property_key(c, m->left);
+    }
+    emit_op(c, OP_SWAP);
+    emit_op(c, OP_DEFINE_METHOD_COMP);
+    emit(c, 0);
+    emit_op(c, OP_POP);
+  }
+}
+
+static void emit_derived_field_inits(sv_compiler_t *c) {
+  sv_compiler_t *owner = c->derived_field_owner;
+  if (owner && owner->field_init_count > 0) 
+    emit_field_inits(c, owner, owner->field_inits, owner->field_init_count);
+}
+
 static void compile_call_emit_invoke(
   sv_compiler_t *c, sv_ast_t *node,
   sv_call_kind_t kind, bool has_spread
@@ -3302,6 +3360,7 @@ static void compile_call_emit_invoke(
     compile_call_args_array(c, node);
     emit_op(c, kind == SV_CALL_SUPER ? OP_SUPER_APPLY : OP_APPLY);
     emit_u16(c, 1);
+    if (kind == SV_CALL_SUPER) emit_derived_field_inits(c);
     return;
   }
 
@@ -3311,6 +3370,7 @@ static void compile_call_emit_invoke(
     kind == SV_CALL_SUPER ? OP_CALL_SUPER :
     kind == SV_CALL_METHOD ? OP_CALL_METHOD : OP_CALL);
   emit_u16(c, (uint16_t)argc);
+  if (kind == SV_CALL_SUPER) emit_derived_field_inits(c);
 }
 
 static sv_call_kind_t compile_call_setup_non_optional(sv_compiler_t *c, sv_ast_t *callee) {
@@ -6111,52 +6171,6 @@ void compile_label(sv_compiler_t *c, sv_ast_t *node) {
   }
 }
 
-static inline bool is_class_method_def(const sv_ast_t *m);
-static void emit_field_inits(sv_compiler_t *c, sv_ast_t **fields, int count) {
-  sv_compiler_t *enc = c->enclosing;
-  for (int i = 0; i < count; i++) {
-    sv_ast_t *m = fields[i];
-    bool is_fn = is_class_method_def(m);
-    if (is_private_name_node(m->left)) {
-      emit_op(c, OP_THIS);
-      emit_private_token(c, m->left);
-      if (is_fn) compile_func_expr(c, m->right);
-      else if (m->right) compile_expr(c, m->right);
-      else emit_op(c, OP_UNDEF);
-      emit_op(c, OP_DEF_PRIVATE);
-      if (m->flags & FN_GETTER) emit(c, SV_COMP_PRIVATE_GETTER);
-      else if (m->flags & FN_SETTER) emit(c, SV_COMP_PRIVATE_SETTER);
-      else emit(c, is_fn ? SV_COMP_PRIVATE_METHOD : SV_COMP_PRIVATE_FIELD);
-      emit_op(c, OP_POP);
-      continue;
-    }
-
-    emit_op(c, OP_THIS);
-    if (m->right) compile_expr(c, m->right);
-    else emit_op(c, OP_UNDEF);
-    if (m->flags & FN_COMPUTED) {
-      int key_local = enc->computed_key_locals[i];
-      enc->locals[key_local].captured = true;
-      uint16_t slot = (uint16_t)local_to_frame_slot(enc, key_local);
-      int uv = add_upvalue(c, slot, true, false);
-      emit_op(c, OP_GET_UPVAL);
-      emit_u16(c, (uint16_t)uv);
-    } else {
-      compile_static_property_key(c, m->left);
-    }
-    emit_op(c, OP_SWAP);
-    emit_op(c, OP_DEFINE_METHOD_COMP);
-    emit(c, 0);
-    emit_op(c, OP_POP);
-  }
-}
-
-static inline bool is_class_method_def(const sv_ast_t *m) {
-  return 
-    m && m->right && m->right->type == N_FUNC &&
-    (m->right->flags & FN_METHOD);
-}
-
 static void compile_static_initializer_value(sv_compiler_t *c, sv_ast_t *expr, int ctor_local);
 
 static void compile_class_method(
@@ -6493,7 +6507,7 @@ void compile_class(sv_compiler_t *c, sv_ast_t *node) {
       emit_op(&comp, OP_POP);
     }
 
-    emit_field_inits(&comp, field_inits, field_count);
+    emit_field_inits(&comp, c, field_inits, field_count);
     emit_op(&comp, OP_RETURN_UNDEF);
 
     sv_func_t *fn = code_arena_bump(sizeof(sv_func_t));
@@ -6730,6 +6744,8 @@ sv_func_t *compile_function_body(
 ) {
   sv_compiler_t comp;
   sv_compile_ctx_init_child(&comp, enclosing, node, mode);
+  if (node->flags & FN_DERIVED_CTOR) comp.derived_field_owner = enclosing;
+  else if (comp.is_arrow) comp.derived_field_owner = enclosing->derived_field_owner;
 
   bool has_own_use_strict = false;
   bool has_non_simple_params = false;
@@ -6958,8 +6974,9 @@ sv_func_t *compile_function_body(
     emit_put_local(&comp, comp.super_local);
   }
 
-  if (enclosing->field_init_count > 0) {
-    emit_field_inits(&comp, enclosing->field_inits, enclosing->field_init_count);
+  if ((node->flags & FN_CLASS_CTOR) && !(node->flags & FN_DERIVED_CTOR) &&
+      enclosing->field_init_count > 0) {
+    emit_field_inits(&comp, enclosing, enclosing->field_inits, enclosing->field_init_count);
   }
 
   bool body_has_await_using = false;

--- a/tests/test_derived_class_fields.cjs
+++ b/tests/test_derived_class_fields.cjs
@@ -1,0 +1,110 @@
+const assert = require('node:assert');
+
+class Base {
+  broken = false;
+}
+class Derived extends Base {
+  broken = true;
+  constructor() {
+    super();
+    assert.strictEqual(this.broken, true);
+  }
+}
+assert.strictEqual(new Derived().broken, true);
+
+const events = [];
+class OrderedBase {
+  value = (events.push('base field'), 1);
+  constructor(value) {
+    events.push('base body');
+    this.value = value;
+  }
+}
+class OrderedDerived extends OrderedBase {
+  value = (events.push('derived field'), this.value + 1);
+  constructor(spread) {
+    events.push('before super');
+    const result = spread ? super(...[4]) : super(4);
+    assert.strictEqual(result, this);
+    assert.strictEqual(this.value, 5);
+    events.push('after super');
+  }
+}
+for (const spread of [false, true]) {
+  events.length = 0;
+  assert.strictEqual(new OrderedDerived(spread).value, 5);
+  assert.deepStrictEqual(events, [
+    'before super', 'base field', 'base body', 'derived field', 'after super'
+  ]);
+}
+
+class Returning extends Base {
+  broken = true;
+  constructor() { return super(); }
+}
+assert.strictEqual(new Returning().broken, true);
+
+class ReplacementBase {
+  constructor() { return { value: 7 }; }
+}
+class ReplacementDerived extends ReplacementBase {
+  value = this.value + 1;
+  #secret = 9;
+  constructor() {
+    super();
+    assert.strictEqual(this.value, 8);
+    assert.strictEqual(this.#secret, 9);
+  }
+}
+assert.strictEqual(new ReplacementDerived().value, 8);
+
+let initialized = 0;
+class ThrowingBase {
+  constructor() { throw new Error('base failed'); }
+}
+class ThrowingDerived extends ThrowingBase {
+  field = ++initialized;
+  constructor() { super(); }
+}
+assert.throws(() => new ThrowingDerived(), /base failed/);
+assert.strictEqual(initialized, 0);
+class Skipped extends Base {
+  field = ++initialized;
+  constructor() { return {}; }
+}
+assert.deepStrictEqual(new Skipped(), {});
+assert.strictEqual(initialized, 0);
+
+let keyCalls = 0;
+class Computed extends Base {
+  [(keyCalls++, 'broken')] = true;
+  constructor() { super(); }
+}
+assert.strictEqual(new Computed().broken, true);
+assert.strictEqual(new Computed().broken, true);
+assert.strictEqual(keyCalls, 1);
+
+class ArrowSuper extends Base {
+  ['broken'] = true;
+  constructor() {
+    const initialize = () => super();
+    initialize();
+    assert.strictEqual(this.broken, true);
+  }
+}
+assert.strictEqual(new ArrowSuper().broken, true);
+
+class Implicit extends Derived {
+  broken = 'implicit';
+}
+assert.strictEqual(new Implicit().broken, 'implicit');
+class Third extends Derived {
+  broken = 'third';
+  constructor() {
+    super();
+    assert.strictEqual(this.broken, 'third');
+  }
+}
+assert.strictEqual(new Third().broken, 'third');
+
+console.log('derived class fields: ok');

--- a/vendor/skim.wrap
+++ b/vendor/skim.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/themackabu/skim.git
-revision = 275c854056de446fbb7e4341ee2a3f3a22d32872
+revision = 1a66b7930eadbea7bcd983cf7d9fa1340751d025
 depth = 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected initialization of fields in derived classes.
  - Field initializers now run in the correct order after `super()` and before the constructor body.
  - Improved handling of computed field names, arrow-function `super()` calls, and implicit constructors.
  - Corrected behavior when constructors return replacement objects or throw errors, ensuring field initializers are skipped or applied appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->