### PR TITLE
nix: update flake to fix deprecation warnings and compile errors

### DIFF
--- a/packages/nix/package.nix
+++ b/packages/nix/package.nix
@@ -1,7 +1,7 @@
 { lib
 , llvmPackages_21
 , stdenv
-, ccacheStdenv
+, ccache
 , meson
 , ninja
 , cmake
@@ -33,19 +33,29 @@ let
         llvmPackages_21.stdenv.cc.override { bintools = llvmPackages_21.bintools; }
       )
     else stdenv;
-  antStdenv = ccacheStdenv.override {
-    stdenv = antBaseStdenv;
-    extraConfig = ''
-      export CCACHE_COMPRESS=1
-      export CCACHE_MAXSIZE=2G
-      export CCACHE_SLOPPINESS=random_seed,time_macros
-      if [ -d /tmp/ant-nix-ccache ] && [ -w /tmp/ant-nix-ccache ]; then
-        export CCACHE_DIR=/tmp/ant-nix-ccache
-      else
-        export CCACHE_DIR="$TMPDIR/ccache"
-      fi
-    '';
-  };
+
+  ccacheConfig = ''
+    export CCACHE_COMPRESS=1
+    export CCACHE_MAXSIZE=2G
+    export CCACHE_SLOPPINESS=random_seed,time_macros
+    if [ -d /tmp/ant-nix-ccache ] && [ -w /tmp/ant-nix-ccache ]; then
+      export CCACHE_DIR=/tmp/ant-nix-ccache
+    else
+      export CCACHE_DIR="$TMPDIR/ccache"
+    fi
+  '';
+
+  ccacheLinks = (ccache.links {
+    unwrappedCC = antBaseStdenv.cc.cc;
+    extraConfig = ccacheConfig;
+  }).overrideAttrs (prev: {
+    passthru = (prev.passthru or { }) // {
+      langC = antBaseStdenv.cc.cc.langC or true;
+      langCC = antBaseStdenv.cc.cc.langCC or true;
+    };
+  });
+
+  antStdenv = overrideCC antBaseStdenv (antBaseStdenv.cc.override { cc = ccacheLinks; });
 
   antVersion = import ./version.nix { inherit lib gitRev; };
   antVendor = callPackage ./vendor.nix {};

--- a/packages/nix/package.nix
+++ b/packages/nix/package.nix
@@ -28,7 +28,7 @@
 let
   zigPkg = if zig_0_16 != null then zig_0_16 else zig;
   antBaseStdenv =
-    if stdenv.isLinux then
+    if stdenv.hostPlatform.isLinux then
       overrideCC llvmPackages_21.stdenv (
         llvmPackages_21.stdenv.cc.override { bintools = llvmPackages_21.bintools; }
       )
@@ -129,7 +129,7 @@ antStdenv.mkDerivation (finalAttrs: {
     curl
     zigPkg
     rustPlatform.cargoSetupHook
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.sigtool
     llvmPackages_21.llvm
   ];
@@ -149,7 +149,7 @@ antStdenv.mkDerivation (finalAttrs: {
     "-Dbuild_git_hash=${gitRev}"
     "-Db_lto_mode=default"
     "-Dembed_example=disabled"
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-Dllvm_nm=${lib.getExe' llvmPackages_21.llvm "llvm-nm"}"
   ] ++ lib.optionals enableNativeTuning [
     "-Dnative_tuning=enabled"
@@ -183,7 +183,7 @@ antStdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postFixup = lib.optionalString stdenv.isDarwin ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
     strip -S -x "$out/bin/ant"
     codesign --force --sign - --entitlements ${../../meson/ant.entitlements} "$out/bin/ant"
   '';


### PR DESCRIPTION
> [!NOTE]
> **AI Disclosure**  
> I used Claude Opus 5 to help fix this, it wrote the initial code then I looked over it, ensured that it was correct, and cleaned up anything unnecessary. It was manually reviewed by myself before making the pull request.

This pull request fixes two issues I found in the Nix package.
1. When a user overrode the `nixpkgs` input it had the chance to break compilation.
2. The previous way the flake was using `isDarwin` / `isLinux` was deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection for Linux and macOS builds.
  * Updated compiler cache integration to provide more reliable build behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->