### PR TITLE
regain performance from migration to path.cjs

### DIFF
--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -8,6 +8,8 @@ Store in-progress execution plans here.
 
 ## Active
 
+- [JS Path Node Performance](path-node-performance.md)
+- [Guarded charCodeAt Opcode](charcode-intrinsic.md)
 - [Private Primordial Capture](private-primordials.md)
 - [ARM64 Nightly Benchmarks](arm64-nightly-benchmarks.md)
 - [Array Backing Store GC Pacing](array-backing-store-gc-pacing.md)

--- a/docs/exec-plans/active/charcode-intrinsic.md
+++ b/docs/exec-plans/active/charcode-intrinsic.md
@@ -1,0 +1,59 @@
+# Guarded charCodeAt opcode
+
+Status: active
+Last reviewed: 2026-09-05
+Owner: theMackabu
+
+## Scope and design
+
+`CALL_CHAR_CODE_AT(argc)` follows the existing `CALL_ARRAY_INCLUDES` pipeline.
+The compiler selects ordinary `.charCodeAt(...)` calls and bindings destructured
+from `StringPrototypeCharCodeAt`, including renamed locals and nested captures.
+Binding hints only select an opcode: they do not prove runtime identity. No
+bare-identifier name heuristic, primordial runtime coupling, or generic call
+dispatch hook is introduced. Optional, spread, and tail calls retain their
+existing lowering.
+
+Interpreter and JIT use the same operation. It recognizes genuine native
+charCodeAt calls and supported bound forms, including call.bind(charCodeAt).
+Flat ASCII strings with numeric indices use an allocation-free read. Other
+inputs, proxies, pre-applied arguments, and replaced functions use normal VM
+dispatch. Original property lookup and argument evaluation are retained.
+The JIT now inlines guarded reads through native Function.call.bind wrappers
+for in-range integer indices on known-ASCII flat or cached-flat rope strings.
+Other cases use the dedicated C helper. The immutable wrapper flag is general
+call metadata, not a primordial lookup. See the path performance plan for
+per-change measurements and expanded guard tests.
+
+Fallback testing also requires propagating receiver/index conversion exceptions
+and rejecting extreme numeric indices before a signed integer conversion.
+
+## Validation
+
+Build, focused guards, primordial tests, and 100 Node path differential probes
+pass. MIR inspection confirms dedicated helper calls in minified path code.
+The full spec suite fails only fetch DNS resolution (`unknown node or service`),
+also reproduced with the preserved binary. Artifacts:
+`/tmp/ant-charcode-opcode.qBcmk0`.
+
+Serial ABBA (six samples per binary, 100k calls, 20k warmup) against the supplied
+pre-change artifact: POSIX normalize 85.91 -> 68.29 ms, Windows normalize
+126.76 -> 111.17 ms, POSIX join 143.05 -> 120.45 ms. POSIX relative regressed
+257.68 -> 283.79 ms; resolve/Windows relative were approximately unchanged.
+Checksums matched. This is not a blanket speedup or installed-C-path parity
+claim; builds use existing PGO inputs with stale-profile warnings. Further
+performance attribution remains open. Raw hashes and samples are in results.json.
+
+## Restored compatibility fixes
+
+The reset also removed two earlier fixes, restored separately at user request:
+Reflect.set now rejects own non-writable/getter-only string properties before
+assignment and propagates setter exceptions. assert.throws checks constructor
+matches before predicates, rejects mismatched Error subclasses, and roots its
+inputs and thrown value across user callbacks. This is not a complete rewrite
+of either API's other compatibility behavior.
+
+New focused tests cover frozen objects/functions, accessors, constructor and
+subclass matching, and predicate callbacks. Both tests pass under Node and Ant.
+The incremental build, assert/reflect specs, primordial and charCodeAt guard
+tests, and preflight all pass.

--- a/docs/exec-plans/active/path-node-performance.md
+++ b/docs/exec-plans/active/path-node-performance.md
@@ -1,0 +1,480 @@
+# JS Path Node Performance
+
+Status: active
+Last reviewed: 2026-09-05
+Owner: theMackabu
+
+## Goal and constraints
+
+Priority update (2026-09-05): the user deferred the remaining performance gap
+to [technical debt](../tech-debt.md). Node-compatible correctness takes priority;
+do not continue performance experiments merely to close these microbenchmarks.
+The original target and measured history below remain as context, not a claim
+of completion.
+
+First match or beat the installed Ant (`$(which ant)`) on all eight existing
+path microbenchmarks, retaining the JS path implementation, primordial
+protection, and Node semantics. The saved pre-optimization JS binary is not
+the baseline for this gate. Node performance is the subsequent target. Optimize
+measured runtime bottlenecks, add regressions, build and test, and compare
+pinned binaries with serial ABBA runs. No commits or pushes. Completion requires
+all eight installed-Ant targets and compatibility validation, not an average
+speedup. This priority was explicitly updated by the user after the three-way
+comparison.
+
+## Updated installed-Ant checkpoint
+
+`/tmp/ant-path-goal.KC4jj3/three-way-before-slice-results.json` records all binary hashes,
+fixture hash, and twelve samples per binary from serial pairwise ABBA runs.
+Measured milliseconds per 100k calls (installed/current/Node):
+
+| Workload | Installed Ant | Current Ant | Node |
+| --- | ---: | ---: | ---: |
+| POSIX normalize | 9.38 | 46.35 | 8.38 |
+| Windows normalize | 10.51 | 86.28 | 15.23 |
+| POSIX join | 15.01 | 84.94 | 18.40 |
+| POSIX cwd resolve | 962.36 | 208.42 | 32.59 |
+| POSIX relative | 26.08 | 160.90 | 32.39 |
+| Windows resolve | 965.86 | 175.06 | 21.45 |
+| Windows relative | 28.09 | 214.43 | 37.57 |
+| POSIX parse | 23.77 | 21.43 | 2.54 |
+
+All fixture checksums match. Current wins three rows; the other five remain
+open. Preserve the resolve and parse wins while improving normalization,
+joining, and relative paths. The allocation-error checks have now been built;
+constant-template tests and 6090 Node differential cases pass on that build.
+
+Fresh normalization profile: `normalize-template-sample.txt` in the same
+artifact directory. Largest named self-sample counts include snapshot append
+395, do_string_op 304, memmove 258, js_type_alloc 251, substring creation 187,
+generic JIT call 169, UTF-16 length 150, and String.slice 128. Unknown JIT
+frames remain substantial. Next investigate temporary string construction
+and slice dispatch, not a new charCodeAt hypothesis without evidence.
+
+### ASCII slice experiment
+
+The existing slice builtin now uses an ASCII path for primitive flat or
+cached-flat strings with nonnegative numeric/undefined bounds. It skips
+receiver coercion and UTF-16 translation, preserves known ASCII metadata,
+and returns the immutable source value for a full-range slice. All other
+cases retain the prior fallback. `test_string_slice_ascii.cjs` passes on
+Ant and Node, including fractional/huge/infinite positive bounds, embedded
+NUL, allocation churn, Unicode fallback, and captured-target protection.
+All 6090 path differential cases pass.
+
+`ascii-slice-results.json` pins the checked object-template build and the
+slice candidate, using six samples each in serial ABBA. Median changes:
+normalize 46.98 -> 45.39 ms (-3%), Windows normalize 86.66 -> 83.92 (-3%),
+join 84.38 -> 82.79 (-2%), cwd resolve 208.30 -> 200.84 (-4%), relative
+167.73 -> 156.36 (-7%), Windows resolve 180.13 -> 165.98 (-8%), Windows
+relative 216.25 -> 206.71 (-4%), parse 22.24 -> 20.13 (-9%). Some ranges
+overlap, especially for the smaller gains. These are per-change results,
+not a new installed-baseline parity claim.
+Preflight passes; the rebuilt candidate passes all 4136 spec tests across
+102 files (`preflight-ascii-slice.log`, `spec-ascii-slice.log`).
+
+### Empty template segments
+
+Inspection of normalization's generated MIR and template compilation showed
+that empty cooked literal segments still emitted additions. The compiler now
+omits only those literal segments, keeping every substitution's immediate
+ToString operation and left-to-right evaluation. Empty templates still emit
+the empty string, and tagged templates retain their separate unchanged path.
+The new focused test passes on Node and Ant, covering coercion/exception
+order, Unicode, append snapshots, reentrancy, and tagged literal arrays.
+The 6090 path differential cases also pass.
+
+`template-empty-results.json` compares pinned slice and empty-segment builds
+in serial ABBA. Normalize 43.25 -> 42.23 ms (-2%), Windows normalize
+80.70 -> 79.21 (-2%), join 81.38 -> 77.56 (-5%), cwd resolve 193.06 ->
+187.75 (-3%), relative 148.19 -> 144.89 (-2%), Windows resolve 158.41 ->
+153.48 (-3%), Windows relative essentially unchanged. Parse's 2% median
+shift is within overlapping ranges and is not attributed to this change.
+Most small improvements have overlapping ranges; baseline parity remains
+unmet. MIR also confirms that short nonempty concatenations fall back from
+the JIT's rope-only allocation path to generic addition, matching the named
+do_string_op samples. This is the next runtime path to investigate.
+Preflight and all 4136 spec tests pass (`preflight-template-empty.log`,
+`spec-template-empty.log`).
+
+### JIT short flat concatenation
+
+The existing string-add JIT fast path now handles nonempty ASCII flat-string
+concatenations below the existing short-cons threshold. It uses the pool's
+shared size-class lookup at compile time, reuses freed slots or initialized
+bump allocation space, and accounts exact requested bytes in gc_pool_alloc.
+The GC pressure floor is a conservative gate: at or above it, normal
+allocation checks the adaptive threshold. No collection or call occurs on
+the inline path. Uninitialized/exhausted buckets, Unicode/unknown metadata,
+ropes, builders, and coercions use existing fallback paths. Focused size-class
+boundary, GC-survivor, Unicode, coercion, snapshot and root tests pass; the
+6090 path differential cases also pass. Compare artifact:
+`short-flat-jit-results.json` (against `ant-template-empty`).
+
+Serial ABBA medians: normalize 42.67 -> 39.82 ms (-7%), Windows normalize
+79.54 -> 75.61 (-5%), join 77.91 -> 74.54 (-4%), cwd resolve 186.95 ->
+171.48 (-8%), relative 145.94 -> 138.14 (-5%), Windows resolve 153.80 ->
+133.72 (-13%), Windows relative 195.37 -> 184.88 (-5%). These seven rows
+have non-overlapping ranges in this run. Parse is unchanged. Long-append
+controls (`short-flat-jit-control-results.json`) are unchanged, ratios
+0.988/1.009/1.002 for 32/10000/10000-with-reads. Preflight and all 4136 spec
+tests pass (`preflight-short-flat-jit.log`, `spec-short-flat-jit.log`).
+
+### Cached-rope length
+
+Fresh 8-second profiles after short flat allocation:
+`normalize-short-flat-sample.txt` and `relative-short-flat-sample.txt`.
+Relative has 947 self samples in str_utf16_len out of 6592 total, 451 in
+rope_flatten, and 199 in jit_helper_get_length. Normalization now has slice
+and snapshot append as its hottest named functions. The JIT length emitter
+did not use a rope's existing flat cache. It now validates that cache and
+branches to the existing flat metadata path without allocating. Uncached
+ropes and unknown UTF-16 metadata keep the helper fallback.
+
+New regression testing also exposed null.length returning without an
+exception on the pre-change binary (`cached-length-baseline-test.log`).
+The VM and JIT length helper now share a nullish-checking value reader, and
+the main JIT emitter checks its error result. Tests retain null/undefined
+and throwing-getter coverage rather than ignoring that pre-existing defect.
+The rebuilt candidate passes the focused Node/Ant test, snapshot tests and
+all 6090 path differential cases. `cached-rope-length-results.json` pins the
+short-flat and cached-length candidates in serial ABBA. Cwd resolve improves
+170.09 -> 147.96 ms (-13%), POSIX relative 135.96 -> 122.95 (-10%), Windows
+resolve 133.28 -> 125.76 (-6%), and Windows relative 182.18 -> 171.60 (-6%).
+Normalize and parse are unchanged. Join's +2.5% median shift has overlapping
+ranges; monitor it in the next comparisons. The nullish fix is included in
+the candidate, not bypassed for measurement.
+Preflight and all 4136 spec tests pass (`preflight-cached-rope-length.log`,
+`spec-cached-rope-length.log`).
+
+### Flat concatenation threshold experiments
+
+The remaining rope_flatten samples motivated comparing the original 13-byte
+cutoff with 64 bytes (`flat64-results.json`). The 64-byte candidate improves
+POSIX relative 122.80 -> 97.61 ms (-21%), Windows relative 172.95 -> 147.30
+(-15%), cwd resolve 148.24 -> 129.03 (-13%), Windows resolve 127.83 ->
+114.92 (-10%). Normalize improves slightly; join and parse are unchanged.
+Focused tests, 6090 differentials, preflight and all 4136 spec tests pass.
+Long append controls are unchanged (`flat64-append-control-results.json`).
+Additional 16/48/128/1024-byte retained/read controls are recorded in
+`flat64-concat-control-results.json`; short read workloads improve 38-43%.
+
+A serial ABBA retained-string memory control revealed the tradeoff:
+200000 unread 48-byte results increase peak RSS from 24772608 to 30941184
+bytes (+25%), `flat64-memory-results.json`. This deliberately keeps input
+halves shared, exposing the cost of storing full flat results versus ropes.
+Selected 32 bytes after the follow-up comparison; the 64-byte candidate
+remains pinned as `ant-flat64` but is not retained in source.
+
+`flat32-results.json`: POSIX relative 121.29 -> 97.11 ms (-20%), Windows
+relative 171.20 -> 146.64 (-14%), Windows resolve 124.41 -> 114.95 (-8%).
+Other rows are essentially unchanged, including cwd resolve, which gives
+up the extra gain of the 64-byte experiment. The existing cwd/parse wins
+over installed Ant remain. In `flat32-memory-results.json`, the 48-byte
+retention control has unchanged peak RSS (24854528 -> 24813568 bytes).
+This does not establish memory neutrality for every string size; it avoids
+the measured 48-byte penalty while keeping the relative-path gains.
+Focused tests and 6090 path differential cases pass on the 32-byte build.
+Preflight and all 4136 spec tests pass. Long-append controls show no
+regression (`flat32-append-control-results.json`, ratios 0.983/0.998/0.985).
+
+### Native normalization trace
+
+Temporary debug-gated native code dumping was used because release MIR
+compiles out its detailed code-generation logs. The instrumentation has
+been removed from source. Diagnostic binary: `ant-native-diagnostic`; no
+performance claim uses it. `native-normalize.log` contains MIR plus mapped
+machine bytes; `native-normalize-sample.txt` captures the same process.
+`analyze-native.mjs` uses llvm-mc to decode sampled instruction windows into
+`native-hotspots.json`. The 16 KiB per-function dump is bounded and does not
+cover every sample; missing addresses are left unclassified.
+
+The hot normalizeString body is `jit_M_0x7cda169010`. Samples include repeated
+closure/native target loads and guards (offsets 3176, 2168, 2128), string
+metadata loads (2352, 1572), and stack loads/boxing (824, 2020). The emitted
+upvalue reader follows closure -> upvalue array -> cell -> location -> value
+at every read. Captured constants and the separator callback warrant
+entry-time load/guard investigation, preserving TDZ and mutable bindings.
+This is diagnostic evidence for the next optimization, not a speed result.
+
+### Captured-constant and target-guard experiment (removed)
+
+The experimental source hoisted multiply-read const upvalues at JIT entry,
+bailing before JS execution if a selected binding is still in TDZ. Mutable
+bindings are not hoisted. A suspended-generator test exercises initialization
+during a call, untaken TDZ reads, and different closures sharing compiled code.
+
+Initial hoisting had no clear path impact (`constant-upvalues-results.json`).
+MIR showed it applied mostly to the benchmark wrapper: esbuild bundling had
+lowered the builtin's top-level const declarations to var. `gen_builtins.js`
+now experimentally minifies standalone CJS modules without bundling while
+retaining bundles for dependency-bearing modules. A missing Meson dependency
+on that generator was also added. Generated output confirms preserved const
+bindings. Combined measurements still show no clear gain
+(`lexical-builtins-results.json`).
+
+The next candidate caches the immutable uncurried charCodeAt target guard at
+entry, propagating its guard register with stack value metadata and clearing
+it at branch merges. Receiver/index checks stay per-call. Generated MIR
+confirms guard reuse (`constant-char-guard-mir.log`), but the ABBA results
+(`constant-char-guard-results.json`, against ant-flat32) still show no clear
+normalize/join improvement. Some resolve medians improve about 4% with
+overlapping ranges. Do not count this as an accepted speedup. The current
+binary is pinned as `ant-constant-char-guard`; the last accepted candidate
+is `ant-flat32`. Focused char guards, TDZ, primordial protection/GC, and 6090
+path differential cases pass. Preflight and all 4136 spec tests also pass
+(`preflight-constant-char-guard.log`, `spec-constant-char-guard.log`). The
+experiment has now been removed: JIT hoisting, cached target guards, the
+generator experiment, and its dedicated upvalue test. Recoverable copies are
+in the artifact directory. The Meson generator dependency fix and paired
+charCodeAt closure guard regression remain; earlier improvements are retained.
+
+### Short snapshot append JIT fast path
+
+The snapshot append helper remained hot in the normalization profile (373
+self samples in `normalize-short-flat-sample.txt`). Non-captured, non-numeric
+locals now reuse the existing inline concatenation allocator for short ASCII
+strings (below 32 bytes), or return an immutable operand for an empty-string
+append. This path cannot call or collect. It updates both the local register
+and frame slot; captured locals, parameters, coercions, larger results, and
+allocation pressure retain the helper. Snapshot operands are already evaluated,
+so RHS replacement and conversion ordering remain unchanged.
+
+The first build failed because the local-only block was placed in the
+parameter branch; this was corrected before testing or measuring the candidate.
+`snapshot-flat-jit-results.json` pins `ant-flat32` and `ant-snapshot-flat-jit`
+with six samples each in serial ABBA. Median milliseconds per 100k calls:
+
+| Workload | Before | Snapshot fast path |
+| --- | ---: | ---: |
+| POSIX normalize | 40.92 | 38.70 |
+| Windows normalize | 77.86 | 74.95 |
+| POSIX join | 78.08 | 74.83 |
+| POSIX cwd resolve | 150.63 | 145.75 |
+| POSIX relative | 99.72 | 93.88 |
+| Windows resolve | 117.49 | 114.60 |
+| Windows relative | 148.68 | 144.35 |
+| POSIX parse | 19.23 | 19.04 |
+
+Normalize and relative sample ranges do not overlap. Join and resolve changes
+are smaller with overlapping ranges; parse is unchanged. Long append controls
+are unchanged (candidate/base 0.994, 0.999, 0.993 for 32/10000/10000-with-read).
+Focused snapshot, GC-root, short concat, and charCodeAt tests pass. Expanded
+short-append boundaries cover 31/32 bytes. All 6090 Node differential cases
+pass. Final rebuild is byte-identical to the measured candidate (SHA256
+`42350abc96bb261d6db2e7fab5f860077913a542de572c27563f055fba5aca10`).
+All 4136 spec tests in 102 files pass, as do preflight and the remaining focused
+regressions (`spec-snapshot-flat-jit.log`, `preflight-snapshot-flat-jit.log`).
+Meson regeneration was already exercised for the retained dependency fix;
+no new build-graph change was made in this step.
+Existing PGO configuration still reports stale control-flow profile warnings.
+Installed-Ant parity remains unmet on five of eight workloads.
+
+Fresh normalization profile: `normalize-snapshot-flat-sample.txt`, 5995 samples.
+Snapshot append no longer appears among leading native self costs. Slice has
+343 self samples, generic JIT call 171, allocation 128, truthiness 104. However,
+4632 samples are unsymbolicated JIT frames; do not attribute those to slice
+or claim that eliminating native calls alone closes the remaining gap.
+
+### Installed-Ant checkpoint after snapshot fast path
+
+`three-way-results.json` contains the latest serial pairwise ABBA run (12
+samples each, unchanged hashes, matching checksums). Milliseconds per 100k:
+
+| Workload | Installed Ant | Current Ant | Node |
+| --- | ---: | ---: | ---: |
+| POSIX normalize | 9.25 | 36.53 | 7.82 |
+| Windows normalize | 10.05 | 72.98 | 14.30 |
+| POSIX join | 14.28 | 71.34 | 17.47 |
+| POSIX cwd resolve | 914.79 | 140.78 | 31.71 |
+| POSIX relative | 24.51 | 90.57 | 30.86 |
+| Windows resolve | 914.45 | 109.83 | 20.04 |
+| Windows relative | 26.71 | 138.76 | 34.91 |
+| POSIX parse | 22.02 | 18.60 | 2.30 |
+
+Three installed-Ant wins remain, five gaps are 3.70-7.26x. Use the paired
+before/candidate run above for attribution, not differences between separate
+three-way checkpoints. The earlier table is preserved in
+`three-way-last-flat32-results.json`.
+
+### Follow-up native attribution and numeric-local lead
+
+Temporary ARM64 diagnostics followed MIR's entry trampoline before dumping
+the mapped code region. The first attempt dumped only the trampoline region;
+it was corrected and the profile rerun. Artifacts: `native-second.log`,
+`native-second-sample.txt`, `native-second-hotspots.json`. These are diagnostic
+runs, not performance comparisons. Instrumentation was removed afterward;
+source matches `swarm-before-second-native-profile.c`, and the restored build
+hash matches `ant-snapshot-flat-jit` exactly.
+
+The hottest mapped normalization offsets include 3176 (separator callee guard,
+120 self samples), 3412 (common join after the inlined separator or its fallback,
+117), 824 (stack load, 113), and 2352 (string metadata load, 102). The common
+join is not evidence that the fallback call ran. Most previous unmapped samples
+now resolve to normalization's generated code. The larger dump also identifies
+short-string copy instructions beyond the earlier 16 KiB diagnostic limit.
+
+Stronger next lead: MIR declares numeric mirrors for locals l1 through l7 and
+guards them at OSR entry, but normal initialization/loop operations keep l1-l4
+boxed while l5 (the loop index) uses its numeric mirror. The compiler hoists
+lexical declaration markers; JIT `jit_has_immediate_numeric_local_init` only
+accepts an immediately adjacent numeric constant and store. `OP_SET_LOCAL_UNDEF`
+otherwise clears numeric specialization. This likely discards useful numeric
+feedback for grouped declarations. Verify builtin bytecode or a minimal grouped
+declaration repro, then consider recognizing a safe straight-line initialization
+prefix. Preserve TDZ, captured bindings, reads before initialization, control
+flow, and bailout state. The plain bytecode diagnostic did not dump the bundled
+path function, so that exact-bytecode verification remains pending. No new
+runtime optimization or speed claim was made in this diagnostic step.
+
+### Removed grouped-initializer and register-argument experiments
+
+The grouped-initializer candidate did preserve numeric registers in the repro
+and bundled path MIR. Focused regressions, 6090 differential cases, and all
+4136 specs passed. However, `grouped-init-results.json` and the reversed-order
+`grouped-init-reverse-results.json` showed small mixed changes with overlapping
+ranges, not a convincing path win.
+
+The combined register-argument candidate also passed focused charCodeAt tests
+and the 6090 differential cases. Its first benchmark was interrupted by SIGTRAP
+inside macOS `pthread_jit_write_protect_np` during MIR initialization. The crash
+report's UUID matched the candidate. Twenty repeated runs each of the combined,
+grouped-only, and accepted snapshot binaries then passed. The completed rerun
+(`char-register-args-results.json`) was noisy and inconclusive; no speedup was
+accepted and the initialization trap's cause remains unresolved.
+
+At the user's request, both experiments and the dedicated grouped-local test
+were removed. Copies are recoverable in `/tmp/ant-path-goal.KC4jj3` as
+`swarm-rejected-grouped-and-register-args.c` and
+`test_jit_grouped_numeric_init.cjs`. Extra-argument evaluation regression coverage
+for the existing charCodeAt opcode remains. `swarm.c` is restored exactly to
+`swarm-before-second-native-profile.c`, retaining all previously accepted work.
+Earlier hoisting/target-guard experiments and temporary native diagnostics are
+also absent. The rebuild matches the accepted snapshot binary SHA256
+`42350abc96bb261d6db2e7fab5f860077913a542de572c27563f055fba5aca10`.
+Preflight, focused charCodeAt/short-append tests, all 6090 Node differential
+cases, and all 4136 spec tests pass (`preflight-clean-experiments.log`,
+`spec-clean-experiments.log`). The refreshed accepted-only comparison is
+`three-way-results.json`; its prior version is preserved in
+`three-way-before-cleanup-table.json`.
+
+## Baseline and evidence
+
+Artifacts: `/tmp/ant-path-goal.KC4jj3`; preserved `ant-baseline` SHA256
+`2a424f01d83f343d26e893e331c507083731a7aa041b95679e790b250faccb2d`.
+Original Node comparison: `/tmp/ant-path-node.b1fMjy/results.json`, Node v26.8.1,
+100k measured operations and 20k warmups, six runs per binary in serial ABBA.
+Ant/Node ratios: POSIX normalize 8.48, Windows normalize 7.49, POSIX join 6.72,
+POSIX cwd resolve 36.98, POSIX relative 8.59, Windows absolute resolve 11.47,
+Windows relative 8.34, POSIX parse 12.29. Checksums agree on the fixture.
+
+Profiles: `/tmp/ant-path-hot.VxZN5A/findings.md`. Instruments aborted; macOS
+sample captured 8 seconds per workload. Relative spends 19.6% self samples in
+generic call dispatch; rope_flatten 7.7%, str_utf16_len 7.0%. Prebuilt input
+control reproduces these costs. Normalize string-construction stacks cover
+33.5% inclusive samples; char opcode helper stacks cover 16.3%. Inclusive
+categories overlap. Unsymbolicated JIT frames limit attribution.
+
+## Work log
+
+1. Implemented: allow the guarded character reader to use a rope's existing
+   cached flat string, without allocation or mutation. Uncached, builder, and
+   non-ASCII values retain the original generic fallback. Add repeated ASCII
+   and Unicode rope character-read coverage. Build and focused Ant/Node tests,
+   primordial mutation tests and primordial GC tests pass. Serial ABBA against
+   preserved baseline: POSIX relative 272.69 -> 207.62 ms (-24%), Windows
+   absolute resolve 236.71 -> 205.61 (-13%), Windows relative 299.37 -> 263.36
+   (-12%). Normalize/join/parse unchanged. `rope-results.json` records hashes
+   and all samples.
+2. Implemented cwd cache after an 8-second isolated cwd profile showed mostly
+   getcwd filesystem syscalls (`cwd-sample.txt`). Node v26.8.1's installed
+   bootstrap source caches cwd until successful chdir. Ant now does the same,
+   with a rooted per-runtime cached string and process-wide atomic generation
+   invalidation across runtimes. External native chdir is not intercepted,
+   as with Node's JS cache. Cache and uncached failure tests pass under both
+   Ant and Node, including deleted cwd, failed chdir, and allocation churn.
+   Serial ABBA: cwd resolution 1134.02 -> 247.81 ms (-78%); other workloads
+   approximately unchanged. See `cwd-results.json`. Still above the 2x target.
+3. Address remaining measured character guard, string construction, and parse
+   bottlenecks individually, with per-change measurements. An 8-second parse
+   profile (`parse-sample.txt`, 5914 samples) has js_try_char_code_at 556 self
+   samples, js_type_alloc 308, js_mkstr_utf16_range 307, memmove 277,
+   sv_call_native 223, jit_helper_call 195, get_slot 178, builtin_string_slice
+   163, jit_helper_typeof 157, builtin_function_call 149, and
+   jit_helper_define_slot 140. utf16_range_to_byte_range already has an ASCII
+   shortcut; do not infer that these samples represent UTF-16 scanning.
+   Next investigate guarded/inlined string operations and object literal
+   initialization, with a full-result parse control to distinguish unused
+   result elimination from general runtime work.
+
+## Subsequent measured changes
+
+- Short immutable snapshot append: only STR_ALC_SNAPSHOT uses a bounded flat
+  append for results up to the existing builder tail capacity. An initial
+  experiment applying it to every append regressed long append controls by
+  43% and was revised, not retained. The snapshot-only version improves POSIX
+  normalize 64.62 -> 54.38 ms (-16%), Windows normalize -10%, join -10%, cwd
+  resolve -8%, POSIX relative -10%, Windows resolve -6%, Windows relative -7%.
+  Parse unchanged. Serial controls for 32/10000 appends, with and without
+  reads, are unchanged (0.999x, 1.007x, 0.997x). Artifacts:
+  `short-snapshot-results.json`, `snapshot-control-results.json`.
+- Inline JIT uncurried charCodeAt: immutable SV_CALL_IS_UNCURRY identifies
+  native Function.call.bind wrappers independently of primordials. Dedicated
+  opcode MIR guards the native target, ASCII flat/cached-rope receiver,
+  in-range integral index and active VM execution, then reads the byte.
+  Other cases use the existing helper. No allocation occurs on the fast path.
+  Serial ABBA against the snapshot-only binary: normalize 54.91 -> 46.07 ms,
+  Windows normalize 93.96 -> 84.03, join 102.58 -> 89.93, cwd resolve 220.85 ->
+  200.23, relative 180.47 -> 156.35, Windows resolve 187.20 -> 174.27, Windows
+  relative 233.68 -> 207.26, parse 27.81 -> 25.14. See
+  `char-inline-results.json`. Focused guards/primordial tests pass; expanded
+  differential: 6090 Node cases, zero differences (`differential-results.json`).
+  Broad suite: 4121 passed, only the known baseline fetch DNS error.
+- Fresh parse profile (`parse-inline-sample.txt`) no longer has charCodeAt
+  among the hottest native functions. Slice construction/allocation and
+  redundant Function.call/native dispatch remain hot. Implemented: collapse
+  native uncurry call plans, retaining current_func, exact explicit receiver,
+  bound arguments and cleanup; leave construction and outside-VM checkpoints
+  unchanged. A new test exposed pre-existing frozen Array.push behavior on
+  the preserved pre-change binary; not changed in this scoped optimization.
+  Serial ABBA (`uncurry-results.json`): parse 26.01 -> 24.61 ms (-5%),
+  join 94.30 -> 88.25 (-6%), relative 164.41 -> 156.94 (-5%); other rows
+  improve 1-3%, with overlapping ranges. Native uncurry tests pass on Node
+  and Ant, including explicit receivers, rebinding, and exception identity.
+- Primitive typeof comparisons: compile comparisons against primitive type
+  names to a tag-test opcode instead of allocating/returning a type string.
+  Preserve operand evaluation, TDZ, undeclared globals, with/eval resolution,
+  and generic object/function classification. Both main and inline JIT
+  emitters support the opcode. `type-test-results.json`: join 89.41 -> 81.30
+  ms (-9%), Windows resolve 176.08 -> 166.73 (-5%), parse 24.49 -> 23.02
+  (-6%). Other improvements are smaller. Focused Ant/Node regression passes.
+  Broad suite at this stage: 4136 passed, zero failures (`spec-type-test.log`).
+- Constant object-literal templates: JIT recognizes consecutive constant
+  definitions with static keys and no branch entry into the skipped span.
+  A private GC-rooted template reuses the existing object-cloning primitive;
+  each execution still creates an independent object and property storage.
+  Dynamic values, computed keys, spreads, and accessors retain normal code.
+  `object-template-results.json`: parse 23.20 -> 20.19 ms (-13%); other seven
+  workloads unchanged. Candidate SHA256:
+  `18f4f42a934af0198dfe9594b27bb53546fcd78433faaea5c499220a4a18315a`.
+  Focused identity, mutation, descriptors, prototype, and fallback tests pass
+  on Ant and Node; 6090 path differential cases have zero differences.
+  Two subsequent allocation-error checks require a rebuild and validation.
+
+## Validation checkpoint (before subsequent changes)
+
+Not complete. All eight performance gates remain open. Existing tree changes
+to charCodeAt, Reflect.set, and assert.throws are retained. Build configuration
+uses existing PGO data with stale-profile warnings; final evidence needs its
+configuration recorded, with no performance attribution based on unmatched
+profile configurations. Both incremental builds succeeded. Preflight passed.
+The current broad suite passes 4121 tests and 101 files; its single fetch DNS
+failure also reproduces on the preserved baseline (`fetch-baseline.log`).
+Focused charCodeAt, cwd cache/error, primordial protection/GC, assert constructor,
+and Reflect.set tests pass. Full path differential expansion remains pending.
+
+Latest serial Node comparison: `node-after-cwd.json` pins both binaries and all
+samples. Ratios in the original workload order: 8.24, 7.26, 6.56, 7.68, 6.49,
+9.92, 7.22, 12.28. Thus zero of eight gates are met yet. Cwd syscall overhead
+and cached-rope character dispatch have improved, but substantial general
+engine work remains. Do not mark the goal complete from these partial wins.

--- a/docs/exec-plans/active/private-primordials.md
+++ b/docs/exec-plans/active/private-primordials.md
@@ -14,8 +14,9 @@ hooks, compiler hints, or opcode changes.
 
 - `include/primordial_list.h` declares the supported captures in a re-includable
   definition table, used to generate IDs and capture metadata.
-- Before JS bootstrap, original values are copied into 20 per-runtime slots:
-  19 exported values plus the original Function.prototype.call for uncurrying.
+- Before JS bootstrap, original values are copied into 21 per-runtime slots:
+  20 exported values (including Error, also used by native assertion matching)
+  plus the original Function.prototype.call for uncurrying.
 - GC marks these slots even if public properties are overwritten or deleted.
 - `ant:internal/primordials` constructs and freezes one null-prototype object
   on first import. Uncurried methods use the existing bound-function machinery.
@@ -24,11 +25,13 @@ hooks, compiler hints, or opcode changes.
   API and does not expose a general capture/lookup facility.
 
 Startup capture is a fixed number of existing property lookups and stores, not
-a traversal of the builtin graph. Slot storage is 160 bytes per runtime on this
+a traversal of the builtin graph. Slot storage is 168 bytes per runtime on this
 64-bit build; this is not a claim about total process memory. Wrapper allocation
 is deferred until first import. Failure leaves the cached object unpublished.
 
 ## Verification and profiling
+
+The measurements below predate the additional Error capture.
 
 The release/PGO/LTO build passes, as do preflight, focused primordial/alias/cwd
 tests, 100 seeded Node path differential probes, and the full spec suite

--- a/docs/exec-plans/completed/README.md
+++ b/docs/exec-plans/completed/README.md
@@ -18,6 +18,7 @@ can reuse the decision history.
 - [Promise Resolution and Await Semantics](promise-resolution-semantics.md)
 - [Promise Resolution Performance](promise-resolution-performance.md)
 - [Property Reference Table Removal](property-reference-table-removal.md)
+- [PAX Tar Extraction](tar-pax-extraction.md)
 - [Static c-ares Release Portability](static-cares-release-portability.md)
 - [tlsuv HTTP Request Body Methods](tlsuv-http-request-body-methods.md)
 - [tlsuv WebSocket Buffered Read](tlsuv-websocket-buffered-read.md)

--- a/docs/exec-plans/completed/tar-pax-extraction.md
+++ b/docs/exec-plans/completed/tar-pax-extraction.md
@@ -1,0 +1,39 @@
+# PAX Tar Extraction
+
+Status: implemented and validated
+Last reviewed: 2026-09-05
+Owner: theMackabu
+
+## Problem and decision
+
+Installing `@mistralai/mistralai@1.15.1` overwrote a JavaScript module with its
+JSON source map. The tarball uses a PAX `path` record for the long `.js.map`
+filename; its fallback header has the same name as the `.js` file. The extractor
+previously treated PAX headers as files and used that fallback name.
+
+Consume per-entry PAX headers as metadata, including across input boundaries.
+Apply `path`, `linkpath`, and `size` to the following entry, then clear the
+pending overrides. Validate full paths before prefix stripping, retain the
+existing traversal checks, and use the effective size for data and padding.
+Allow paths up to the existing validation limit of 4096 bytes. Bound each PAX
+metadata body to 64 KiB and reject malformed or oversized records. Unknown PAX
+keys are ignored. Global PAX, GNU extension headers, and other unsupported entry
+types fail explicitly rather than being extracted as ordinary files.
+
+## Validation
+
+- `zig test src/pkg/extractor.zig -lc -lz`: four tests passed, covering the
+  JS/source-map collision, fragmented input, override lifetime, size and link
+  overrides, malformed records, unsafe paths, and buffer limits.
+- `meson compile -C build`: passed.
+- `maid preflight` and its recommended `maid knowledge`: passed.
+- Streamed the actual Mistral 1.15.1 npm tarball through `Extractor` in 137-byte
+  compressed chunks. All 3260 output files matched npm's extraction byte for
+  byte, with no additional files. The extracted SDK loaded in Node and Ant.
+
+## Existing cache
+
+This changes future extraction only. Previously corrupted installed files and
+package-cache entries need removal and reinstallation; the extractor does not
+rewrite cache hits. The reproduction confirmed that a cache hit can retain the
+old corruption after rebuilding. No global cache was cleared during validation.

--- a/docs/exec-plans/tech-debt.md
+++ b/docs/exec-plans/tech-debt.md
@@ -18,6 +18,25 @@ scheduled.
 
 ## Open Items
 
+- Area: JS path performance (`src/builtins/node/path.cjs`, Silver runtime)
+  - Issue: The compatible JS implementation beats installed Ant on three of eight path microbenchmarks, but normalize, join, and relative remain 3.7-7.2x slower. Performance parity is deferred; Node-compatible correctness takes priority over speed. Keep primordial protection and do not trade semantics for benchmark gains.
+  - Impact: Current timings are roughly 0.4-1.5 microseconds per call. This is a substantial microbenchmark gap, but does not establish an application-level regression. Profile representative applications before adding runtime complexity; path-heavy bundling, crawling, and module resolution are useful candidates.
+  - Proposed fix: Revisit only with measured application impact. Profile the remaining JIT/string costs, retain only repeatable wins, add compatibility regressions, and compare pinned installed/current/Node binaries serially with ABBA ordering. Do not revive the removed hoisting, grouped-initializer, or register-argument experiments without new evidence.
+  - Owner: theMackabu
+  - Status: backlog (2026-09-05; accuracy first)
+  - Evidence: Accepted-only checkpoint, median milliseconds per 100,000 calls, 20,000 warmups, 12 samples per binary; lower is better. Hashes and raw runs are in `/tmp/ant-path-goal.KC4jj3/three-way-results.json`. These measurements predate the reserved-name compatibility fix. Details and experiment history: [path performance plan](active/path-node-performance.md). All 4,136 spec tests and 6,090 Node differential cases passed at this checkpoint; finite coverage is not proof of complete compatibility.
+
+  | Workload | Baseline `$(which ant)` | Current `./build/ant` | Node |
+  | --- | ---: | ---: | ---: |
+  | posix.normalize | 9.19 | 37.97 | 8.17 |
+  | win32.normalize | 10.38 | 74.28 | 14.72 |
+  | posix.join | 14.62 | 73.63 | 18.15 |
+  | posix.resolve (cwd) | 945.52 | 147.84 | 32.54 |
+  | posix.relative (absolute) | 25.30 | 93.40 | 31.88 |
+  | win32.resolve (absolute) | 960.83 | 113.88 | 20.72 |
+  | win32.relative (absolute) | 27.67 | 142.84 | 36.54 |
+  | posix.parse | 23.10 | 19.01 | 2.39 |
+
 - Area: module-level cached JS values (`g_*` statics)
   - Issue: RESOLVED for the 129 value caches audited on 2026-08-02: module-level `ant_value_t` caches migrated to per-isolate `js->builtins` / `js->mutable_roots` and are marked centrally in `gc_visit_roots` (see completed/module-import-gc-flake.md). The 2026-08-26 isolate audit found a broader remaining surface: a heuristic declaration scan reports 172 candidate mutable file-scope declarations in 58 source files. That raw count includes harmless startup configuration and intentionally shared native services, but it also includes active-resource lists, caches, native handles, root registries, and mutable library state. The global string-intern hash in `src/ant.c` is unguarded during insert/rehash and needs either isolate ownership or synchronization; the cage allocator and native-handle registry already use locks and can remain process-wide if their lifetime contracts survive a focused audit. Descriptors, builtins/mutable roots, normal ESM module state, events, regex, process state, rope mark metadata, and most heap rosters are already isolate-owned.
   - Impact: Same-process workers are now an intended consumer, so the remainder is no longer hypothetical. Any static that stores an isolate pointer, heap value, GC working state, libuv handle, or mutable ownership list can cause cross-isolate marking, callback dispatch through the wrong `ant_t`, teardown of another isolate's resources, or a data race.

--- a/docs/exec-plans/tech-debt.md
+++ b/docs/exec-plans/tech-debt.md
@@ -18,6 +18,14 @@ scheduled.
 
 ## Open Items
 
+- Area: Reflect.set receiver and success semantics (`src/modules/reflect.c`, property-setting internals)
+  - Issue: Reflect.set ignores its optional receiver and returns true after js_setprop unless an exception occurs. js_setprop returns the assigned value even for some rejected writes, so its result cannot be interpreted as a success boolean. Existing own-property read-only checks do not cover inherited restrictions, non-extensible receivers, or falsy proxy set traps.
+  - Impact: Accessors can receive the wrong this value, data writes can modify the target instead of the receiver, and callers can observe success when nothing was written.
+  - Proposed fix: Address in a separate compatibility PR. Share a receiver-aware internal [[Set]] operation with explicit success/rejection/exception results; retain assignment-expression values and strict-mode throwing behavior at their callers. Avoid duplicating the property-definition and proxy machinery in a Reflect-only implementation. Preserve thrown-value identity and GC roots across callbacks.
+  - Validation: Compare with Node for inherited setters and read-only properties, distinct and primitive receivers, receiver-side accessors, frozen/non-extensible objects and arrays, proxy set/defineProperty traps and transparent fallbacks, revocation, SameValue invariants, and exception propagation. Run focused tests and the full spec suite before landing.
+  - Owner: theMackabu
+  - Status: backlog (2026-09-05); unfinished Reflect-specific implementation and test removed from this PR at user request. The earlier frozen-own-property fix remains. Recoverable local experiment: `/tmp/ant-reflect-deferred.0pgnxD` (not a validated implementation or durable dependency).
+
 - Area: JS path performance (`src/builtins/node/path.cjs`, Silver runtime)
   - Issue: The compatible JS implementation beats installed Ant on three of eight path microbenchmarks, but normalize, join, and relative remain 3.7-7.2x slower. Performance parity is deferred; Node-compatible correctness takes priority over speed. Keep primordial protection and do not trade semantics for benchmark gains.
   - Impact: Current timings are roughly 0.4-1.5 microseconds per call. This is a substantial microbenchmark gap, but does not establish an application-level regression. Profile representative applications before adding runtime complexity; path-heavy bundling, crawling, and module resolution are useful candidates.

--- a/include/gc/strings.h
+++ b/include/gc/strings.h
@@ -5,7 +5,7 @@
 #include "value.h"
 #include <stdbool.h>
 
-static constexpr int STR_SHORT_CONS_THRESHOLD = 13;
+static constexpr int STR_SHORT_CONS_THRESHOLD = 32;
 
 enum: uint64_t {
   STR_META_ASCII_SHIFT = 56,

--- a/include/internal.h
+++ b/include/internal.h
@@ -633,9 +633,16 @@ sv_func_t *js_compile_parsed_bytecode(
 
 bool is_proxy(ant_value_t obj);
 bool is_array_value(ant_value_t value);
+bool js_is_array_includes_builtin(ant_value_t func);
 bool strict_eq_values(ant_t *js, ant_value_t l, ant_value_t r);
 bool same_value_values(ant_t *js, ant_value_t l, ant_value_t r);
 bool js_deep_equal(ant_t *js, ant_value_t a, ant_value_t b, bool strict);
+bool js_is_prototype_of(ant_t *js, ant_value_t proto_obj, ant_value_t obj);
+
+bool js_try_char_code_at(
+  ant_t *js, ant_value_t func, ant_value_t receiver,
+  ant_value_t *args, int argc, ant_value_t *result
+);
 
 ant_value_t js_eval_bytecode_eval_in_env_with_strict(
   ant_t *js, const char *buf, size_t len,
@@ -660,11 +667,9 @@ ant_value_t js_is_array_value_checked(ant_t *js, ant_value_t value, bool *out);
 ant_value_t do_instanceof(ant_t *js, ant_value_t l, ant_value_t r);
 ant_value_t do_in(ant_t *js, ant_value_t l, ant_value_t r);
 
-bool js_is_prototype_of(ant_t *js, ant_value_t proto_obj, ant_value_t obj);
 ant_value_t builtin_object_isPrototypeOf(ant_t *js, ant_value_t *args, int nargs);
 ant_value_t builtin_object_freeze(ant_t *js, ant_value_t *args, int nargs);
-
-bool js_is_array_includes_builtin(ant_value_t func);
+ant_value_t builtin_string_charCodeAt(ant_t *js, ant_value_t *args, int nargs);
 
 ant_value_t js_array_includes_call(ant_t *js, ant_value_t this_val, ant_value_t *args, int nargs);
 ant_value_t builtin_array_includes(ant_t *js, ant_value_t *args, int nargs);

--- a/include/pool.h
+++ b/include/pool.h
@@ -23,8 +23,6 @@ struct ant_pool_block {
   uint8_t data[];
 };
 
-static constexpr int ANT_POOL_SIZE_CLASS_COUNT = 32;
-
 static constexpr size_t ANT_POOL_ROPE_BLOCK_SIZE   = 64u * 1024u;
 static constexpr size_t ANT_POOL_SYMBOL_BLOCK_SIZE = 32u * 1024u;
 static constexpr size_t ANT_POOL_BIGINT_BLOCK_SIZE = 64u * 1024u;
@@ -49,6 +47,9 @@ typedef struct {
   uint8_t *end;
   size_t slot_stride;
 } ant_pool_bucket_t;
+
+static constexpr int ANT_POOL_SIZE_CLASS_COUNT = 32;
+int pool_size_class_index(size_t need);
 
 typedef struct {
   ant_pool_t base;

--- a/include/primordial_list.h
+++ b/include/primordial_list.h
@@ -17,6 +17,7 @@ PRIMORDIAL_DEF(StringPrototypeToLowerCase,  STRING_PROTO,   "toLowerCase", true)
 PRIMORDIAL_DEF(StringPrototypeToUpperCase,  STRING_PROTO,   "toUpperCase", true)
 PRIMORDIAL_DEF(JSONStringify,               JSON,           "stringify",   false)
 PRIMORDIAL_DEF(String,                      GLOBAL,         "String",      false)
+PRIMORDIAL_DEF(Error,                       GLOBAL,         "Error",       false)
 PRIMORDIAL_DEF(TypeError,                   GLOBAL,         "TypeError",   false)
 #undef PRIMORDIAL_DEF
 #endif

--- a/include/silver/compiler.h
+++ b/include/silver/compiler.h
@@ -45,6 +45,7 @@ typedef struct {
   bool is_const;
   bool captured;
   bool is_tdz;
+  bool char_code_at_hint;
   uint8_t inferred_type;
   sv_binding_meta_t binding;
 } sv_local_t;

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -210,6 +210,7 @@ typedef struct {
   const uint32_t *key_atoms;
   uint16_t key_count;
   bool shape_build_failed;
+  ant_value_t literal_template;
 } sv_obj_site_cache_t;
 
 static constexpr uint32_t SV_GF_IC_AUX_MISS_SHIFT = 8u;
@@ -583,6 +584,7 @@ static inline sv_upvalue_t *js_upvalue_alloc(ant_t *js) {
 #define SV_CALL_BORROWED_UPVALS  (1u << 4)
 #define SV_CALL_HAS_EVAL_ENV     (1u << 5)
 #define SV_CALL_HAS_BOUND_THIS   (1u << 6)
+#define SV_CALL_IS_UNCURRY       (1u << 7)
 
 static constexpr char SV_CLASS_CTOR_CALL_ERROR[] =
   "Class constructor cannot be invoked without 'new'";
@@ -941,6 +943,7 @@ typedef enum {
 
 typedef enum {
   SV_CALL_EXEC_NATIVE = 0,
+  SV_CALL_EXEC_UNCURRIED_NATIVE,
   SV_CALL_EXEC_PROXY_APPLY,
   SV_CALL_EXEC_PROXY_CONSTRUCT,
   SV_CALL_EXEC_DEFAULT_CTOR,
@@ -1139,6 +1142,16 @@ static inline ant_value_t sv_prepare_call(
     return js_mkundef();
   }
 
+  if (
+    !is_construct_call && js->vm_exec_depth != 0 &&
+    (closure->call_flags & SV_CALL_IS_UNCURRY) &&
+    vtype(closure->bound_this) == kTypeBuiltin
+  ) {
+    plan->kind = SV_CALL_EXEC_UNCURRIED_NATIVE;
+    plan->ctx.this_val = plan->ctx.argc ? plan->ctx.args[0] : js_mkundef();
+    if (plan->ctx.argc) { plan->ctx.args++; plan->ctx.argc--; }
+  }
+
   return js_mkundef();
 }
 
@@ -1166,6 +1179,18 @@ static inline ant_value_t sv_execute_call_plan(
     ant_value_t result = sv_call_native(
       js, plan->func, plan->ctx.this_val, plan->ctx.args, plan->ctx.argc
     );
+    sv_call_cleanup(js, &plan->ctx);
+    return result;
+  }
+
+  case SV_CALL_EXEC_UNCURRIED_NATIVE: {
+    ant_value_t saved_func = js->current_func;
+    js->current_func = plan->func;
+    ant_value_t result = sv_call_native(
+      js, plan->closure->bound_this, 
+      plan->ctx.this_val, plan->ctx.args, plan->ctx.argc
+    );
+    js->current_func = saved_func;
     sv_call_cleanup(js, &plan->ctx);
     return result;
   }}

--- a/include/silver/glue.h
+++ b/include/silver/glue.h
@@ -96,6 +96,11 @@ ant_value_t jit_helper_call_method(
   ant_value_t *out_this
 );
 
+ant_value_t jit_helper_call_char_code_at(
+  sv_vm_t *vm, ant_t *js, ant_value_t func, 
+  ant_value_t receiver, ant_value_t *args, int argc
+);
+
 ant_value_t jit_helper_call_array_includes(
   sv_vm_t *vm, ant_t *js,
   ant_value_t call_func, ant_value_t call_this,
@@ -162,6 +167,11 @@ ant_value_t jit_helper_apply(
 
 ant_value_t jit_helper_object(
   sv_vm_t *vm, ant_t *js,
+  sv_func_t *func, sv_obj_site_cache_t *site
+);
+
+ant_value_t jit_helper_object_template(
+  sv_vm_t *vm, ant_t *js, 
   sv_func_t *func, sv_obj_site_cache_t *site
 );
 

--- a/include/silver/opcode.h
+++ b/include/silver/opcode.h
@@ -157,6 +157,7 @@ OP_DEF(  USHR,              1,   2,   1, none)      /* >>> (matches TOK_ZSHR) */
 
 OP_DEF(  NOT,               1,   1,   1, none)      /* ! */
 OP_DEF(  TYPEOF,            1,   1,   1, none)
+OP_DEF(  IS_PRIMITIVE_TYPE, 2,   1,   1, u8)        /* typeof primitive comparison without a string */
 OP_DEF(  VOID,              1,   1,   1, none)      /* eval + push undefined */
 OP_DEF(  DELETE,            1,   2,   1, none)      /* obj key -> bool */
 OP_DEF(  DELETE_VAR,        5,   0,   1, atom)      /* delete unqualified name */
@@ -177,6 +178,7 @@ OP_DEF(  CALL_METHOD,       3,   2,   1, npop)      /* this func args... -> resu
 OP_DEF(  CALL_SUPER,        3,   3,   1, npop)      /* this super new.target args... -> this */
 OP_DEF(  CALL_IS_PROTO,     3,   3,   1, u16)       /* this func arg -> bool (ic_idx:u16) */
 OP_DEF(  CALL_ARRAY_INCLUDES, 3, 2,   1, npop)      /* this func args... -> bool */
+OP_DEF(  CALL_CHAR_CODE_AT,   3, 2,   1, npop)      /* this func args... -> result */
 OP_DEF(  CALL_MAP_TEMPLATE,   5,   2,   1, map_template) /* this func substitutions... -> result; descriptor:u32 */
 OP_DEF(  CALL_STABLE_BUILTIN, 4, 2,   1, u8_u16)    /* this func args... -> result (kind:u8 argc:u16) */
 OP_DEF(  CALL_CALL,         3,   1,   1, u8_u8)     /* X a... b... -> X(a...)(b...); n1:u8 n2:u8 — fuses curried steps */
@@ -407,6 +409,7 @@ OP_FLAG(USHR                  , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_INLINEABLE | SV
 
 OP_FLAG(NOT                   , SV_OPF_JIT_ELIGIBLE)
 OP_FLAG(TYPEOF                , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_NEEDS_BAILOUT)
+OP_FLAG(IS_PRIMITIVE_TYPE     , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_INLINEABLE)
 OP_FLAG(VOID                  , SV_OPF_JIT_ELIGIBLE)
 OP_FLAG(DELETE                , SV_OPF_JIT_ELIGIBLE)
 
@@ -425,6 +428,7 @@ OP_FLAG(CALL_METHOD           , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_INLINEABLE | SV
 OP_FLAG(CALL_SUPER            , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_NEEDS_ARGS_BUF)
 OP_FLAG(CALL_IS_PROTO         , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_NEEDS_IC_EPOCH)
 OP_FLAG(CALL_ARRAY_INCLUDES   , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_NEEDS_ARGS_BUF)
+OP_FLAG(CALL_CHAR_CODE_AT     , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_NEEDS_ARGS_BUF)
 OP_FLAG(CALL_MAP_TEMPLATE     , SV_OPF_JIT_ELIGIBLE)
 OP_FLAG(CALL_STABLE_BUILTIN   , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_INLINEABLE | SV_OPF_JIT_NEEDS_ARGS_BUF)
 OP_FLAG(CALL_CALL             , SV_OPF_JIT_ELIGIBLE | SV_OPF_JIT_NEEDS_ARGS_BUF | SV_OPF_JIT_NEEDS_IC_EPOCH)

--- a/meson/builtins/meson.build
+++ b/meson/builtins/meson.build
@@ -10,6 +10,7 @@ builtins_h = custom_target(
   input: builtin_files,
   output: ['builtin_bundle_data.h', 'snapshot_data.h'],
   depends: tools_npm_ci,
+  depend_files: files('../../src/tools/gen_builtins.js'),
   command: [
     node,
     src_root / 'src' / 'tools' / 'gen_builtins.js',

--- a/src/ant.c
+++ b/src/ant.c
@@ -6288,13 +6288,17 @@ static ant_value_t builtin_function_bind(ant_t *js, ant_value_t *args, int nargs
     if (vtype(func_proto) == kTypeFunction) js_set_proto_init(bound_func, func_proto);
 
     uint8_t bind_flags = SV_CALL_HAS_BOUND_THIS;
+    if (js_as_cfunc(func) == builtin_function_call) bind_flags |= SV_CALL_IS_UNCURRY;
     if (bound_argc > 0) bind_flags |= SV_CALL_HAS_BOUND_ARGS;
+    
     ant_value_t bound = js_obj_to_func_ex(js, bound_func, bind_flags);
     sv_closure_t *bc = js_func_closure(bound);
     bc->bound_this = this_arg;
-    if (bound_argc > 0 &&
-        !bound_argv_copy(bc, bound_args, bound_argc, NULL, 0))
-      return js_mkerr(js, "oom");
+    
+    if (
+      bound_argc > 0 && 
+      !bound_argv_copy(bc, bound_args, bound_argc, NULL, 0)
+    ) return js_mkerr(js, "oom");
     
     ant_value_t length_result = js_define_bound_function_length(js, bound_func, bound_length);
     if (is_err(length_result)) return length_result;
@@ -13325,6 +13329,39 @@ static ant_value_t builtin_string_split(ant_t *js, ant_value_t *args, int nargs)
 }
 
 static ant_value_t builtin_string_slice(ant_t *js, ant_value_t *args, int nargs) {
+  ant_value_t receiver = js->this_val;
+  if (str_is_heap_rope(receiver)) receiver = rope_cached_flat(receiver);
+  ant_flat_string_t *flat = ant_str_flat_ptr(receiver);
+  
+  bool numeric_start = nargs == 0 || vtype(args[0]) == kTypeUndefined ||
+    (vtype(args[0]) == kTypeNumber && tod(args[0]) >= 0);
+    
+  bool numeric_end = nargs < 2 || vtype(args[1]) == kTypeUndefined ||
+    (vtype(args[1]) == kTypeNumber && tod(args[1]) >= 0);
+    
+  if (flat && str_flat_ascii_state(flat) == STR_ASCII_YES && numeric_start && numeric_end) {
+    size_t len = (size_t)flat->len;
+    double start_arg = nargs && vtype(args[0]) == kTypeNumber ? tod(args[0]) : 0;
+    double end_arg = nargs >= 2 && vtype(args[1]) == kTypeNumber ? tod(args[1]) : (double)len;
+    
+    size_t start = start_arg >= (double)len ? len : (size_t)start_arg;
+    size_t end = end_arg >= (double)len ? len : (size_t)end_arg;
+    
+    if (start == 0 && end == len) return receiver;
+    size_t result_len = end > start ? end - start : 0;
+    GC_ROOT_SAVE(mark, js);
+    GC_ROOT_PIN(js, receiver);
+    
+    ant_value_t result = js_mkstr(js, NULL, result_len);
+    if (!is_err(result)) {
+      ant_flat_string_t *out = ant_str_flat_ptr(result);
+      memcpy(out->bytes, flat->bytes + start, result_len);
+      str_flat_init_meta(out, STR_ASCII_YES);
+    } GC_ROOT_RESTORE(js, mark);
+    
+    return result;
+  }
+
   ant_value_t this_unwrapped = unwrap_primitive(js, js->this_val);
   ant_value_t str = js_tostring_val(js, this_unwrapped);
   if (is_err(str)) return str;
@@ -13660,13 +13697,16 @@ static ant_value_t builtin_string_sup(ant_t *js, ant_value_t *args, int nargs) {
   return builtin_string_html(js, args, nargs, "sup", NULL);
 }
 
-static ant_value_t builtin_string_charCodeAt(ant_t *js, ant_value_t *args, int nargs) {
+ant_value_t builtin_string_charCodeAt(ant_t *js, ant_value_t *args, int nargs) {
   ant_value_t str = to_string_val(js, js->this_val);
+  
+  if (is_err(str)) return str;
   if (vtype(str) != kTypeString) return js_mkerr(js, "charCodeAt called on non-string");
   
   double idx_d = nargs < 1 ? 0.0 : js_to_number(js, args[0]);
+  if (js->thrown_exists) return mkval(kTypeError, 0);
   if (isnan(idx_d)) idx_d = 0.0;
-  if (isinf(idx_d) || idx_d > (double)LONG_MAX) return tov(JS_NAN);
+  if (idx_d >= (double)LONG_MAX || idx_d <= (double)LONG_MIN) return tov(JS_NAN);
   
   long idx_l = (long) idx_d;
   if (idx_l < 0) return tov(JS_NAN);
@@ -13678,6 +13718,42 @@ static ant_value_t builtin_string_charCodeAt(ant_t *js, ant_value_t *args, int n
   if (code_unit == 0xFFFFFFFF) return tov(JS_NAN);
   
   return tov((double) code_unit);
+}
+
+bool js_try_char_code_at(
+  ant_t *js, ant_value_t func, ant_value_t receiver,
+  ant_value_t *args, int argc, ant_value_t *result
+) {
+  if (vtype(func) == kTypeFunction) {
+    sv_closure_t *closure = js_func_closure(func);
+    if (closure->func || (closure->call_flags & SV_CALL_HAS_BOUND_ARGS)) return false;
+    func = get_slot(closure->func_obj, SLOT_CFUNC);
+    
+    if (closure->call_flags & SV_CALL_HAS_BOUND_THIS) receiver = closure->bound_this;
+    if (vtype(func) == kTypeBuiltin && js_as_cfunc(func) == builtin_function_call) {
+      if (argc == 0) return false;
+      func = receiver; receiver = *args++; argc--;
+    }
+  }
+  
+  if (vtype(func) != kTypeBuiltin || js_as_cfunc(func) != builtin_string_charCodeAt) return false;
+  if (vtype(receiver) != kTypeString) return false;
+  if (argc > 0 && vtype(args[0]) != kTypeNumber) return false;
+  if (str_is_heap_rope(receiver)) receiver = rope_cached_flat(receiver);
+  if (vtype(receiver) != kTypeString) return false;
+  if (str_is_heap_rope(receiver) || str_is_heap_builder(receiver)) return false;
+
+  ant_offset_t length;
+  const char *bytes = (const char *)(uintptr_t)vstr(js, receiver, &length);
+  
+  if (!str_is_ascii(bytes)) return false;
+  double index = argc ? tod(args[0]) : 0;
+  
+  index = isnan(index) ? 0 : trunc(index);
+  *result = index < 0 || index >= (double)length
+    ? tov(JS_NAN) : tov((double)(unsigned char)bytes[(size_t)index]);
+  
+  return true;
 }
 
 static ant_value_t builtin_string_codePointAt(ant_t *js, ant_value_t *args, int nargs) {

--- a/src/builtins/node/path.cjs
+++ b/src/builtins/node/path.cjs
@@ -474,7 +474,7 @@ const win32 = {
       } while ((index = StringPrototypeIndexOf(path, ':', index + 1)) !== -1);
     }
     const colonIndex = StringPrototypeIndexOf(path, ':');
-    if (isWindowsReservedName(path, colonIndex)) {
+    if (colonIndex !== -1 && isWindowsReservedName(path, colonIndex)) {
       return `.\\${device ?? ''}${tail}`;
     }
     if (device === undefined) {

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -378,7 +378,9 @@ static void gc_mark_func(ant_t *js, sv_func_t *func) {
     gc_mark_func(js, func->child_funcs[i]);
     
   for (uint32_t i = 0; i < func->obj_site_count; i++) {
-    if (func->obj_sites) ant_gc_shapes_mark(func->obj_sites[i].shared_shape);
+    if (!func->obj_sites) continue;
+    ant_gc_shapes_mark(func->obj_sites[i].shared_shape);
+    gc_mark_value(js, func->obj_sites[i].literal_template);
   }
 
   for (int i = 0; i < func->gc_const_slot_count; i++) {

--- a/src/modules/assert.c
+++ b/src/modules/assert.c
@@ -3,6 +3,7 @@
 #include "ant.h"
 #include "errors.h"
 #include "internal.h"
+#include "gc/roots.h"
 
 #include "modules/assert.h"
 #include "silver/engine.h"
@@ -158,23 +159,59 @@ static ant_value_t assert_not_deep_strict_equal(ant_t *js, ant_value_t *args, in
   return js_mkundef();
 }
 
-static ant_value_t assert_throws(ant_t *js, ant_value_t *args, int nargs) {
-  if (nargs < 1 || vtype(args[0]) != kTypeFunction)
-    return js_mkerr(js, "assert.throws: first argument must be a function");
-  ant_value_t result = sv_vm_call(js->vm, js, args[0], js_mkundef(), NULL, 0, NULL, false);
+static ant_value_t assert_exception_matches(
+  ant_t *js, ant_value_t thrown, ant_value_t expected, ant_value_t message
+) {
+  if (!is_callable(expected)) return js_mkundef();
+  ant_value_t prototype = js_get(js, expected, "prototype");
+  if (is_err(prototype)) return prototype;
   
-  if (!is_err(result))
-    return js_mkerr(js, "Missing expected exception");
-
-  ant_value_t thrown = js_take_thrown(js, result);
-  if (nargs >= 2 && is_callable(args[1])) {
-    ant_value_t valid = sv_vm_call(js->vm, js, args[1], js_mkundef(), &thrown, 1, NULL, false);
-    if (is_err(valid)) return valid;
-    if (valid != js_true)
-      return assertion_error(js, "The validation function is expected to return true", js_mkundef());
+  if (!is_undefined(prototype)) {
+    ant_value_t matches = do_instanceof(js, thrown, expected);
+    if (is_err(matches)) return matches;
+    if (js_truthy(js, matches)) return js_mkundef();
   }
 
+  ant_value_t error_ctor = js_get(js, js_glob(js), "Error");
+  if (is_err(error_ctor)) return error_ctor;
+  if (js_is_prototype_of(js, error_ctor, expected))
+    return assertion_error(js, "The error is expected to be an instance of the specified constructor", message);
+
+  ant_value_t receiver = js_mkobj(js);
+  if (is_err(receiver)) return receiver;
+  ant_value_t valid = sv_vm_call(js->vm, js, expected, receiver, &thrown, 1, NULL, false);
+  
+  if (is_err(valid)) return valid;
+  if (valid != js_true)
+    return assertion_error(js, "The validation function is expected to return true", message);
+  
   return js_mkundef();
+}
+
+static ant_value_t assert_throws(ant_t *js, ant_value_t *args, int nargs) {
+  if (nargs < 1 || !is_callable(args[0]))
+    return js_mkerr(js, "assert.throws: first argument must be a function");
+
+  GC_ROOT_SAVE(mark, js);
+  ant_value_t fn = args[0];
+  ant_value_t expected = nargs >= 2 ? args[1] : js_mkundef();
+  ant_value_t message = nargs >= 3 ? args[2] : js_mkundef();
+  ant_value_t thrown = js_mkundef();
+  
+  GC_ROOT_PIN(js, fn);
+  GC_ROOT_PIN(js, expected);
+  GC_ROOT_PIN(js, message);
+  GC_ROOT_PIN(js, thrown);
+
+  ant_value_t result = sv_vm_call(js->vm, js, fn, js_mkundef(), NULL, 0, NULL, false);
+  if (!is_err(result))
+    result = assertion_error(js, "Missing expected exception", message);
+  else {
+    thrown = js_take_thrown(js, result);
+    result = assert_exception_matches(js, thrown, expected, message);
+  } GC_ROOT_RESTORE(js, mark);
+  
+  return result;
 }
 
 static ant_value_t assert_does_not_throw(ant_t *js, ant_value_t *args, int nargs) {

--- a/src/modules/assert.c
+++ b/src/modules/assert.c
@@ -172,8 +172,7 @@ static ant_value_t assert_exception_matches(
     if (js_truthy(js, matches)) return js_mkundef();
   }
 
-  ant_value_t error_ctor = js_get(js, js_glob(js), "Error");
-  if (is_err(error_ctor)) return error_ctor;
+  ant_value_t error_ctor = js->primordial_values[ANT_PRIMORDIAL_Error];
   if (js_is_prototype_of(js, error_ctor, expected))
     return assertion_error(js, "The error is expected to be an instance of the specified constructor", message);
 

--- a/src/modules/process.c
+++ b/src/modules/process.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <time.h>
 #include <uthash.h>
 #include <uv.h>
@@ -76,6 +77,8 @@ typedef struct {
 
 struct ant_process_state {
   ant_value_t process_obj;
+  ant_value_t cached_cwd;
+  uint64_t cwd_epoch;
   ant_value_t stdin_obj;
   ant_value_t stdout_obj;
   ant_value_t stderr_obj;
@@ -100,6 +103,7 @@ struct ant_process_state {
   #endif
 };
 
+static atomic_uint_fast64_t process_cwd_epoch;
 static ant_process_state_t *process_state(ant_t *js) {
   if (js->process_state) return js->process_state;
 
@@ -109,6 +113,7 @@ static ant_process_state_t *process_state(ant_t *js) {
   ps->sandbox_tty_rows = 24;
   ps->sandbox_tty_cols = 80;
   ps->stdin_state.decoder = js_mkundef();
+  ps->cached_cwd = js_mkundef();
   ps->stdin_state.refed = true;
 
   js->process_state = ps;
@@ -1063,6 +1068,7 @@ static ant_value_t process_chdir(ant_t *js, ant_value_t *args, int nargs) {
   
   int result = uv_chdir(dir);
   if (result != 0) return js_mkerr(js, "ENOENT: no such file or directory, chdir");
+  atomic_fetch_add_explicit(&process_cwd_epoch, 1, memory_order_release);
   return js_mkundef();
 }
 
@@ -1461,6 +1467,12 @@ static ant_value_t env_keys(ant_t *js, ant_value_t obj) {
 }
 
 static ant_value_t process_cwd(ant_t *js, ant_value_t *args, int nargs) {
+  ant_process_state_t *ps = process_state(js);
+  if (!ps) return js_mkerr(js, "Out of memory");
+  
+  uint64_t epoch = atomic_load_explicit(&process_cwd_epoch, memory_order_acquire);
+  if (ps->cwd_epoch == epoch && vtype(ps->cached_cwd) == kTypeString) return ps->cached_cwd;
+
   char inline_cwd[4096];
   char *cwd = inline_cwd;
   
@@ -1485,6 +1497,11 @@ static ant_value_t process_cwd(ant_t *js, ant_value_t *args, int nargs) {
   }
   
   if (cwd != inline_cwd) free(cwd);
+  if (vtype(result) == kTypeString) {
+    ps->cached_cwd = result;
+    ps->cwd_epoch = epoch;
+  }
+  
   return result;
 }
 
@@ -1877,6 +1894,7 @@ bool has_active_stdin(ant_t *js) {
 void gc_mark_process(ant_t *js, gc_mark_fn mark) {
   ant_process_state_t *ps = js->process_state;
   if (!ps) return;
+  mark(js, ps->cached_cwd);
   if (is_object_type(ps->process_obj)) mark(js, ps->process_obj);
   if (is_object_type(ps->stdin_obj)) mark(js, ps->stdin_obj);
   if (is_object_type(ps->stdout_obj)) mark(js, ps->stdout_obj);

--- a/src/modules/reflect.c
+++ b/src/modules/reflect.c
@@ -61,11 +61,23 @@ static ant_value_t reflect_set(ant_t *js, ant_value_t *args, int nargs) {
   
   if (vtype(key) != kTypeString) return js_false;
   
-  char *key_str = js_getstr(js, key, NULL);
+  size_t key_len;
+  char *key_str = js_getstr(js, key, &key_len);
   if (!key_str) return js_false;
+
+  ant_value_t target_obj = js_as_obj(target);
+  prop_meta_t meta;
   
-  js_set(js, target, key_str, value);
-  return js_true; 
+  if (!is_proxy(target_obj) && lookup_string_prop_meta(js, target_obj, key_str, key_len, &meta)) {
+    bool writable = (meta.has_getter || meta.has_setter) ? meta.has_setter : meta.writable;
+    if (!writable) return js_false;
+  }
+
+  ant_value_t result = js_setprop(js, target, key, value);
+  if (is_err(result)) return result;
+  if (js->thrown_exists) return mkval(kTypeError, 0);
+  
+  return js_true;
 }
 
 static ant_value_t reflect_has(ant_t *js, ant_value_t *args, int nargs) {

--- a/src/pkg/extractor.zig
+++ b/src/pkg/extractor.zig
@@ -216,11 +216,20 @@ pub const TarParser = struct {
   strip_prefix: [128]u8,
   strip_prefix_len: usize,
   prefix_detected: bool,
-  path_buf: [256]u8,
+  path_buf: [4096]u8,
+  pax_data: [64 * 1024]u8 = undefined,
+  pax_len: usize = 0,
+  pax_path: [4096]u8 = undefined,
+  pax_path_len: usize = 0,
+  pax_link: [4096]u8 = undefined,
+  pax_link_len: usize = 0,
+  pax_size: ?u64 = null,
+  entry_size: u64 = 0,
 
   const State = enum {
     read_header,
     read_file_data,
+    read_pax_data,
     skip_padding,
   };
 
@@ -246,6 +255,7 @@ pub const TarParser = struct {
     mode: u32,
     size: u64,
     entry_type: Type,
+    link_target: []const u8,
 
     pub const Type = enum {
       file,
@@ -267,6 +277,37 @@ pub const TarParser = struct {
     };
   };
 
+  fn parsePax(self: *TarParser) ExtractError!void {
+    var records = self.pax_data[0..self.pax_len];
+    while (records.len > 0) {
+      const space = std.mem.indexOfScalar(u8, records, ' ') orelse return error.InvalidTarHeader;
+      const len = std.fmt.parseInt(usize, records[0..space], 10) catch return error.InvalidTarHeader;
+      if (len <= space + 1 or len > records.len or records[len - 1] != '\n') return error.InvalidTarHeader;
+      const record = records[space + 1 .. len - 1];
+      const equals = std.mem.indexOfScalar(u8, record, '=') orelse return error.InvalidTarHeader;
+      const key = record[0..equals];
+      const value = record[equals + 1 ..];
+      if (std.mem.eql(u8, key, "path")) {
+        try validatePath(value);
+        @memcpy(self.pax_path[0..value.len], value);
+        self.pax_path_len = value.len;
+      } else if (std.mem.eql(u8, key, "linkpath")) {
+        try validatePath(value);
+        @memcpy(self.pax_link[0..value.len], value);
+        self.pax_link_len = value.len;
+      } else if (std.mem.eql(u8, key, "size")) {
+        self.pax_size = std.fmt.parseInt(u64, value, 10) catch return error.InvalidTarHeader;
+      }
+      records = records[len..];
+    }
+  }
+
+  fn finishData(self: *TarParser) void {
+    const padding = (512 - (self.entry_size % 512)) % 512;
+    self.skip_bytes = @intCast(padding);
+    self.state = if (padding > 0) .skip_padding else .read_header;
+  }
+
   pub fn feed(self: *TarParser, data: []const u8) ParseResult {
     switch (self.state) {
       .read_header => {
@@ -283,7 +324,21 @@ pub const TarParser = struct {
 
         if (self.header.isZero()) {
           return .{ .kind = .end_of_archive, .consumed = to_copy };
-        } var path = self.header.getName(&self.path_buf) catch {
+        }
+        const header_size = self.header.getSize() catch return .{ .kind = .{ .err = error.InvalidTarHeader }, .consumed = to_copy };
+        if (self.header.typeflag == 'x') {
+          if (header_size > self.pax_data.len) return .{ .kind = .{ .err = error.UnsupportedFormat }, .consumed = to_copy };
+          self.pax_len = 0;
+          self.entry_size = header_size;
+          self.current_file_remaining = header_size;
+          self.state = if (header_size > 0) .read_pax_data else .read_header;
+          return .{ .kind = .need_more_data, .consumed = to_copy };
+        }
+        // Do not silently extract unsupported metadata using a truncated name.
+        if (!self.header.isFile() and !self.header.isDirectory() and !self.header.isSymlink()) {
+          return .{ .kind = .{ .err = error.UnsupportedFormat }, .consumed = to_copy };
+        }
+        var path = if (self.pax_path_len > 0) self.pax_path[0..self.pax_path_len] else self.header.getName(&self.path_buf) catch {
           return .{ .kind = .{ .err = ExtractError.InvalidPath }, .consumed = to_copy };
         };
 
@@ -307,7 +362,10 @@ pub const TarParser = struct {
           return .{ .kind = .{ .err = ExtractError.InvalidPath }, .consumed = to_copy };
         };
 
-        const size = self.header.getSize() catch return .{ .kind = .{ .err = ExtractError.InvalidTarHeader }, .consumed = to_copy };
+        const size = self.pax_size orelse header_size;
+        self.pax_path_len = 0;
+        self.pax_size = null;
+        self.entry_size = size;
         const mode = self.header.getMode() catch return .{ .kind = .{ .err = ExtractError.InvalidTarHeader }, .consumed = to_copy };
 
         const entry_type: Entry.Type = if (self.header.isDirectory()) .directory
@@ -324,8 +382,11 @@ pub const TarParser = struct {
           .mode = mode,
           .size = size,
           .entry_type = entry_type,
+          .link_target = if (self.pax_link_len > 0) self.pax_link[0..self.pax_link_len]
+            else std.mem.sliceTo(&self.header.linkname, 0),
         };
         
+        self.pax_link_len = 0;
         return .{ .consumed = to_copy, .kind = .{ .entry = entry } };
       },
 
@@ -333,16 +394,21 @@ pub const TarParser = struct {
         const to_read: usize = @min(self.current_file_remaining, data.len);
         self.current_file_remaining -= to_read;
 
-        if (self.current_file_remaining == 0) {
-          const size = self.header.getSize() catch return .{ .kind = .{ .err = ExtractError.InvalidTarHeader }, .consumed = to_read };
-          const padding = (512 - (size % 512)) % 512;
-          if (padding > 0) {
-            self.skip_bytes = @intCast(padding);
-            self.state = .skip_padding;
-          } else self.state = .read_header;
-        }
+        if (self.current_file_remaining == 0) self.finishData();
 
         return .{ .kind = .{ .file_data = data[0..to_read] }, .consumed = to_read };
+      },
+
+      .read_pax_data => {
+        const to_read: usize = @intCast(@min(self.current_file_remaining, data.len));
+        @memcpy(self.pax_data[self.pax_len..][0..to_read], data[0..to_read]);
+        self.pax_len += to_read;
+        self.current_file_remaining -= to_read;
+        if (self.current_file_remaining == 0) {
+          self.parsePax() catch |err| return .{ .kind = .{ .err = err }, .consumed = to_read };
+          self.finishData();
+        }
+        return .{ .kind = .need_more_data, .consumed = to_read };
       },
 
       .skip_padding => {
@@ -371,7 +437,7 @@ pub const Extractor = struct {
   parser: TarParser,
   decompressor: *GzipDecompressor,
   current_file: ?std.Io.File,
-  current_file_path: [256]u8,
+  current_file_path: [4096]u8,
   current_file_path_len: usize,
   current_file_mode: u32,
   files_extracted: u32,
@@ -425,7 +491,7 @@ pub const Extractor = struct {
     if (comptime builtin.os.tag != .windows) {
       if (self.current_file_mode & 0o111 != 0) {
         const path = self.current_file_path[0..self.current_file_path_len];
-        var path_buf: [257]u8 = undefined;
+        var path_buf: [4097]u8 = undefined;
         @memcpy(path_buf[0..path.len], path);
         path_buf[path.len] = 0;
         const path_z: [*:0]const u8 = path_buf[0..path.len :0];
@@ -452,7 +518,7 @@ pub const Extractor = struct {
       const result = self.parser.feed(remaining);
       remaining = remaining[result.consumed..];
       switch (result.kind) {
-        .need_more_data => return,
+        .need_more_data => if (result.consumed == 0) return,
         .entry => |entry| try self.handleEntry(entry),
         .file_data => |d| try self.writeFileData(d),
         .end_of_archive => {
@@ -483,7 +549,7 @@ pub const Extractor = struct {
       break :blk true;
     };
     self.current_file = try self.output_dir.createFile(io, entry.path, .{});
-    const len = @min(entry.path.len, 256);
+    const len = entry.path.len;
     @memcpy(self.current_file_path[0..len], entry.path[0..len]);
     self.current_file_path_len = len;
     self.current_file_mode = entry.mode;
@@ -491,8 +557,7 @@ pub const Extractor = struct {
   }
   
   inline fn createSymlink(self: *Extractor, entry: TarParser.Entry) !void {
-    const linkname_len = std.mem.indexOfScalar(u8, &self.parser.header.linkname, 0) orelse self.parser.header.linkname.len;
-    const target = self.parser.header.linkname[0..linkname_len];
+    const target = entry.link_target;
     
     if (entry.path.len == 0 or target.len == 0) return;
     try validatePath(target);
@@ -531,3 +596,147 @@ pub const Extractor = struct {
     return self.gzip_finished and self.archive_finished and self.files_extracted > 0;
   }
 };
+
+const TestTar = struct {
+  bytes: [16384]u8 = @splat(0),
+  len: usize = 0,
+
+  fn add(self: *TestTar, name: []const u8, kind: u8, body: []const u8) !void {
+    var header = std.mem.zeroes(TarHeader);
+    @memcpy(header.name[0..@min(name.len, 100)], name[0..@min(name.len, 100)]);
+    _ = try std.fmt.bufPrint(&header.size, "{o:0>11}", .{body.len});
+    _ = try std.fmt.bufPrint(&header.mode, "{o:0>7}", .{@as(u32, 0o644)});
+    header.typeflag = kind;
+    @memcpy(self.bytes[self.len..][0..512], std.mem.asBytes(&header));
+    self.len += 512;
+    @memcpy(self.bytes[self.len..][0..body.len], body);
+    self.len += (body.len + 511) / 512 * 512;
+  }
+
+  fn paxRecord(buf: []u8, key: []const u8, value: []const u8) ![]const u8 {
+    var len = key.len + value.len + 4;
+    while (true) {
+      const record = try std.fmt.bufPrint(buf, "{d} {s}={s}\n", .{ len, key, value });
+      if (record.len == len) return record;
+      len = record.len;
+    }
+  }
+};
+
+test "PAX source map paths survive arbitrary input boundaries and apply once" {
+  const name = "getchatcompletionfieldoptionscountsv1observabilitychatcompletionfieldsfieldnameoptionscountspost.js";
+  var tar = TestTar{};
+  try tar.add(name, '0', "module.exports = 1;");
+  var record_buf: [512]u8 = undefined;
+  try tar.add("PaxHeader/map", 'x', try TestTar.paxRecord(&record_buf, "path", "package/" ++ name ++ ".map"));
+  // npm's fallback header truncates .map away, colliding with the JS file.
+  try tar.add(name, '0', "{\"version\":3}");
+  try tar.add("package/after.js", '0', "after");
+  const paths = [_][]const u8{ name, name ++ ".map", "after.js" };
+  const bodies = [_][]const u8{ "module.exports = 1;", "{\"version\":3}", "after" };
+  for ([_]usize{ 1, 7, 511, 512, 513, 16384 }) |chunk_size| {
+    var parser = TarParser.init("package/");
+    var offset: usize = 0;
+    var count: usize = 0;
+    var body_offset: usize = 0;
+    while (offset < tar.len) {
+      const result = parser.feed(tar.bytes[offset..@min(offset + chunk_size, tar.len)]);
+      try std.testing.expect(result.consumed > 0);
+      offset += result.consumed;
+      switch (result.kind) {
+        .entry => |entry| {
+          if (count > 0) try std.testing.expectEqual(bodies[count - 1].len, body_offset);
+          try std.testing.expect(count < paths.len);
+          try std.testing.expectEqualStrings(paths[count], entry.path);
+          try std.testing.expectEqual(bodies[count].len, entry.size);
+          body_offset = 0;
+          count += 1;
+        },
+        .file_data => |data| {
+          try std.testing.expect(count > 0);
+          try std.testing.expectEqualStrings(bodies[count - 1][body_offset..][0..data.len], data);
+          body_offset += data.len;
+        },
+        .need_more_data => {},
+        else => return error.UnexpectedParseResult,
+      }
+    }
+    try std.testing.expectEqual(paths.len, count);
+    try std.testing.expectEqual(bodies[count - 1].len, body_offset);
+  }
+}
+
+test "PAX rejects malformed records and unsafe paths" {
+  for ([_][]const u8{ "999 path=a\n", "0 path=a\n", "12 path=abc!", "12 missing=\n" }) |bad| {
+    // The last record is a valid unknown key and must be ignored.
+    var parser = TarParser.init("package/");
+    @memcpy(parser.pax_data[0..bad.len], bad);
+    parser.pax_len = bad.len;
+    if (std.mem.eql(u8, bad, "12 missing=\n")) {
+      try parser.parsePax();
+    } else try std.testing.expectError(error.InvalidTarHeader, parser.parsePax());
+  }
+  for ([_][]const u8{ "../escape", "package/../../escape", "/absolute", "package/a\\b", "package/a\x00b" }) |path| {
+    var parser = TarParser.init("package/");
+    const record = try TestTar.paxRecord(&parser.pax_data, "path", path);
+    parser.pax_len = record.len;
+    try std.testing.expectError(error.InvalidPath, parser.parsePax());
+  }
+}
+
+test "PAX size and linkpath override one entry" {
+  var tar = TestTar{};
+  var buf: [512]u8 = undefined;
+  const first = try TestTar.paxRecord(&buf, "linkpath", "long/target");
+  const first_len = first.len;
+  const second = try TestTar.paxRecord(buf[first_len..], "size", "3");
+  try tar.add("PaxHeader/link", 'x', buf[0 .. first_len + second.len]);
+  const entry_offset = tar.len;
+  try tar.add("package/link", '2', "abc");
+  // The PAX size controls both data consumption and padding.
+  @memcpy(tar.bytes[entry_offset + 124 ..][0..11], "00000000000");
+  try tar.add("package/next", '0', "");
+  var parser = TarParser.init("package/");
+  var offset: usize = 0;
+  var count: usize = 0;
+  while (offset < tar.len) {
+    const result = parser.feed(tar.bytes[offset..tar.len]);
+    try std.testing.expect(result.consumed > 0);
+    offset += result.consumed;
+    switch (result.kind) {
+      .entry => |entry| {
+        try std.testing.expectEqualStrings(if (count == 0) "long/target" else "", entry.link_target);
+        try std.testing.expectEqual(@as(u64, if (count == 0) 3 else 0), entry.size);
+        count += 1;
+      },
+      .file_data => |data| try std.testing.expectEqualStrings("abc", data),
+      .need_more_data => {},
+      else => return error.UnexpectedParseResult,
+    }
+  }
+  try std.testing.expectEqual(@as(usize, 2), count);
+}
+
+test "PAX accepts paths beyond the legacy buffer and rejects oversized metadata" {
+  var parser = TarParser.init("package/");
+  var path: [300]u8 = @splat('a');
+  path[100] = '/';
+  path[200] = '/';
+  const record = try TestTar.paxRecord(&parser.pax_data, "path", &path);
+  parser.pax_len = record.len;
+  try parser.parsePax();
+  try std.testing.expectEqualStrings(&path, parser.pax_path[0..parser.pax_path_len]);
+
+  var tar = TestTar{};
+  try tar.add("PaxHeader/large", 'x', "");
+  @memcpy(tar.bytes[124..][0..11], "00000200001"); // 64 KiB + 1
+  parser = TarParser.init("package/");
+  const result = parser.feed(tar.bytes[0..512]);
+  try std.testing.expectEqual(error.UnsupportedFormat, result.kind.err);
+  for ([_]u8{ 'g', 'L', 'K' }) |kind| {
+    tar.bytes[156] = kind;
+    parser = TarParser.init("package/");
+    const unsupported = parser.feed(tar.bytes[0..512]);
+    try std.testing.expectEqual(error.UnsupportedFormat, unsupported.kind.err);
+  }
+}

--- a/src/pool.c
+++ b/src/pool.c
@@ -18,10 +18,9 @@ static inline size_t align_up_size(size_t value, size_t align) {
   return (value + mask) & ~mask;
 }
 
-static inline int pool_size_class_index(size_t need) {
-  for (int i = 0; i < ANT_POOL_SIZE_CLASS_COUNT; i++) {
+int pool_size_class_index(size_t need) {
+  for (int i = 0; i < ANT_POOL_SIZE_CLASS_COUNT; i++)
     if (need <= g_size_classes[i]) return i;
-  }
   return -1;
 }
 

--- a/src/silver/compiler.c
+++ b/src/silver/compiler.c
@@ -1821,15 +1821,16 @@ static bool is_self_append_inplace_safe_expr(sv_compiler_t *c, sv_ast_t *node) {
 }
 
 static void compile_template_items(sv_compiler_t *c, sv_ast_t *node, int start) {
-  compile_expr(c, node->args.items[start]);
-  if (!is_template_segment(node->args.items[start]))
-    emit_op(c, OP_TO_STRING);
-  for (int i = start + 1; i < node->args.count; i++) {
+  bool has_value = false;
+  for (int i = start; i < node->args.count; i++) {
     sv_ast_t *item = node->args.items[i];
+    if (is_template_segment(item) && item->len == 0) continue;
     compile_expr(c, item);
     if (!is_template_segment(item)) emit_op(c, OP_TO_STRING);
-    emit_op(c, OP_ADD);
+    if (has_value) emit_op(c, OP_ADD);
+    has_value = true;
   }
+  if (!has_value) emit_constant(c, js_mkstr_permanent(c->js, "", 0));
 }
 
 static void compile_self_append_rhs(
@@ -1878,6 +1879,19 @@ static inline bool is_ident_name(sv_ast_t *node, const char *name) {
     && memcmp(node->str, name, n) == 0;
 }
 
+static void mark_char_code_at_binding(sv_compiler_t *c, sv_ast_t *prop) {
+  if (!prop || prop->type != N_PROPERTY || (prop->flags & FN_COMPUTED)) return;
+  sv_ast_t *key = prop->left;
+  sv_ast_t *value = prop->right;
+  
+  if (!key || !key->str || !is_ident_str(key->str, key->len, "StringPrototypeCharCodeAt", 25)) return;
+  if (value && (value->type == N_ASSIGN_PAT || value->type == N_ASSIGN)) value = value->left;
+  if (!value || value->type != N_IDENT) return;
+  
+  int local = resolve_local(c, value->str, value->len);
+  if (local >= 0) c->locals[local].char_code_at_hint = true;
+}
+
 static void hoist_var_pattern(sv_compiler_t *c, sv_ast_t *pat) {
   if (!pat) return;
   switch (pat->type) {
@@ -1897,6 +1911,7 @@ static void hoist_var_pattern(sv_compiler_t *c, sv_ast_t *pat) {
           hoist_var_pattern(c, prop->right);
         else if (prop->type == N_REST || prop->type == N_SPREAD)
           hoist_var_pattern(c, prop->right);
+        mark_char_code_at_binding(c, prop);
       }
       break;
     case N_ASSIGN_PAT:
@@ -1993,6 +2008,7 @@ static void hoist_lexical_pattern(sv_compiler_t *c, sv_ast_t *pat,
           hoist_lexical_pattern(c, prop->right, is_const);
         else if (prop->type == N_REST || prop->type == N_SPREAD)
           hoist_lexical_pattern(c, prop->right, is_const);
+        mark_char_code_at_binding(c, prop);
       }
       break;
     default:
@@ -2604,8 +2620,33 @@ void compile_expr(sv_compiler_t *c, sv_ast_t *node) {
   }
 }
 
+static void compile_typeof_op(sv_compiler_t *c, sv_ast_t *node, int test_type);
+
+static bool compile_primitive_type_compare(sv_compiler_t *c, sv_ast_t *node) {
+  if (node->op != TOK_SEQ && node->op != TOK_SNE && node->op != TOK_EQ && node->op != TOK_NE) return false;
+  sv_ast_t *type = node->left, *name = node->right;
+  
+  if (name->type == N_TYPEOF) { type = node->right; name = node->left; }
+  if (type->type != N_TYPEOF || name->type != N_STRING) return false;
+  
+  static const struct { const char *name; uint8_t type; } primitives[] = {
+    {"string", kTypeString}, {"number", kTypeNumber}, {"boolean", kTypeBool},
+    {"undefined", kTypeUndefined}, {"symbol", kTypeSymbol}, {"bigint", kTypeBigInt},
+  };
+  
+  for (size_t i = 0; i < sizeof(primitives) / sizeof(primitives[0]); i++) {
+    if (!is_ident_str(name->str, name->len, primitives[i].name, (uint32_t)strlen(primitives[i].name))) continue;
+    compile_typeof_op(c, type, primitives[i].type);
+    if (node->op == TOK_SNE || node->op == TOK_NE) emit_op(c, OP_NOT);
+    return true;
+  }
+  
+  return false;
+}
+
 void compile_binary(sv_compiler_t *c, sv_ast_t *node) {
   uint8_t op = node->op;
+  if (compile_primitive_type_compare(c, node)) return;
 
   if (op == TOK_LAND) {
     compile_expr(c, node->left);
@@ -3063,14 +3104,14 @@ void compile_ternary(sv_compiler_t *c, sv_ast_t *node) {
   patch_jump(c, end_jump);
 }
 
-void compile_typeof(sv_compiler_t *c, sv_ast_t *node) {
+static void compile_typeof_op(sv_compiler_t *c, sv_ast_t *node, int test_type) {
   sv_ast_t *arg = node->right;
   if (arg->type == N_IDENT) {
     int local = resolve_local(c, arg->str, arg->len);
     if (local != -1) {
       uint8_t inferred = get_local_inferred_type(c, local);
       const char *known = typeof_name_for_type(inferred);
-      if (known && c->with_depth == 0 && c->locals[local].is_const) {
+      if (test_type < 0 && known && c->with_depth == 0 && c->locals[local].is_const) {
         emit_constant(c, js_mkstr_permanent(c->js, known, strlen(known)));
         return;
       }
@@ -3108,7 +3149,15 @@ void compile_typeof(sv_compiler_t *c, sv_ast_t *node) {
         arg->str, arg->len);
     }
   } else compile_expr(c, arg);
-  emit_op(c, OP_TYPEOF);
+  
+  if (test_type >= 0) {
+    emit_op(c, OP_IS_PRIMITIVE_TYPE);
+    emit(c, (uint8_t)test_type);
+  } else emit_op(c, OP_TYPEOF);
+}
+
+void compile_typeof(sv_compiler_t *c, sv_ast_t *node) {
+  compile_typeof_op(c, node, -1);
 }
 
 static bool sv_node_has_optional_base(sv_ast_t *n) {
@@ -3453,6 +3502,42 @@ static bool compile_call_array_includes_intrinsic(
   for (int i = 0; i < node->args.count; i++)
     compile_expr(c, node->args.items[i]);
   emit_op(c, OP_CALL_ARRAY_INCLUDES);
+  emit_u16(c, (uint16_t)node->args.count);
+  
+  return true;
+}
+
+static bool is_char_code_at_binding(sv_compiler_t *c, sv_ast_t *callee) {
+  if (!callee || callee->type != N_IDENT) return false;
+  for (sv_compiler_t *scope = c; scope; scope = scope->enclosing) {
+    int local = resolve_local(scope, callee->str, callee->len);
+    if (local >= 0) return scope->locals[local].char_code_at_hint;
+  }
+  return false;
+}
+
+static bool compile_call_char_code_at_intrinsic(
+  sv_compiler_t *c, sv_ast_t *node, bool has_spread
+) {
+  if (!node || has_spread || node->args.count > UINT16_MAX) return false;
+  sv_ast_t *callee = node->left;
+  
+  if (!callee) return false;
+  if (callee->type == N_MEMBER) {
+    if (member_call_needs_optional_base_guard(callee)) return false;
+    if ((callee->flags & 1) || !callee->right || !callee->right->str) return false;
+    if (is_ident_name(callee->left, "super")) return false;
+    if (!is_ident_str(callee->right->str, callee->right->len, "charCodeAt", 10)) return false;
+  } else if (!is_char_code_at_binding(c, callee)) return false;
+
+  sv_call_kind_t kind = compile_call_setup_non_optional(c, callee);
+  if (kind == SV_CALL_DIRECT) {
+    emit_op(c, OP_UNDEF);
+    emit_op(c, OP_SWAP);
+  }
+  
+  for (int i = 0; i < node->args.count; i++) compile_expr(c, node->args.items[i]);
+  emit_op(c, OP_CALL_CHAR_CODE_AT);
   emit_u16(c, (uint16_t)node->args.count);
   
   return true;
@@ -4125,6 +4210,9 @@ void compile_call(sv_compiler_t *c, sv_ast_t *node) {
     return;
 
   if (compile_call_array_includes_intrinsic(c, node, has_spread))
+    return;
+
+  if (compile_call_char_code_at_intrinsic(c, node, has_spread))
     return;
 
   if (compile_call_map_template_intrinsic(c, node, has_spread, false))

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -707,6 +707,35 @@ ant_value_t sv_string_builder_flush_slot(
   return out;
 }
 
+static bool sv_try_short_string_append(
+  ant_t *js, ant_value_t lhs, ant_value_t rhs, ant_value_t *result
+) {
+  ant_flat_string_t *left = sv_string_builder_flat_ptr(lhs);
+  ant_flat_string_t *right = sv_string_builder_flat_ptr(rhs);
+  
+  if (!left || !right) return false;
+  if (left->len > STR_BUILDER_TAIL_CAP || right->len > STR_BUILDER_TAIL_CAP - left->len) return false;
+  
+  if (left->len == 0) { *result = rhs; return true; }
+  if (right->len == 0) { *result = lhs; return true; }
+
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, lhs);
+  GC_ROOT_PIN(js, rhs);
+  size_t len = (size_t)(left->len + right->len);
+  *result = js_mkstr(js, NULL, len);
+  
+  if (!is_err(*result)) {
+    ant_flat_string_t *out = ant_str_flat_ptr(*result);
+    memcpy(out->bytes, left->bytes, (size_t)left->len);
+    memcpy(out->bytes + left->len, right->bytes, (size_t)right->len);
+    out->bytes[len] = '\0';
+    str_flat_init_meta(out, str_detect_ascii_bytes(out->bytes, len));
+  } GC_ROOT_RESTORE(js, mark);
+  
+  return true;
+}
+
 ant_value_t sv_string_builder_append_slot(
   sv_vm_t *vm, ant_t *js, sv_frame_t *frame,
   sv_func_t *func, uint16_t slot_idx, ant_value_t rhs
@@ -783,9 +812,17 @@ ant_value_t sv_string_builder_append_snapshot_slot(
   ant_value_t *slot = sv_frame_slot_ptr(frame, slot_idx);
   if (!slot) return js_mkerr(js, "invalid string builder slot");
 
-  // the snapshot path is only semantically required if the slot changed while
-  // evaluating the RHS. when it did not, delegate to the normal append path so
-  // active builders can keep appending in place instead of rebuilding.
+  // Snapshot-aware appends have already exposed the old immutable value.
+  // Keep short results flat instead of allocating and immediately reading a builder.
+  ant_value_t short_result;
+  if (sv_try_short_string_append(js, lhs, rhs, &short_result)) {
+    if (is_err(short_result)) return short_result;
+    *slot = short_result;
+    sv_record_slot_feedback(frame, func, slot_idx, *slot);
+    return js_mkundef();
+  }
+
+  // Reuse active builders when evaluating the RHS did not change the slot.
   if (*slot == lhs)
     return sv_string_builder_append_slot(vm, js, frame, func, slot_idx, rhs);
 
@@ -1681,6 +1718,10 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
 
   L_NOT:         { sv_op_not(vm, js);                   NEXT(1); }
   L_TYPEOF:      { sv_op_typeof(vm, js);                NEXT(1); }
+  L_IS_PRIMITIVE_TYPE: {
+    vm->stack[vm->sp - 1] = js_bool(vtype(vm->stack[vm->sp - 1]) == ip[1]);
+    NEXT(2);
+  }
   L_VOID:        { sv_op_void(vm);                      NEXT(1); }
   L_DELETE:      { VM_CHECK(sv_op_delete(vm, js));      NEXT(1); }
   L_DELETE_VAR:  { sv_op_delete_var(vm, js, func, ip);  NEXT(5); }
@@ -1974,6 +2015,20 @@ ant_value_t sv_execute_frame(sv_vm_t *vm, sv_func_t *func, ant_value_t this, ant
 
   L_CALL_SUPER: {
     VM_CHECK(sv_op_call_super(vm, js, frame, ip));
+    NEXT(3);
+  }
+
+  L_CALL_CHAR_CODE_AT: {
+    uint16_t call_argc = sv_get_u16(ip + 1);
+    ant_value_t *call_args = &vm->stack[vm->sp - call_argc];
+    ant_value_t target = vm->stack[vm->sp - call_argc - 1];
+    ant_value_t receiver = vm->stack[vm->sp - call_argc - 2];
+    frame->ip = ip;
+    ant_value_t result = sv_op_call_char_code_at(vm, js, target, receiver, call_args, call_argc);
+    sv_sync_frame_locals(vm, &frame, &func, &bp, &lp);
+    vm->sp -= call_argc + 2;
+    if (is_err(result)) { sv_err = result; goto sv_throw; }
+    vm->stack[vm->sp++] = result;
     NEXT(3);
   }
 

--- a/src/silver/glue.c
+++ b/src/silver/glue.c
@@ -683,6 +683,13 @@ ant_value_t jit_helper_call_is_proto(
   return sv_vm_call(vm, js, call_func, call_this, args, 1, NULL, false);
 }
 
+ant_value_t jit_helper_call_char_code_at(
+  sv_vm_t *vm, ant_t *js, ant_value_t func, 
+  ant_value_t receiver, ant_value_t *args, int argc
+) {
+  return sv_op_call_char_code_at(vm, js, func, receiver, args, argc);
+}
+
 ant_value_t jit_helper_call_array_includes(
   sv_vm_t *vm, ant_t *js,
   ant_value_t call_func, ant_value_t call_this,
@@ -1199,13 +1206,7 @@ void jit_helper_set_name(
 }
 
 ant_value_t jit_helper_get_length(sv_vm_t *vm, ant_t *js, ant_value_t obj) {
-  if (vtype(obj) == kTypeArray)
-    return tov((double)(uint32_t)js_arr_len(js, obj));
-
-  if (vtype(obj) == kTypeString)
-    return tov((double)str_utf16_len(js, obj));
-
-  return js_getprop_fallback(js, obj, "length");
+  return sv_get_length_value(js, obj);
 }
 
 ant_value_t jit_helper_get_length_inline(sv_vm_t *vm, ant_t *js, ant_value_t obj) {
@@ -1307,6 +1308,7 @@ ant_value_t jit_helper_object(
   sv_obj_site_cache_t *site
 ) {
   ant_value_t obj = mkobj(js, 0);
+  if (is_err(obj)) return obj;
   ant_object_t *ptr = js_obj_ptr(js_as_obj(obj));
   
   sv_obj_site_apply(js, func, site, ptr);
@@ -1314,6 +1316,36 @@ ant_value_t jit_helper_object(
   
   if (vtype(proto) == kTypeObject) js_set_proto_init(obj, proto);
   return obj;
+}
+
+ant_value_t jit_helper_object_template(sv_vm_t *vm, ant_t *js, sv_func_t *func, sv_obj_site_cache_t *site) {
+  if (vtype(site->literal_template) != kTypeObject) {
+    ant_value_t seed = jit_helper_object(vm, js, func, site);
+    if (is_err(seed)) return seed;
+    GC_ROOT_SAVE(mark, js);
+    GC_ROOT_PIN(js, seed);
+    
+    uint8_t *ip = func->code + site->bc_off + sv_op_size[OP_OBJECT];
+    for (uint16_t i = 0; i < site->key_count; i++) {
+      ant_value_t value;
+      int size = sv_literal_constant_at(func, ip, &value);
+      ANT_ASSERT(size != 0, "invalid constant literal template");
+      
+      sv_atom_t *key = &func->atoms[site->key_atoms[i]];
+      sv_define_slot(js, seed, value, key->str, key->len, i);
+      
+      if (js->thrown_exists) {
+        GC_ROOT_RESTORE(js, mark);
+        return mkval(kTypeError, 0);
+      }
+      ip += size + sv_op_size[OP_DEFINE_SLOT];
+    }
+    
+    site->literal_template = seed;
+    GC_ROOT_RESTORE(js, mark);
+  }
+  
+  return js_mkobj_from_template(js, site->literal_template);
 }
 
 ant_value_t jit_helper_regexp(

--- a/src/silver/ops/calls.h
+++ b/src/silver/ops/calls.h
@@ -65,6 +65,18 @@ static inline ant_value_t sv_op_call_stable_builtin(
     vm, js, call_func, call_this, args, argc, NULL, false);
 }
 
+static inline ant_value_t sv_op_call_char_code_at(
+  sv_vm_t *vm, ant_t *js, ant_value_t func, ant_value_t receiver,
+  ant_value_t *args, int argc
+) {
+  ant_value_t result;
+  if (!js_try_char_code_at(js, func, receiver, args, argc, &result))
+    return sv_vm_call(vm, js, func, receiver, args, argc, NULL, false);
+  js->new_target = js_mkundef();
+  sv_vm_maybe_checkpoint_microtasks(js);
+  return result;
+}
+
 static inline void sv_call_args_reset(sv_call_args_t *a, ant_value_t *args, int argc) {
   a->args = args;
   a->argc = argc;

--- a/src/silver/ops/literals.h
+++ b/src/silver/ops/literals.h
@@ -14,6 +14,33 @@ static inline void sv_op_const_i8(sv_vm_t *vm, uint8_t *ip) {
   vm->stack[vm->sp++] = tov((double)val);
 }
 
+static inline int sv_literal_constant_at(sv_func_t *func, const uint8_t *ip, ant_value_t *value) {
+  if (ip >= func->code + func->code_len) return 0;
+  int size = sv_op_size[*ip];
+  if (!size || ip + size > func->code + func->code_len) return 0;
+  
+  switch (*ip) {
+    case OP_CONST: case OP_CONST8: {
+      uint32_t index = *ip == OP_CONST ? sv_get_u32(ip + 1) : ip[1];
+      if (index >= (uint32_t)func->const_count) return 0;
+      *value = func->constants[index];
+      uint8_t type = vtype(*value);
+      if (type != kTypeString && type != kTypeNumber && type != kTypeBool &&
+          type != kTypeNull && type != kTypeUndefined && type != kTypeBigInt) return 0;
+      break;
+    }
+    
+    case OP_CONST_I8: *value = tov((double)(int8_t)ip[1]); break;
+    case OP_TRUE: *value = js_true; break;
+    case OP_FALSE: *value = js_false; break;
+    case OP_NULL: *value = js_mknull(); break;
+    case OP_UNDEF: *value = js_mkundef(); break;
+    default: return 0;
+  }
+  
+  return size;
+}
+
 static inline void sv_op_const8(sv_vm_t *vm, sv_func_t *func, uint8_t *ip) {
   uint8_t idx = sv_get_u8(ip + 1);
   vm->stack[vm->sp++] = func->constants[idx];

--- a/src/silver/ops/property.h
+++ b/src/silver/ops/property.h
@@ -1148,20 +1148,21 @@ static inline void sv_op_define_slot(
   sv_define_slot(js, obj, val, a->str, a->len, slot);
 }
 
+static inline ant_value_t sv_get_length_value(ant_t *js, ant_value_t obj) {
+  if (vtype(obj) == kTypeArray) return tov((double)(uint32_t)js_arr_len(js, obj));
+  if (vtype(obj) == kTypeString) return tov((double)str_utf16_len(js, obj));
+  
+  if (vtype(obj) == kTypeNull || vtype(obj) == kTypeUndefined) return js_mkerr_typed(
+    js, JS_ERR_TYPE, "Cannot read properties of %s (reading 'length')",
+    vtype(obj) == kTypeNull ? "null" : "undefined"
+  );
+  
+  return js_getprop_fallback(js, obj, "length");
+}
+
 static inline ant_value_t sv_op_get_length(sv_vm_t *vm, ant_t *js) {
   ant_value_t obj = vm->stack[--vm->sp];
-
-  if (vtype(obj) == kTypeArray) {
-    vm->stack[vm->sp++] = tov((double)(uint32_t)js_arr_len(js, obj));
-    return js_mkundef();
-  }
-  
-  if (vtype(obj) == kTypeString) {
-    vm->stack[vm->sp++] = tov((double)str_utf16_len(js, obj));
-    return js_mkundef();
-  }
-
-  ant_value_t res = js_getprop_fallback(js, obj, "length");
+  ant_value_t res = sv_get_length_value(js, obj);
   if (is_err(res)) return res;
   
   vm->stack[vm->sp++] = res;

--- a/src/silver/swarm.c
+++ b/src/silver/swarm.c
@@ -3,6 +3,7 @@
 #include "silver/engine.h"
 #include "silver/opcode.h"
 #include "ops/globals.h"
+#include "ops/literals.h"
 
 #include "internal.h"
 #include "debug.h"
@@ -52,6 +53,7 @@ static void jit_load_externals_once(sv_jit_ctx_t *jc) {
   LOAD_EXT(jit_helper_call);
   LOAD_EXT(jit_helper_call_method);
   LOAD_EXT(jit_helper_call_array_includes);
+  LOAD_EXT(jit_helper_call_char_code_at);
   LOAD_EXT(jit_helper_call_map_template);
   LOAD_EXT(jit_helper_map_template_fast);
   LOAD_EXT(jit_helper_map_numeric_pair_fast);
@@ -109,6 +111,7 @@ static void jit_load_externals_once(sv_jit_ctx_t *jc) {
   LOAD_EXT(jit_helper_put_private);
   LOAD_EXT(jit_helper_put_global);
   LOAD_EXT(jit_helper_object);
+  LOAD_EXT(jit_helper_object_template);
   LOAD_EXT(jit_helper_regexp);
   LOAD_EXT(jit_helper_define_slot);
   LOAD_EXT(jit_helper_array);
@@ -271,6 +274,24 @@ static MIR_label_t label_for_offset(MIR_context_t ctx, jit_label_map_t *lm,
   return lbl;
 }
 
+static int jit_constant_object_span(sv_func_t *func, sv_obj_site_cache_t *site, jit_label_map_t *lm) {
+  if (!site || !site->key_atoms || !site->key_count) return 0;
+  uint8_t *begin = func->code + site->bc_off + sv_op_size[OP_OBJECT];
+  uint8_t *ip = begin, *end = func->code + func->code_len;
+  for (uint16_t i = 0; i < site->key_count; i++) {
+    ant_value_t value;
+    int size = sv_literal_constant_at(func, ip, &value);
+    if (!size) return 0;
+    ip += size;
+    if (ip + sv_op_size[OP_DEFINE_SLOT] > end || *ip != OP_DEFINE_SLOT ||
+        sv_get_u32(ip + 1) != site->key_atoms[i] || sv_get_u16(ip + 5) != i) return 0;
+    ip += sv_op_size[OP_DEFINE_SLOT];
+  }
+  for (int i = 0; i < lm->count; i++)
+    if (lm->entries[i].bc_off >= begin - func->code && lm->entries[i].bc_off < ip - func->code) return 0;
+  return (int)(ip - begin);
+}
+
 static void label_record_sp(jit_label_map_t *lm, int bc_off, int sp) {
   for (int i = 0; i < lm->count; i++)
     if (lm->entries[i].bc_off != bc_off) continue;
@@ -396,7 +417,9 @@ static void mir_emit_get_length(
   MIR_label_t encode = MIR_new_label(ctx);
   MIR_label_t slow = MIR_new_label(ctx);
   MIR_label_t done = MIR_new_label(ctx);
-  MIR_label_t nonflat = builder_slot ? MIR_new_label(ctx) : slow;
+  MIR_label_t flat = MIR_new_label(ctx);
+  MIR_label_t nonflat = MIR_new_label(ctx);
+  MIR_label_t builder = builder_slot ? MIR_new_label(ctx) : slow;
 
   MIR_append_insn(ctx, fn,
     MIR_new_insn(ctx, MIR_URSH,
@@ -425,6 +448,7 @@ static void mir_emit_get_length(
       MIR_new_label_op(ctx, nonflat),
       MIR_new_reg_op(ctx, tag),
       MIR_new_uint_op(ctx, STR_HEAP_TAG_FLAT)));
+  MIR_append_insn(ctx, fn, flat);
   MIR_append_insn(ctx, fn,
     MIR_new_insn(ctx, MIR_MOV,
       MIR_new_reg_op(ctx, len),
@@ -462,8 +486,26 @@ static void mir_emit_get_length(
   MIR_append_insn(ctx, fn,
     MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, encode)));
 
+  MIR_append_insn(ctx, fn, nonflat);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, builder), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, STR_HEAP_TAG_ROPE)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+    MIR_new_reg_op(ctx, ptr), MIR_new_reg_op(ctx, ptr), MIR_new_uint_op(ctx, ~STR_HEAP_TAG_MASK)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, len),
+    MIR_new_mem_op(ctx, MIR_JSVAL, offsetof(ant_rope_heap_t, cached), ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_URSH,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, len), MIR_new_uint_op(ctx, NANBOX_TYPE_SHIFT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, JIT_STR_TAG)));
+  mir_emit_decode_ref(ctx, fn, ptr, len);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, ptr), MIR_new_uint_op(ctx, STR_HEAP_TAG_MASK)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, STR_HEAP_TAG_FLAT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, flat)));
+
   if (builder_slot) {
-    MIR_append_insn(ctx, fn, nonflat);
+    MIR_append_insn(ctx, fn, builder);
     MIR_append_insn(ctx, fn,
       MIR_new_insn(ctx, MIR_BNE,
         MIR_new_label_op(ctx, slow),
@@ -1147,6 +1189,122 @@ static MIR_reg_t mir_emit_exact_integer_guard(
       MIR_new_reg_op(ctx, roundtrip)));
 
   return integer;
+}
+
+static void mir_emit_primitive_type_test(
+  MIR_context_t ctx, MIR_item_t fn, MIR_reg_t value, MIR_reg_t scratch, uint8_t type
+) {
+  if (type == kTypeNumber) {
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ULE,
+      MIR_new_reg_op(ctx, scratch), MIR_new_reg_op(ctx, value), MIR_new_uint_op(ctx, NANBOX_PREFIX)));
+  } else {
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_URSH,
+      MIR_new_reg_op(ctx, scratch), MIR_new_reg_op(ctx, value), MIR_new_uint_op(ctx, NANBOX_TYPE_SHIFT)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_EQ,
+      MIR_new_reg_op(ctx, scratch), MIR_new_reg_op(ctx, scratch),
+      MIR_new_uint_op(ctx, (NANBOX_PREFIX >> NANBOX_TYPE_SHIFT) | type)));
+  }
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_OR,
+    MIR_new_reg_op(ctx, value), MIR_new_reg_op(ctx, scratch), MIR_new_uint_op(ctx, js_false)));
+}
+
+static void mir_emit_uncurried_char_code_at(
+  MIR_context_t ctx, MIR_item_t fn, MIR_reg_t target, MIR_reg_t args,
+  MIR_reg_t result, MIR_reg_t js, MIR_reg_t d_slot,
+  MIR_label_t slow, MIR_label_t done, int site
+) {
+  char name[48];
+  MIR_reg_t regs[5];
+  for (int i = 0; i < 5; i++) {
+    snprintf(name, sizeof(name), "char_%d_%d", site, i);
+    regs[i] = MIR_new_func_reg(ctx, fn->u.func, MIR_T_I64, name);
+  }
+  MIR_reg_t tag = regs[0], ptr = regs[1], value = regs[2], index = regs[3], len = regs[4];
+  snprintf(name, sizeof(name), "char_double_%d", site);
+  MIR_reg_t number = MIR_new_func_reg(ctx, fn->u.func, MIR_T_D, name);
+  MIR_label_t flat = MIR_new_label(ctx);
+
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_URSH,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, target), MIR_new_uint_op(ctx, NANBOX_TYPE_SHIFT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag),
+    MIR_new_uint_op(ctx, (NANBOX_PREFIX >> NANBOX_TYPE_SHIFT) | kTypeFunction)));
+  mir_emit_decode_ref(ctx, fn, ptr, target);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, tag), MIR_new_mem_op(ctx, MIR_T_U32, offsetof(sv_closure_t, call_flags), ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, tag),
+    MIR_new_uint_op(ctx, SV_CALL_IS_UNCURRY | SV_CALL_HAS_BOUND_ARGS)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, SV_CALL_IS_UNCURRY)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, value), MIR_new_mem_op(ctx, MIR_JSVAL, offsetof(sv_closure_t, bound_this), ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_URSH,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, value), MIR_new_uint_op(ctx, NANBOX_TYPE_SHIFT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag),
+    MIR_new_uint_op(ctx, (NANBOX_PREFIX >> NANBOX_TYPE_SHIFT) | kTypeBuiltin)));
+  mir_emit_decode_ref(ctx, fn, ptr, value);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, tag), MIR_new_mem_op(ctx, MIR_T_P, offsetof(ant_cfunc_meta_t, fn), ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, (uintptr_t)builtin_string_charCodeAt)));
+
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, value), MIR_new_mem_op(ctx, MIR_JSVAL, 0, args, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_URSH,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, value), MIR_new_uint_op(ctx, NANBOX_TYPE_SHIFT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, JIT_STR_TAG)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, value), MIR_new_uint_op(ctx, STR_HEAP_TAG_MASK)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BEQ,
+    MIR_new_label_op(ctx, flat), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, STR_HEAP_TAG_FLAT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, STR_HEAP_TAG_ROPE)));
+  mir_emit_decode_ref(ctx, fn, ptr, value);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+    MIR_new_reg_op(ctx, ptr), MIR_new_reg_op(ctx, ptr), MIR_new_uint_op(ctx, ~STR_HEAP_TAG_MASK)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, value), MIR_new_mem_op(ctx, MIR_JSVAL, offsetof(ant_rope_heap_t, cached), ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_URSH,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, value), MIR_new_uint_op(ctx, NANBOX_TYPE_SHIFT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, JIT_STR_TAG)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, value), MIR_new_uint_op(ctx, STR_HEAP_TAG_MASK)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, STR_HEAP_TAG_FLAT)));
+
+  MIR_append_insn(ctx, fn, flat);
+  mir_emit_decode_ref(ctx, fn, ptr, value);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, tag), MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_flat_string_t, meta), ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+    MIR_new_reg_op(ctx, tag), MIR_new_reg_op(ctx, tag), MIR_new_uint_op(ctx, STR_META_ASCII_MASK)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag),
+    MIR_new_uint_op(ctx, (uint64_t)STR_ASCII_YES << STR_META_ASCII_SHIFT)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, index), MIR_new_mem_op(ctx, MIR_JSVAL, sizeof(ant_value_t), args, 0, 1)));
+  MIR_reg_t integer = mir_emit_exact_integer_guard(
+    ctx, fn, index, 0, false, d_slot, 0, INT32_MAX, slow, site);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, len), MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_flat_string_t, len), ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_UBGE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, integer), MIR_new_reg_op(ctx, len)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, tag), MIR_new_mem_op(ctx, MIR_T_U32, offsetof(ant_t, vm_exec_depth), js, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BEQ,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tag), MIR_new_int_op(ctx, 0)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_reg_op(ctx, value), MIR_new_mem_op(ctx, MIR_T_U8, offsetof(ant_flat_string_t, bytes), ptr, integer, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_I2D,
+    MIR_new_reg_op(ctx, number), MIR_new_reg_op(ctx, value)));
+  mir_d_to_i64_non_nan(ctx, fn, result, number, d_slot);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_JSVAL, offsetof(ant_t, new_target), js, 0, 1), MIR_new_uint_op(ctx, js_mkundef())));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, done)));
 }
 
 static MIR_reg_t mir_emit_word32_guard(
@@ -2055,10 +2213,124 @@ static void mir_emit_string_concat_classify_side(
   MIR_append_insn(ctx, fn, done);
 }
 
+static void mir_emit_short_string_concat(
+  MIR_context_t ctx, MIR_item_t fn, MIR_reg_t r_js,
+  MIR_reg_t lp, MIR_reg_t rp, MIR_reg_t llen, MIR_reg_t rlen, MIR_reg_t len,
+  MIR_reg_t ldepth, MIR_reg_t rdepth, MIR_reg_t dst,
+  MIR_reg_t bucket, MIR_reg_t ptr, MIR_reg_t count, MIR_reg_t next,
+  MIR_reg_t tmp, MIR_reg_t current, MIR_reg_t index,
+  MIR_label_t slow
+) {
+  MIR_label_t bucket_ready = MIR_new_label(ctx);
+  MIR_label_t bump = MIR_new_label(ctx);
+  MIR_label_t allocated = MIR_new_label(ctx);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_OR,
+    MIR_new_reg_op(ctx, tmp), MIR_new_reg_op(ctx, ldepth), MIR_new_reg_op(ctx, rdepth)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, tmp), MIR_new_int_op(ctx, 0)));
+  for (int side = 0; side < 2; side++) {
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, tmp),
+      MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_flat_string_t, meta), side ? rp : lp, 0, 1)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_AND,
+      MIR_new_reg_op(ctx, tmp), MIR_new_reg_op(ctx, tmp), MIR_new_uint_op(ctx, STR_META_ASCII_MASK)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BNE, MIR_new_label_op(ctx, slow),
+      MIR_new_reg_op(ctx, tmp), MIR_new_uint_op(ctx, (uint64_t)STR_ASCII_YES << STR_META_ASCII_SHIFT)));
+  }
+
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, count),
+    MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_t, gc_pool_alloc), r_js, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ADD,
+    MIR_new_reg_op(ctx, count), MIR_new_reg_op(ctx, count), MIR_new_reg_op(ctx, len)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ADD,
+    MIR_new_reg_op(ctx, count), MIR_new_reg_op(ctx, count), MIR_new_uint_op(ctx, sizeof(ant_flat_string_t) + 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_UBGE, MIR_new_label_op(ctx, slow),
+    MIR_new_reg_op(ctx, count), MIR_new_uint_op(ctx, GC_POOL_PRESSURE_FLOOR)));
+
+  for (size_t max_len = 1; max_len < STR_SHORT_CONS_THRESHOLD; max_len++) {
+    size_t overhead = sizeof(ant_flat_string_t) + _Alignof(ant_flat_string_t);
+    int class_index = pool_size_class_index(overhead + max_len);
+    if (class_index < 0) continue;
+    if (max_len + 1 < STR_SHORT_CONS_THRESHOLD &&
+        class_index == pool_size_class_index(overhead + max_len + 1)) continue;
+    MIR_label_t next_class = MIR_new_label(ctx);
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_UBGT, MIR_new_label_op(ctx, next_class),
+      MIR_new_reg_op(ctx, len), MIR_new_uint_op(ctx, max_len)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, bucket),
+      MIR_new_reg_op(ctx, r_js), MIR_new_uint_op(ctx,
+        offsetof(ant_t, pool.string.classes) + (size_t)class_index * sizeof(ant_pool_bucket_t))));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, bucket_ready)));
+    MIR_append_insn(ctx, fn, next_class);
+  }
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, slow)));
+  MIR_append_insn(ctx, fn, bucket_ready);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, ptr),
+    MIR_new_mem_op(ctx, MIR_T_P, offsetof(ant_pool_bucket_t, slot_free), bucket, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BEQ,
+    MIR_new_label_op(ctx, bump), MIR_new_reg_op(ctx, ptr), MIR_new_int_op(ctx, 0)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, next),
+    MIR_new_mem_op(ctx, MIR_T_P, 0, ptr, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_T_P, offsetof(ant_pool_bucket_t, slot_free), bucket, 0, 1), MIR_new_reg_op(ctx, next)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, allocated)));
+  MIR_append_insn(ctx, fn, bump);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, current),
+    MIR_new_mem_op(ctx, MIR_T_P, offsetof(ant_pool_bucket_t, current), bucket, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_BEQ,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, current), MIR_new_int_op(ctx, 0)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, ptr),
+    MIR_new_mem_op(ctx, MIR_T_P, offsetof(ant_pool_bucket_t, cursor), bucket, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, next),
+    MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_pool_bucket_t, slot_stride), bucket, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ADD,
+    MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, ptr), MIR_new_reg_op(ctx, next)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, tmp),
+    MIR_new_mem_op(ctx, MIR_T_P, offsetof(ant_pool_bucket_t, end), bucket, 0, 1)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_UBGT,
+    MIR_new_label_op(ctx, slow), MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, tmp)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_T_P, offsetof(ant_pool_bucket_t, cursor), bucket, 0, 1), MIR_new_reg_op(ctx, next)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_SUB,
+    MIR_new_reg_op(ctx, tmp), MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, current)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_SUB,
+    MIR_new_reg_op(ctx, tmp), MIR_new_reg_op(ctx, tmp), MIR_new_uint_op(ctx, offsetof(ant_pool_block_t, data))));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_pool_block_t, used), current, 0, 1), MIR_new_reg_op(ctx, tmp)));
+  MIR_append_insn(ctx, fn, allocated);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_t, gc_pool_alloc), r_js, 0, 1), MIR_new_reg_op(ctx, count)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_flat_string_t, len), ptr, 0, 1), MIR_new_reg_op(ctx, len)));
+  mir_load_imm(ctx, fn, tmp, ((uint64_t)STR_ASCII_YES << STR_META_ASCII_SHIFT) | STR_UTF16_LEN_UNKNOWN);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_T_U64, offsetof(ant_flat_string_t, meta), ptr, 0, 1), MIR_new_reg_op(ctx, tmp)));
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ADD,
+    MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, ptr), MIR_new_uint_op(ctx, offsetof(ant_flat_string_t, bytes))));
+  for (int side = 0; side < 2; side++) {
+    MIR_label_t copy = MIR_new_label(ctx);
+    mir_load_imm(ctx, fn, index, 0);
+    MIR_append_insn(ctx, fn, copy);
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, tmp),
+      MIR_new_mem_op(ctx, MIR_T_U8, offsetof(ant_flat_string_t, bytes), side ? rp : lp, index, 1)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+      MIR_new_mem_op(ctx, MIR_T_U8, 0, next, index, 1), MIR_new_reg_op(ctx, tmp)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ADD,
+      MIR_new_reg_op(ctx, index), MIR_new_reg_op(ctx, index), MIR_new_int_op(ctx, 1)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_UBLT, MIR_new_label_op(ctx, copy),
+      MIR_new_reg_op(ctx, index), MIR_new_reg_op(ctx, side ? rlen : llen)));
+    MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_ADD,
+      MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, index)));
+  }
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_MOV,
+    MIR_new_mem_op(ctx, MIR_T_U8, 0, next, 0, 1), MIR_new_int_op(ctx, 0)));
+  mir_emit_cage_offset(ctx, fn, dst, ptr);
+  MIR_append_insn(ctx, fn, MIR_new_insn(ctx, MIR_OR,
+    MIR_new_reg_op(ctx, dst), MIR_new_reg_op(ctx, dst), MIR_new_uint_op(ctx, mkval(kTypeString, STR_HEAP_TAG_FLAT))));
+}
+
 static void mir_emit_string_concat_fastpath(
   MIR_context_t ctx, MIR_item_t fn,
   MIR_reg_t r_js, MIR_reg_t lhs, MIR_reg_t rhs, MIR_reg_t dst,
-  MIR_label_t slow, int owner_id, int bc_off
+  MIR_label_t slow, int owner_id, int bc_off, bool flat_only
 ) {
   char names[16][48];
   MIR_reg_t regs[16];
@@ -2086,6 +2358,7 @@ static void mir_emit_string_concat_fastpath(
   MIR_label_t depth_ready = MIR_new_label(ctx);
   MIR_label_t depth_done = MIR_new_label(ctx);
   MIR_label_t done = MIR_new_label(ctx);
+  MIR_label_t short_flat = MIR_new_label(ctx);
 
   MIR_append_insn(ctx, fn,
     MIR_new_insn(ctx, MIR_BEQ, MIR_new_label_op(ctx, return_right),
@@ -2097,133 +2370,144 @@ static void mir_emit_string_concat_fastpath(
     MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, len),
       MIR_new_reg_op(ctx, llen), MIR_new_reg_op(ctx, rlen)));
   MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_UBLT, MIR_new_label_op(ctx, slow),
+    MIR_new_insn(ctx, MIR_UBLT, MIR_new_label_op(ctx, short_flat),
       MIR_new_reg_op(ctx, len),
       MIR_new_int_op(ctx, STR_SHORT_CONS_THRESHOLD)));
 
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, count),
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_t, rope_gc.young_alloc), r_js, 0, 1)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_UBGE, MIR_new_label_op(ctx, slow),
-      MIR_new_reg_op(ctx, count),
-      MIR_new_uint_op(ctx, GC_ROPE_NURSERY_THRESHOLD)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, head),
-      MIR_new_mem_op(ctx, MIR_T_P,
-        (MIR_disp_t)offsetof(ant_t, rope_gc.young.head), r_js, 0, 1)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_BEQ, MIR_new_label_op(ctx, slow),
-      MIR_new_reg_op(ctx, head), MIR_new_int_op(ctx, 0)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, used),
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_pool_block_t, used), head, 0, 1)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, cap),
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_pool_block_t, cap), head, 0, 1)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, next),
-      MIR_new_reg_op(ctx, used), MIR_new_uint_op(ctx, sizeof(ant_rope_heap_t))));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_UBGT, MIR_new_label_op(ctx, slow),
-      MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, cap)));
+  if (flat_only) {
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, slow)));
+  } else {
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, count),
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_t, rope_gc.young_alloc), r_js, 0, 1)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_UBGE, MIR_new_label_op(ctx, slow),
+        MIR_new_reg_op(ctx, count),
+        MIR_new_uint_op(ctx, GC_ROPE_NURSERY_THRESHOLD)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, head),
+        MIR_new_mem_op(ctx, MIR_T_P,
+          (MIR_disp_t)offsetof(ant_t, rope_gc.young.head), r_js, 0, 1)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_BEQ, MIR_new_label_op(ctx, slow),
+        MIR_new_reg_op(ctx, head), MIR_new_int_op(ctx, 0)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, used),
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_pool_block_t, used), head, 0, 1)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, cap),
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_pool_block_t, cap), head, 0, 1)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, next),
+        MIR_new_reg_op(ctx, used), MIR_new_uint_op(ctx, sizeof(ant_rope_heap_t))));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_UBGT, MIR_new_label_op(ctx, slow),
+        MIR_new_reg_op(ctx, next), MIR_new_reg_op(ctx, cap)));
 
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, ptr),
-      MIR_new_reg_op(ctx, head),
-      MIR_new_uint_op(ctx, offsetof(ant_pool_block_t, data))));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, ptr),
-      MIR_new_reg_op(ctx, ptr), MIR_new_reg_op(ctx, used)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_pool_block_t, used), head, 0, 1),
-      MIR_new_reg_op(ctx, next)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, ptr),
+        MIR_new_reg_op(ctx, head),
+        MIR_new_uint_op(ctx, offsetof(ant_pool_block_t, data))));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, ptr),
+        MIR_new_reg_op(ctx, ptr), MIR_new_reg_op(ctx, used)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_pool_block_t, used), head, 0, 1),
+        MIR_new_reg_op(ctx, next)));
 
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, next),
-      MIR_new_reg_op(ctx, count), MIR_new_uint_op(ctx, sizeof(ant_rope_heap_t))));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_t, rope_gc.young_alloc), r_js, 0, 1),
-      MIR_new_reg_op(ctx, next)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, count),
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_t, gc_pool_alloc), r_js, 0, 1)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, count),
-      MIR_new_reg_op(ctx, count), MIR_new_uint_op(ctx, sizeof(ant_rope_heap_t))));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_t, gc_pool_alloc), r_js, 0, 1),
-      MIR_new_reg_op(ctx, count)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, next),
+        MIR_new_reg_op(ctx, count), MIR_new_uint_op(ctx, sizeof(ant_rope_heap_t))));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_t, rope_gc.young_alloc), r_js, 0, 1),
+        MIR_new_reg_op(ctx, next)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, count),
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_t, gc_pool_alloc), r_js, 0, 1)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, count),
+        MIR_new_reg_op(ctx, count), MIR_new_uint_op(ctx, sizeof(ant_rope_heap_t))));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_t, gc_pool_alloc), r_js, 0, 1),
+        MIR_new_reg_op(ctx, count)));
 
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_T_U64,
-        (MIR_disp_t)offsetof(ant_rope_heap_t, len), ptr, 0, 1),
-      MIR_new_reg_op(ctx, len)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, depth),
-      MIR_new_reg_op(ctx, ldepth)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_UBGE, MIR_new_label_op(ctx, depth_ready),
-      MIR_new_reg_op(ctx, ldepth), MIR_new_reg_op(ctx, rdepth)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, depth),
-      MIR_new_reg_op(ctx, rdepth)));
-  MIR_append_insn(ctx, fn, depth_ready);
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_BEQ, MIR_new_label_op(ctx, depth_done),
-      MIR_new_reg_op(ctx, depth),
-      MIR_new_uint_op(ctx, ANT_ROPE_DEPTH_SATURATED)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, depth),
-      MIR_new_reg_op(ctx, depth), MIR_new_int_op(ctx, 1)));
-  MIR_append_insn(ctx, fn, depth_done);
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_T_U16,
-        (MIR_disp_t)offsetof(ant_rope_heap_t, depth), ptr, 0, 1),
-      MIR_new_reg_op(ctx, depth)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_T_U16,
-        (MIR_disp_t)offsetof(ant_rope_heap_t, flags), ptr, 0, 1),
-      MIR_new_uint_op(ctx, ANT_ROPE_FLAG_YOUNG)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_T_U32,
-        (MIR_disp_t)offsetof(ant_rope_heap_t, mark_epoch), ptr, 0, 1),
-      MIR_new_int_op(ctx, 0)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_JSVAL,
-        (MIR_disp_t)offsetof(ant_rope_heap_t, left), ptr, 0, 1),
-      MIR_new_reg_op(ctx, lhs)));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_JSVAL,
-        (MIR_disp_t)offsetof(ant_rope_heap_t, right), ptr, 0, 1),
-      MIR_new_reg_op(ctx, rhs)));
-  mir_load_imm(ctx, fn, tmp, mkval(kTypeUndefined, 0));
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_MOV,
-      MIR_new_mem_op(ctx, MIR_JSVAL,
-        (MIR_disp_t)offsetof(ant_rope_heap_t, cached), ptr, 0, 1),
-      MIR_new_reg_op(ctx, tmp)));
-  mir_emit_cage_offset(ctx, fn, dst, ptr);
-  MIR_append_insn(ctx, fn,
-    MIR_new_insn(ctx, MIR_OR, MIR_new_reg_op(ctx, dst),
-      MIR_new_reg_op(ctx, dst),
-      MIR_new_uint_op(ctx, mkval(kTypeString, STR_HEAP_TAG_ROPE))));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_U64,
+          (MIR_disp_t)offsetof(ant_rope_heap_t, len), ptr, 0, 1),
+        MIR_new_reg_op(ctx, len)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, depth),
+        MIR_new_reg_op(ctx, ldepth)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_UBGE, MIR_new_label_op(ctx, depth_ready),
+        MIR_new_reg_op(ctx, ldepth), MIR_new_reg_op(ctx, rdepth)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV, MIR_new_reg_op(ctx, depth),
+        MIR_new_reg_op(ctx, rdepth)));
+    MIR_append_insn(ctx, fn, depth_ready);
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_BEQ, MIR_new_label_op(ctx, depth_done),
+        MIR_new_reg_op(ctx, depth),
+        MIR_new_uint_op(ctx, ANT_ROPE_DEPTH_SATURATED)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_ADD, MIR_new_reg_op(ctx, depth),
+        MIR_new_reg_op(ctx, depth), MIR_new_int_op(ctx, 1)));
+    MIR_append_insn(ctx, fn, depth_done);
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_U16,
+          (MIR_disp_t)offsetof(ant_rope_heap_t, depth), ptr, 0, 1),
+        MIR_new_reg_op(ctx, depth)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_U16,
+          (MIR_disp_t)offsetof(ant_rope_heap_t, flags), ptr, 0, 1),
+        MIR_new_uint_op(ctx, ANT_ROPE_FLAG_YOUNG)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_T_U32,
+          (MIR_disp_t)offsetof(ant_rope_heap_t, mark_epoch), ptr, 0, 1),
+        MIR_new_int_op(ctx, 0)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_JSVAL,
+          (MIR_disp_t)offsetof(ant_rope_heap_t, left), ptr, 0, 1),
+        MIR_new_reg_op(ctx, lhs)));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_JSVAL,
+          (MIR_disp_t)offsetof(ant_rope_heap_t, right), ptr, 0, 1),
+        MIR_new_reg_op(ctx, rhs)));
+    mir_load_imm(ctx, fn, tmp, mkval(kTypeUndefined, 0));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_MOV,
+        MIR_new_mem_op(ctx, MIR_JSVAL,
+          (MIR_disp_t)offsetof(ant_rope_heap_t, cached), ptr, 0, 1),
+        MIR_new_reg_op(ctx, tmp)));
+    mir_emit_cage_offset(ctx, fn, dst, ptr);
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_OR, MIR_new_reg_op(ctx, dst),
+        MIR_new_reg_op(ctx, dst),
+        MIR_new_uint_op(ctx, mkval(kTypeString, STR_HEAP_TAG_ROPE))));
+    MIR_append_insn(ctx, fn,
+      MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, done)));
+  }
+
+  MIR_append_insn(ctx, fn, short_flat);
+  mir_emit_short_string_concat(ctx, fn, r_js, lp, rp, llen, rlen, len,
+    ldepth, rdepth, dst, head, ptr, count, next, tmp, cap, used, slow);
   MIR_append_insn(ctx, fn,
     MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, done)));
 
@@ -3895,7 +4179,7 @@ static void jit_emit_inline_body(
           MIR_reg_t rd = inl_vs[isp++];
           inl_num[isp - 1] = 0;
           mir_emit_string_concat_fastpath(
-            ctx, jit_func, r_js, rl, rr, rd, slow, id, str_bc_off
+            ctx, jit_func, r_js, rl, rr, rd, slow, id, str_bc_off, false
           );
           break;
         }
@@ -4270,6 +4554,12 @@ static void jit_emit_inline_body(
         MIR_append_insn(ctx, jit_func, is_true);
         mir_load_imm(ctx, jit_func, rs, js_true);
         MIR_append_insn(ctx, jit_func, is_done);
+        break;
+      }
+
+      case OP_IS_PRIMITIVE_TYPE: {
+        INL_FLUSH_ALL();
+        mir_emit_primitive_type_test(ctx, jit_func, inl_vs[isp - 1], r_bool, ip[1]);
         break;
       }
 
@@ -5773,6 +6063,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
   MIR_item_t imp_call  = MIR_new_import(ctx, "jit_helper_call");
   MIR_item_t imp_call_method = MIR_new_import(ctx, "jit_helper_call_method");
   MIR_item_t imp_call_array_includes = MIR_new_import(ctx, "jit_helper_call_array_includes");
+  MIR_item_t imp_call_char_code_at = MIR_new_import(ctx, "jit_helper_call_char_code_at");
   MIR_item_t imp_call_map_template =
     MIR_new_import(ctx, "jit_helper_call_map_template");
   MIR_item_t imp_map_template_fast =
@@ -5836,6 +6127,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
   MIR_item_t imp_put_private = MIR_new_import(ctx, "jit_helper_put_private");
   MIR_item_t imp_put_global  = MIR_new_import(ctx, "jit_helper_put_global");
   MIR_item_t imp_object      = MIR_new_import(ctx, "jit_helper_object");
+  MIR_item_t imp_object_template = MIR_new_import(ctx, "jit_helper_object_template");
   MIR_item_t imp_regexp      = MIR_new_import(ctx, "jit_helper_regexp");
   MIR_item_t imp_define_slot = MIR_new_import(ctx, "jit_helper_define_slot");
   MIR_item_t imp_array       = MIR_new_import(ctx, "jit_helper_array");
@@ -7334,7 +7626,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
           MIR_label_t slow = MIR_new_label(ctx);
           MIR_label_t done = MIR_new_label(ctx);
           mir_emit_string_concat_fastpath(
-            ctx, jit_func, r_js, rl, rr, rd, slow, 0, bc_off
+            ctx, jit_func, r_js, rl, rr, rd, slow, 0, bc_off, false
           );
           MIR_append_insn(ctx, jit_func,
             MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, done)));
@@ -9781,6 +10073,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
       case OP_STR_ALC_SNAPSHOT: {
         uint16_t slot_idx = sv_get_u16(ip + 1);
         int pre_op_sp = vs.sp;
+        MIR_label_t flat_append_done = NULL;
         if ((int)slot_idx < param_count) {
           if (!writes_params) {
             MIR_label_t arg_in_range = MIR_new_label(ctx);
@@ -9823,6 +10116,23 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
           MIR_reg_t rhs = vstack_pop(&vs);
           MIR_reg_t lhs = vstack_pop(&vs);
 
+          if ((!captured_locals || !captured_locals[local_idx]) &&
+              (!known_type_locals || known_type_locals[local_idx] != SV_TI_NUM)) {
+            MIR_label_t flat_append_slow = MIR_new_label(ctx);
+            flat_append_done = MIR_new_label(ctx);
+            mir_emit_string_concat_fastpath(ctx, jit_func, r_js, lhs, rhs, r_tmp,
+              flat_append_slow, 0, bc_off, true);
+            MIR_append_insn(ctx, jit_func, MIR_new_insn(ctx, MIR_MOV,
+              MIR_new_reg_op(ctx, local_regs[local_idx]), MIR_new_reg_op(ctx, r_tmp)));
+            MIR_append_insn(ctx, jit_func, MIR_new_insn(ctx, MIR_MOV,
+              MIR_new_mem_op(ctx, MIR_JSVAL, (MIR_disp_t)((size_t)local_idx * sizeof(ant_value_t)), r_lbuf, 0, 1),
+              MIR_new_reg_op(ctx, r_tmp)));
+            mir_load_imm(ctx, jit_func, r_err_tmp, js_mkundef());
+            MIR_append_insn(ctx, jit_func,
+              MIR_new_insn(ctx, MIR_JMP, MIR_new_label_op(ctx, flat_append_done)));
+            MIR_append_insn(ctx, jit_func, flat_append_slow);
+          }
+
           MIR_append_insn(ctx, jit_func,
             MIR_new_insn(ctx, MIR_MOV,
               MIR_new_mem_op(ctx, MIR_T_I64,
@@ -9859,6 +10169,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
               MIR_new_reg_op(ctx, local_regs[local_idx]),
               MIR_new_mem_op(ctx, MIR_T_I64,
                 (MIR_disp_t)((int)local_idx * (int)sizeof(ant_value_t)), r_lbuf, 0, 1)));
+          if (flat_append_done) MIR_append_insn(ctx, jit_func, flat_append_done);
           if (known_func_locals) known_func_locals[local_idx] = NULL;
           if (known_type_locals && known_type_locals[local_idx] != SV_TI_NUM)
             known_type_locals[local_idx] = SV_TI_UNKNOWN;
@@ -10852,15 +11163,20 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
           func, (uint32_t)bc_off
         );
         MIR_reg_t dst = vstack_push(&vs);
+        int literal_span = jit_constant_object_span(func, site, &lm);
         MIR_append_insn(ctx, jit_func,
           MIR_new_call_insn(ctx, 7,
             MIR_new_ref_op(ctx, object_proto),
-            MIR_new_ref_op(ctx, imp_object),
+            MIR_new_ref_op(ctx, literal_span ? imp_object_template : imp_object),
             MIR_new_reg_op(ctx, dst),
             MIR_new_reg_op(ctx, r_vm),
             MIR_new_reg_op(ctx, r_js),
             MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)func),
             MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)site)));
+        if (literal_span) {
+          JIT_EMIT_THROW_IF_ERROR(dst);
+          ip += literal_span;
+        }
         break;
       }
 
@@ -11493,6 +11809,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
           builder_length,
           -1, bc_off
         );
+        JIT_EMIT_THROW_IF_ERROR(dst);
         break;
       }
 
@@ -12069,6 +12386,14 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         break;
       }
 
+      case OP_IS_PRIMITIVE_TYPE: {
+        vstack_ensure_boxed(&vs, vs.sp - 1, ctx, jit_func, r_d_slot);
+        mir_emit_primitive_type_test(ctx, jit_func, vstack_top(&vs), r_bool, ip[1]);
+        vstack_clear_value_info(&vs, vs.sp - 1);
+        if (vs.known_bool) vs.known_bool[vs.sp - 1] = 1;
+        break;
+      }
+
       case OP_VOID: {
         MIR_reg_t rs = vstack_top(&vs);
         mir_load_imm(ctx, jit_func, rs, mkval(kTypeUndefined, 0));
@@ -12159,6 +12484,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         break;
       }
 
+      case OP_CALL_CHAR_CODE_AT:
       case OP_CALL_ARRAY_INCLUDES: {
         vstack_flush_to_boxed(&vs, ctx, jit_func, r_d_slot);
         uint16_t call_argc = sv_get_u16(ip + 1);
@@ -12180,10 +12506,20 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         MIR_reg_t r_call_this = vstack_pop(&vs);
         MIR_reg_t r_call_res = vstack_push(&vs);
 
+        MIR_label_t char_done = NULL;
+        if (op == OP_CALL_CHAR_CODE_AT && call_argc >= 2) {
+          MIR_label_t char_slow = MIR_new_label(ctx);
+          char_done = MIR_new_label(ctx);
+          mir_emit_uncurried_char_code_at(ctx, jit_func, r_call_func, r_arg_arr,
+            r_call_res, r_js, r_d_slot, char_slow, char_done, mir_next_reg_site(&reg_site_n));
+          MIR_append_insn(ctx, jit_func, char_slow);
+        }
+
         MIR_append_insn(ctx, jit_func,
           MIR_new_call_insn(ctx, 9,
             MIR_new_ref_op(ctx, call_proto),
-            MIR_new_ref_op(ctx, imp_call_array_includes),
+            MIR_new_ref_op(ctx, op == OP_CALL_CHAR_CODE_AT
+              ? imp_call_char_code_at : imp_call_array_includes),
             MIR_new_reg_op(ctx, r_call_res),
             MIR_new_reg_op(ctx, r_vm),
             MIR_new_reg_op(ctx, r_js),
@@ -12203,6 +12539,7 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
         }
 
         JIT_EMIT_THROW_IF_ERROR(r_call_res);
+        if (char_done) MIR_append_insn(ctx, jit_func, char_done);
         break;
       }
 

--- a/src/silver/swarm.c
+++ b/src/silver/swarm.c
@@ -11173,10 +11173,8 @@ sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_clos
             MIR_new_reg_op(ctx, r_js),
             MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)func),
             MIR_new_uint_op(ctx, (uint64_t)(uintptr_t)site)));
-        if (literal_span) {
-          JIT_EMIT_THROW_IF_ERROR(dst);
-          ip += literal_span;
-        }
+        JIT_EMIT_THROW_IF_ERROR(dst);
+        if (literal_span) ip += literal_span;
         break;
       }
 

--- a/tests/test_assert_throws_constructor.cjs
+++ b/tests/test_assert_throws_constructor.cjs
@@ -11,4 +11,27 @@ assert.throws(() => { throw sentinel; }, function(error) { 'use strict'; return 
 assert.throws(() => assert.throws(() => { throw sentinel; }, () => false));
 assert.throws(() => assert.throws(() => { throw sentinel; }, () => { throw sentinel; }), error => error === sentinel);
 assert.throws(() => assert.throws(() => {}, Error));
+
+const errorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'Error');
+let errorReads = 0;
+function checkMatchingException() {
+  assert.throws(() => { throw 123; }, value => value === 123);
+  assert.throws(() => { throw new CustomError('test'); }, CustomError);
+}
+try {
+  globalThis.Error = function ReplacementError() {};
+  checkMatchingException();
+  assert.throws(
+    () => assert.throws(() => { throw sentinel; }, CustomError),
+    error => error.message.includes('instance')
+  );
+  Object.defineProperty(globalThis, 'Error', {
+    configurable: true,
+    get() { errorReads++; throw sentinel; }
+  });
+  checkMatchingException();
+} finally {
+  Object.defineProperty(globalThis, 'Error', errorDescriptor);
+}
+assert.strictEqual(errorReads, 0);
 console.log('assert.throws constructors and validation callbacks ok');

--- a/tests/test_assert_throws_constructor.cjs
+++ b/tests/test_assert_throws_constructor.cjs
@@ -1,0 +1,14 @@
+const assert = require('node:assert');
+assert.throws(() => { throw new TypeError('test'); }, TypeError);
+assert.throws(() => { throw new TypeError('test'); }, Error);
+class CustomError extends Error {}
+assert.throws(() => { throw new CustomError('test'); }, CustomError);
+assert.throws(() => assert.throws(() => { throw new RangeError('wrong'); }, TypeError));
+assert.throws(() => assert.throws(() => { throw new Error('wrong'); }, CustomError));
+const sentinel = new Error('sentinel');
+assert.throws(() => { throw sentinel; }, error => error === sentinel);
+assert.throws(() => { throw sentinel; }, function(error) { 'use strict'; return this !== undefined && error === sentinel; });
+assert.throws(() => assert.throws(() => { throw sentinel; }, () => false));
+assert.throws(() => assert.throws(() => { throw sentinel; }, () => { throw sentinel; }), error => error === sentinel);
+assert.throws(() => assert.throws(() => {}, Error));
+console.log('assert.throws constructors and validation callbacks ok');

--- a/tests/test_charcode_intrinsic.cjs
+++ b/tests/test_charcode_intrinsic.cjs
@@ -1,0 +1,122 @@
+const assert = require('node:assert');
+const original = String.prototype.charCodeAt;
+const captured = Function.prototype.call.bind(original);
+
+function makePaired(source) {
+  const { StringPrototypeCharCodeAt: read } = source;
+  return function paired(s, i) { return read(s, i) + read(s, i); };
+}
+const paired = makePaired({StringPrototypeCharCodeAt: captured});
+const pairedReplacement = makePaired({StringPrototypeCharCodeAt: () => 7});
+const pairedSlice = makePaired({StringPrototypeCharCodeAt: Function.prototype.call.bind(String.prototype.slice)});
+for (let i = 0; i < 30000; i++) {
+  assert.strictEqual(paired('abc', 1), 196);
+  assert.strictEqual(pairedReplacement('abc', 1), 14);
+  assert.strictEqual(pairedSlice('abc', 1), 'bcbc');
+}
+assert.strictEqual(paired('é😀', 1), 0xd83d * 2);
+assert.ok(Number.isNaN(paired('abc', Infinity)));
+
+function makeExtra(source) {
+  const { StringPrototypeCharCodeAt: read } = source;
+  return function extra(s, i, effect) { return read(s, i, effect()); };
+}
+const extra = makeExtra({StringPrototypeCharCodeAt: captured});
+const extraFallback = makeExtra({StringPrototypeCharCodeAt: (s, i, value) => s + i + value});
+let extraCalls = 0;
+function extraEffect() { extraCalls++; return '!'; }
+for (let i = 0; i < 1000; i++) assert.strictEqual(extra('abc', 1, extraEffect), 98);
+assert.strictEqual(extraFallback('abc', 1, extraEffect), 'abc1!');
+assert.strictEqual(extraCalls, 1001);
+const extraError = new Error('extra argument');
+assert.throws(() => extra('abc', 1, () => { throw extraError; }), e => e === extraError);
+
+function direct(s, i) { const value = s.charCodeAt(i); return value; }
+function aliases(source) {
+  let { StringPrototypeCharCodeAt: read } = source;
+  function scan(s, i) { const value = read(s, i); return value; }
+  for (let i = 0; i < 30000; i++) assert.strictEqual(scan('abc', i % 3), 97 + i % 3);
+  check(scan);
+  read = (s, i) => s.length + i;
+  assert.strictEqual(scan('abc', 1), 4);
+  function shadow(read) { const value = read('abc', 1); return value; }
+  assert.strictEqual(shadow(() => 123), 123);
+}
+function check(fn) {
+  for (const [i, expected] of [[0, 97], [-0.5, 97], [1.9, 98], [NaN, 97], [undefined, 97], ['1', 98]])
+    assert.strictEqual(fn('abc', i), expected);
+  for (const i of [-1, 3, Infinity, -Infinity, 1e100, -1e100])
+    assert.ok(Number.isNaN(fn('abc', i)));
+  assert.ok(Number.isNaN(fn('', 0)));
+  assert.strictEqual(fn('é😀', 0), 233);
+  assert.strictEqual(fn('é😀', 1), 0xd83d);
+  assert.strictEqual(fn('é😀', 2), 0xde00);
+  assert.strictEqual(fn('x'.repeat(4096) + 'z', 4096), 122);
+  // Exercise first reads and cached flat storage without assuming rope layout.
+  for (const suffix of ['z', 'é', '😀']) {
+    const rope = 'x'.repeat(4096) + suffix;
+    const expected = suffix === 'z' ? 122 : suffix === 'é' ? 233 : 0xd83d;
+    for (let i = 0; i < 1000; i++) {
+      assert.strictEqual(fn(rope, 4096), expected);
+      assert.strictEqual(fn(rope, 4095), 120);
+      assert.ok(Number.isNaN(fn(rope, rope.length)));
+    }
+    if (suffix === '😀') assert.strictEqual(fn(rope, 4097), 0xde00);
+  }
+  const error = new Error('index conversion');
+  assert.throws(() => fn('abc', { valueOf() { throw error; } }), e => e === error);
+}
+for (let i = 0; i < 30000; i++) assert.strictEqual(direct('abc', i % 3), 97 + i % 3);
+check(direct);
+aliases({ StringPrototypeCharCodeAt: captured });
+function uncurriedVariants(source) {
+  const { StringPrototypeCharCodeAt: read } = source;
+  function scan(s, i) { const result = read(s, i); return result; }
+  for (let i = 0; i < 30000; i++) assert.strictEqual(scan('abc', 1), 98);
+  check(scan);
+}
+uncurriedVariants({ StringPrototypeCharCodeAt: captured.bind(null) });
+function mismatchedNative() {
+  const { StringPrototypeCharCodeAt: read } = {
+    StringPrototypeCharCodeAt: Function.prototype.call.bind(String.prototype.slice)
+  };
+  for (let i = 0; i < 30000; i++) assert.strictEqual(read('abc', 1), 'bc');
+}
+mismatchedNative();
+function preappliedUncurried() {
+  const { StringPrototypeCharCodeAt: read } = {
+    StringPrototypeCharCodeAt: captured.bind(null, 'abc')
+  };
+  for (let i = 0; i < 30000; i++) assert.strictEqual(read(1, 0), 98);
+}
+preappliedUncurried();
+
+let effects = 0;
+try {
+  String.prototype.charCodeAt = i => { effects++; return 1000 + i; };
+  assert.strictEqual(direct('abc', 2), 1002);
+  assert.strictEqual(captured('abc', 2), 99);
+  assert.strictEqual(effects, 1);
+} finally { String.prototype.charCodeAt = original; }
+const receiver = {
+  get charCodeAt() { effects++; return original; },
+  toString() { return 'xyz'; }
+};
+assert.strictEqual(direct(receiver, 1), 121);
+assert.strictEqual(effects, 2);
+const bound = { charCodeAt: original.bind('abc') };
+const prebound = { charCodeAt: original.bind('abc', 1) };
+for (let i = 0; i < 30000; i++) {
+  assert.strictEqual(direct(bound, 2), 99);
+  assert.strictEqual(direct(prebound, 2), 98);
+}
+const proxy = new Proxy(original.bind('abc'), { apply(target, self, args) { return 1234; } });
+assert.strictEqual(direct({ charCodeAt: proxy }, 0), 1234);
+function absent() { const result = 'abc'.charCodeAt(); return result; }
+for (let i = 0; i < 30000; i++) assert.strictEqual(absent(), 97);
+assert.strictEqual(null?.charCodeAt(0), undefined);
+assert.strictEqual('abc'.charCodeAt?.(1), 98);
+assert.strictEqual('abc'.charCodeAt(...[2]), 99);
+const sentinel = new Error('receiver conversion');
+assert.throws(() => direct({ charCodeAt: original, toString() { throw sentinel; } }, 0), e => e === sentinel);
+console.log('charCodeAt intrinsic: direct, aliases, guards and fallbacks ok');

--- a/tests/test_jit_cached_rope_length.cjs
+++ b/tests/test_jit_cached_rope_length.cjs
@@ -1,0 +1,38 @@
+const assert = require('node:assert');
+const charCodeAt = Function.prototype.call.bind(String.prototype.charCodeAt);
+function length(value) { return value.length; }
+function concat(a, b) { return a + b; }
+assert.throws(() => length(null), TypeError);
+assert.throws(() => length(undefined), TypeError);
+const cases = [
+  ['abcdefghijklmnop', 'qrstuvwxyz', 26],
+  ['abcdefghijklmnop', '😀é\ud800', 20],
+  ['😀'.repeat(20), 'z'.repeat(20), 60],
+  ['a'.repeat(200), '\0'.repeat(200), 400],
+];
+const keep = [];
+for (let round = 0; round < 30000; round++) {
+  const [a, b, size] = cases[round & 3];
+  const value = concat(a, b);
+  // Exercise uncached length, a flattening consumer, then repeated cached reads.
+  assert.strictEqual(length(value), size);
+  assert.strictEqual(charCodeAt(value, 0), charCodeAt(a, 0));
+  for (let i = 0; i < 8; i++) assert.strictEqual(length(value), size);
+  if (round % 100 === 0) keep.push([value, size]);
+}
+for (const [value, size] of keep) assert.strictEqual(length(value), size);
+assert.strictEqual(length([1, 2, 3]), 3);
+assert.strictEqual(length(new String('😀')), 2);
+let reads = 0;
+assert.strictEqual(length({get length() { reads++; return 42; }}), 42);
+assert.strictEqual(reads, 1);
+assert.throws(() => length(null), TypeError);
+assert.throws(() => length(undefined), TypeError);
+const sentinel = {};
+let after = false;
+try {
+  length({get length() { throw sentinel; }});
+  after = true;
+} catch (error) { assert.strictEqual(error, sentinel); }
+assert.strictEqual(after, false);
+console.log('cached rope ASCII/UTF-16 length, survivors and property fallback ok');

--- a/tests/test_jit_constant_object_template.cjs
+++ b/tests/test_jit_constant_object_template.cjs
@@ -1,0 +1,43 @@
+const assert = require('node:assert');
+function make() { return { root: '', dir: '', base: '', ext: '', name: '' }; }
+function values() { return { a: 1, b: true, c: null, d: 'é😀', e: 12345678901234567890n }; }
+for (let i = 0; i < 50000; i++) {
+  const a = make(), b = make();
+  assert.notStrictEqual(a, b);
+  a.root = 'changed';
+  delete a.name;
+  a.extra = i;
+  assert.deepStrictEqual(b, { root: '', dir: '', base: '', ext: '', name: '' });
+  if (i % 100 === 0) {
+    Object.freeze(a);
+    assert.strictEqual(Object.isFrozen(make()), false);
+    assert.deepStrictEqual(values(), { a: 1, b: true, c: null, d: 'é😀', e: 12345678901234567890n });
+  }
+}
+assert.deepStrictEqual(Object.keys(make()), ['root', 'dir', 'base', 'ext', 'name']);
+assert.deepStrictEqual(Object.getOwnPropertyDescriptor(make(), 'name'), {
+  value: '', writable: true, enumerable: true, configurable: true
+});
+let effects = 0;
+function dynamic() { return { a: ++effects, [String(effects)]: { nested: effects }, get b() { return effects; } }; }
+for (let i = 1; i <= 1000; i++) {
+  const result = dynamic();
+  assert.strictEqual(result.a, i);
+  assert.strictEqual(result.b, i);
+  assert.strictEqual(result[String(i)].nested, i);
+}
+function nested() { return { child: {} }; }
+assert.notStrictEqual(nested().child, nested().child);
+function special() { return { __proto__: null, a: 1 }; }
+assert.strictEqual(Object.getPrototypeOf(special()), null);
+const original = Object.getOwnPropertyDescriptor(Object.prototype, 'root');
+let setters = 0;
+try {
+  Object.defineProperty(Object.prototype, 'root', { configurable: true, set() { setters++; } });
+  for (let i = 0; i < 1000; i++) assert.strictEqual(make().root, '');
+  assert.strictEqual(setters, 0);
+} finally {
+  if (original) Object.defineProperty(Object.prototype, 'root', original);
+  else delete Object.prototype.root;
+}
+console.log('constant literal identity, mutation, GC churn, descriptors and fallback effects ok');

--- a/tests/test_jit_short_string_concat.cjs
+++ b/tests/test_jit_short_string_concat.cjs
@@ -1,0 +1,32 @@
+const assert = require('node:assert');
+function concat(left, right) { return left + right; }
+const cases = [];
+for (let left = 0; left <= 15; left++) {
+  for (let right = 0; right <= 15; right++) {
+    cases.push(['a'.repeat(left), 'b'.repeat(right)]);
+  }
+}
+cases.push(['a\0', 'b'], ['é', '😀'], ['\ud83d', '\ude00'], ['a', '\ud800']);
+for (const size of [31, 32, 39, 40, 47, 48, 55, 56, 62, 63, 64, 65, 80]) {
+  cases.push(['a'.repeat(size - 1), 'b'], ['a', 'b'.repeat(size - 1)]);
+}
+const expected = cases.map(([a, b]) => [a, b].join(''));
+const survivors = [];
+for (let round = 0; round < 1500; round++) {
+  for (let i = 0; i < cases.length; i++) {
+    const result = concat(cases[i][0], cases[i][1]);
+    assert.strictEqual(result, expected[i]);
+    assert.strictEqual(result.length, expected[i].length);
+    if (round % 100 === 0) survivors.push([result, i]);
+  }
+}
+for (const [value, i] of survivors) assert.strictEqual(value, expected[i]);
+assert.strictEqual(concat(3, 4), 7);
+assert.strictEqual(concat('a', 4), 'a4');
+const events = [];
+const left = { [Symbol.toPrimitive](hint) { events.push('left ' + hint); return 'a'; } };
+const right = { [Symbol.toPrimitive](hint) { events.push('right ' + hint); return 'b'; } };
+assert.strictEqual(concat(left, right), 'ab');
+assert.deepStrictEqual(events, ['left default', 'right default']);
+assert.throws(() => concat('a', Symbol()), TypeError);
+console.log('JIT short concat size classes, GC survivors, Unicode and coercion ok');

--- a/tests/test_native_uncurry.cjs
+++ b/tests/test_native_uncurry.cjs
@@ -1,0 +1,38 @@
+const assert = require('node:assert');
+const uncurry = target => Function.prototype.call.bind(target);
+const slice = uncurry(String.prototype.slice);
+const join = uncurry(Array.prototype.join);
+const push = uncurry(Array.prototype.push);
+const tag = uncurry(Object.prototype.toString);
+const has = uncurry(Object.prototype.hasOwnProperty);
+const apply = uncurry(Function.prototype.call);
+for (let i = 0; i < 30000; i++) {
+  assert.strictEqual(slice('abc', 1, 2), 'b');
+  assert.strictEqual(join([1, 2], ':'), '1:2');
+  assert.strictEqual(tag(null), '[object Null]');
+  assert.strictEqual(tag(), '[object Undefined]');
+  assert.strictEqual(has({ a: 1 }, 'a'), true);
+  assert.strictEqual(apply(function (n) { 'use strict'; return this === null ? n : -1; }, null, 42), 42);
+}
+assert.strictEqual(slice.bind(null, 'abc')(1), 'bc');
+assert.strictEqual(slice.bind(null, 'abc', 1)(), 'bc');
+const many = Array.from({ length: 40 }, (_, i) => i);
+const target = [];
+assert.strictEqual(push.bind(null, target, ...many)(40), 41);
+assert.deepStrictEqual(target, [...many, 40]);
+let effects = 0;
+const converted = { toString() { effects++; return 'abc'; } };
+assert.strictEqual(slice(converted, 1), 'bc');
+assert.strictEqual(effects, 1);
+const sentinel = new Error('receiver');
+assert.throws(() => slice({ toString() { throw sentinel; } }), e => e === sentinel);
+assert.throws(() => uncurry(String.prototype.repeat)('x', -1));
+const custom = uncurry(function () { 'use strict'; return this; });
+assert.strictEqual(custom(null), null);
+assert.strictEqual(custom(), undefined);
+const original = String.prototype.slice;
+try {
+  String.prototype.slice = () => 'changed';
+  assert.strictEqual(slice('abc', 1), 'bc');
+} finally { String.prototype.slice = original; }
+console.log('native uncurry receivers, bound arguments, callbacks and exceptions ok');

--- a/tests/test_path_windows_reserved_names.cjs
+++ b/tests/test_path_windows_reserved_names.cjs
@@ -1,0 +1,10 @@
+const assert = require('node:assert');
+const { win32 } = require('node:path');
+
+// Node upstream b0a4f162: a missing colon must not truncate the name
+// before checking whether it is a Windows reserved device.
+for (const name of ['CONx', 'NULl', 'NULs', 'LPT1x', 'PRNzzz', 'CON']) {
+  assert.strictEqual(win32.normalize(name), name);
+}
+assert.strictEqual(win32.normalize('CON:'), '.\\CON:.');
+console.log('Windows reserved-name normalization ok');

--- a/tests/test_primitive_type_compare.cjs
+++ b/tests/test_primitive_type_compare.cjs
@@ -1,0 +1,30 @@
+const assert = require('node:assert');
+function checks(value) {
+  return [typeof value === 'string', typeof value == 'number',
+    typeof value === 'boolean', 'undefined' === typeof value,
+    'symbol' == typeof value, typeof value === 'bigint',
+    typeof value !== 'string', 'number' != typeof value];
+}
+const names = ['string', 'number', 'boolean', 'undefined', 'symbol', 'bigint'];
+const values = ['abc', '', 'x'.repeat(4096) + 'y', 0, -0, NaN, Infinity, -Infinity,
+  1.5, true, false, undefined, null, {}, [], function () {}, Symbol('x'), 42n,
+  new String('abc'), new Number(1), new Boolean(false),
+  new Proxy({}, {}), new Proxy(function () {}, {})];
+for (let i = 0; i < 30000; i++) {
+  const value = values[i % values.length];
+  const actualType = typeof value;
+  const expected = names.map(name => actualType === name);
+  expected.push(actualType !== names[0], actualType !== names[1]);
+  assert.deepStrictEqual(checks(value), expected);
+}
+assert.strictEqual(typeof antMissingTypeTestBinding === 'undefined', true);
+assert.throws(() => { const result = typeof lexical === 'string'; let lexical; return result; }, ReferenceError);
+let reads = 0;
+const holder = { get value() { reads++; return 'abc'; } };
+assert.strictEqual(typeof holder.value === 'string', true);
+assert.strictEqual(reads, 1);
+const sentinel = new Error('getter');
+assert.throws(() => typeof ({ get value() { throw sentinel; } }).value === 'string', e => e === sentinel);
+assert.strictEqual(eval('typeof antMissingEvalTypeTestBinding === "undefined"'), true);
+assert.strictEqual(Function('object', 'with (object) { return typeof value === "string"; }')({ value: 'abc' }), true);
+console.log('primitive typeof comparisons, NaN, boxed values, proxies, TDZ and effects ok');

--- a/tests/test_primordials.cjs
+++ b/tests/test_primordials.cjs
@@ -8,11 +8,12 @@ const saved = {
   isArray: Array.isArray,
   stringify: JSON.stringify,
   String,
+  Error,
   TypeError,
 };
 let p, normalized;
 try {
-  const poisoned = () => { throw new Error('mutable builtin used'); };
+  const poisoned = () => { throw new saved.Error('mutable builtin used'); };
   delete String.prototype.slice;
   String.prototype.charCodeAt = poisoned;
   String.prototype.toLowerCase = poisoned;
@@ -21,11 +22,13 @@ try {
   Array.isArray = poisoned;
   JSON.stringify = poisoned;
   globalThis.String = poisoned;
+  globalThis.Error = poisoned;
   globalThis.TypeError = poisoned;
   p = require('ant:internal/primordials');
   normalized = require('node:path').normalize('/a/../b');
 } finally {
   globalThis.String = saved.String;
+  globalThis.Error = saved.Error;
   globalThis.TypeError = saved.TypeError;
   String.prototype.slice = saved.slice;
   String.prototype.charCodeAt = saved.charCodeAt;
@@ -40,10 +43,12 @@ assert.strictEqual(normalized, '/b');
 assert.strictEqual(Object.getPrototypeOf(p), null);
 assert.strictEqual(Object.isFrozen(p), true);
 assert.strictEqual(require('ant:internal/primordials'), p);
-assert.strictEqual(Object.keys(p).length, 19);
+assert.strictEqual(Object.keys(p).length, 20);
 assert.strictEqual(p.ArrayIsArray([]), true);
 assert.strictEqual(p.JSONStringify({ x: 1 }), '{"x":1}');
 assert.strictEqual(p.String(123), '123');
+assert.strictEqual(p.Error, saved.Error);
+assert.strictEqual(new p.Error('captured').message, 'captured');
 assert.strictEqual(p.TypeError, saved.TypeError);
 assert.strictEqual(p.StringPrototypeSlice('abcd', 1, 3), 'bc');
 assert.strictEqual(p.StringPrototypeCharCodeAt('abc', 1), 98);

--- a/tests/test_process_cwd_cache.cjs
+++ b/tests/test_process_cwd_cache.cjs
@@ -1,0 +1,36 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const previous = process.cwd();
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ant-cwd-cache-'));
+const child = path.join(directory, 'child');
+fs.mkdirSync(child);
+try {
+  process.chdir(directory);
+  const current = fs.realpathSync(directory);
+  for (let i = 0; i < 30000; i++) assert.strictEqual(process.cwd(), current);
+  assert.strictEqual(path.resolve('file'), path.join(current, 'file'));
+  assert.throws(() => process.chdir(path.join(directory, 'missing')));
+  assert.strictEqual(process.cwd(), current);
+  for (let i = 0; i < 100000; i++) String(i).repeat(20);
+  assert.strictEqual(process.cwd(), current);
+  process.chdir('child');
+  assert.strictEqual(process.cwd(), fs.realpathSync(child));
+  process.chdir('..');
+  assert.strictEqual(process.cwd(), current);
+  if (process.platform !== 'win32') {
+    process.chdir(child);
+    const cached = process.cwd();
+    fs.rmdirSync(child);
+    // Node retains a successful cached value until a successful chdir.
+    assert.strictEqual(process.cwd(), cached);
+    assert.strictEqual(path.resolve('file'), path.join(cached, 'file'));
+  }
+} finally {
+  process.chdir(previous);
+  if (fs.existsSync(child)) fs.rmdirSync(child);
+  fs.rmdirSync(directory);
+}
+assert.strictEqual(process.cwd(), previous);
+console.log('cwd cache, invalidation, allocation churn and deleted cached cwd ok');

--- a/tests/test_reflect_set_frozen.cjs
+++ b/tests/test_reflect_set_frozen.cjs
@@ -1,0 +1,22 @@
+const assert = require('node:assert');
+for (const object of [{ x: 1 }, Object.assign(Object.create(null), { x: 1 }), Object.assign(function() {}, { x: 1 })]) {
+  Object.freeze(object);
+  assert.strictEqual(Reflect.set(object, 'x', 2), false);
+  assert.strictEqual(Reflect.set(object, 'x', 1), false);
+  assert.strictEqual(object.x, 1);
+}
+const readOnly = Object.defineProperty({}, 'x', { value: 1, configurable: true });
+assert.strictEqual(Reflect.set(readOnly, 'x', 2), false);
+assert.strictEqual(readOnly.x, 1);
+let stored;
+const accessor = Object.freeze({ set x(value) { stored = value; }, get y() { return 1; } });
+assert.strictEqual(Reflect.set(accessor, 'x', 2), true);
+assert.strictEqual(stored, 2);
+assert.strictEqual(Reflect.set(accessor, 'y', 2), false);
+const sentinel = new Error('setter');
+const throwing = Object.freeze({ set x(value) { throw sentinel; } });
+assert.throws(() => Reflect.set(throwing, 'x', 2), error => error === sentinel);
+const writable = { x: 1 };
+assert.strictEqual(Reflect.set(writable, 'x', 2), true);
+assert.strictEqual(writable.x, 2);
+console.log('Reflect.set frozen and readonly own properties ok');

--- a/tests/test_string_short_append.cjs
+++ b/tests/test_string_short_append.cjs
@@ -1,0 +1,27 @@
+const assert = require('node:assert');
+function collect(piece, count) {
+  let value = '';
+  const snapshots = [];
+  for (let i = 0; i < count; i++) {
+    snapshots.push(value);
+    value += piece;
+  }
+  for (let i = 0; i < count; i++) assert.strictEqual(snapshots[i], piece.repeat(i));
+  assert.strictEqual(value, piece.repeat(count));
+  return value;
+}
+for (let i = 0; i < 30000; i++) collect(i & 1 ? 'abc' : 'é😀', 3);
+for (const piece of ['x', 'é😀', '\ud800', '\0z']) collect(piece, 400);
+for (const length of [12, 13, 15, 16, 30, 31, 32, 33, 255, 256, 257, 1024]) collect('x'.repeat(length), 4);
+function reentrant() {
+  let value = 'left';
+  function rhs() { value = 'replaced'; return 'right'; }
+  value += rhs();
+  assert.strictEqual(value, 'leftright');
+  value += { [Symbol.toPrimitive]() { value = 'changed'; return '!'; } };
+  assert.strictEqual(value, 'leftright!');
+  assert.throws(() => { value += Symbol('no'); }, TypeError);
+  assert.strictEqual(value, 'leftright!');
+}
+for (let i = 0; i < 30000; i++) reentrant();
+console.log('short append snapshots, growth, Unicode and reentrancy ok');

--- a/tests/test_string_slice_ascii.cjs
+++ b/tests/test_string_slice_ascii.cjs
@@ -1,0 +1,35 @@
+const assert = require('node:assert');
+const slice = Function.prototype.call.bind(String.prototype.slice);
+
+function expected(value, start, end) {
+  const length = value.length;
+  start = start === undefined ? 0 : Math.min(Math.trunc(start), length);
+  end = end === undefined ? length : Math.min(Math.trunc(end), length);
+  let result = '';
+  for (let i = start; i < end; i++) result += value[i];
+  return result;
+}
+
+const inputs = ['', 'a', 'abc\0def', 'x'.repeat(300), 'y'.repeat(10000)];
+const bounds = [undefined, 0, -0, 0.9, 1, 1.9, 3, 100, 1e30, Infinity];
+for (let round = 0; round < 100; round++) {
+  for (const input of inputs) {
+    for (const start of bounds) {
+      for (const end of bounds) {
+        assert.strictEqual(slice(input, start, end), expected(input, start, end));
+      }
+    }
+    assert.strictEqual(slice(input), input);
+  }
+}
+
+// Unicode and negative bounds retain the UTF-16 fallback.
+assert.strictEqual(slice('a😀z', 1, 2), '\ud83d');
+assert.strictEqual(slice('a😀z', 2, 3), '\ude00');
+assert.strictEqual(slice('abcdef', -3, -1), 'de');
+assert.strictEqual(slice(new String('abcdef'), 1, 3), 'bc');
+const original = String.prototype.slice;
+String.prototype.slice = () => 'replaced';
+assert.strictEqual(slice('abcdef', 1, 3), 'bc');
+String.prototype.slice = original;
+console.log('ASCII slice bounds, allocation churn, Unicode and captured target ok');

--- a/tests/test_template_empty_segments.cjs
+++ b/tests/test_template_empty_segments.cjs
@@ -1,0 +1,49 @@
+const assert = require('node:assert');
+function single(value) { return `${value}`; }
+function adjacent(a, b, c) { return `${a}${b}${c}`; }
+function append(a, b) { a = `${a}${b}`; return a; }
+for (let i = 0; i < 30000; i++) {
+  assert.strictEqual(single(i), String(i));
+  assert.strictEqual(adjacent('a', i & 1 ? '' : '😀', 'z'), i & 1 ? 'az' : 'a😀z');
+  assert.strictEqual(append('left', 'right'), 'leftright');
+}
+assert.strictEqual(``, '');
+assert.strictEqual(single(undefined), 'undefined');
+assert.strictEqual(single(null), 'null');
+assert.strictEqual(single(123n), '123');
+assert.throws(() => single(Symbol('x')), TypeError);
+assert.strictEqual(adjacent('', '', ''), '');
+
+const events = [];
+function item(name) {
+  events.push('eval ' + name);
+  return { [Symbol.toPrimitive](hint) { events.push('convert ' + name + ' ' + hint); return name; } };
+}
+assert.strictEqual(`${item('a')}${item('b')}${item('c')}`, 'abc');
+assert.deepStrictEqual(events, ['eval a', 'convert a string', 'eval b', 'convert b string', 'eval c', 'convert c string']);
+let reached = false;
+assert.throws(() => `${Symbol()}${reached = true}`, TypeError);
+assert.strictEqual(reached, false);
+
+function snapshot() {
+  let value = 'initial';
+  const before = `${value}`;
+  value += ' changed';
+  assert.strictEqual(before, 'initial');
+  value = `${value}${{ toString() { value = 'reentrant'; return '!'; } }}`;
+  assert.strictEqual(value, 'initial changed!');
+  value = `${value}`;
+  assert.strictEqual(value, 'initial changed!');
+}
+for (let i = 0; i < 30000; i++) snapshot();
+
+// Tagged templates retain all literal segments and do not coerce substitutions.
+const marker = Symbol('marker');
+function tagged(strings, a, b) {
+  assert.deepStrictEqual([...strings], ['', '', '']);
+  assert.deepStrictEqual([...strings.raw], ['', '', '']);
+  assert.strictEqual(a, marker);
+  assert.strictEqual(b, 42);
+}
+tagged`${marker}${42}`;
+console.log('empty template segments, coercion order, snapshots and tags ok');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved `String.prototype.charCodeAt` performance while preserving fallback behavior for unusual inputs.
  - Optimized primitive `typeof` comparisons and common string operations.
  - Added caching for repeated `process.cwd()` calls.
  - Expanded `assert.throws` to support error constructors and validation callbacks.
  - Added POSIX PAX metadata support for tar extraction, including extended paths, link targets, and sizes.

- **Bug Fixes**
  - Corrected `Reflect.set` behavior for read-only and frozen properties.
  - Fixed Windows path normalization for reserved device names.
  - Improved handling of string slicing, concatenation, templates, and object literals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->