### PR TITLE
node module parity

### DIFF
--- a/examples/spec/modules.js
+++ b/examples/spec/modules.js
@@ -4,12 +4,44 @@ import * as path from 'ant:path';
 import * as fs from 'ant:fs';
 import * as shell from 'ant:shell';
 import * as ffi from 'ant:ffi';
+import { createRequire, Module } from 'node:module';
 
 import testJson from './test.json';
 import { name, version, count } from './test.json';
 import textContent from './test.txt';
 
 console.log('Module Tests\n');
+
+const constructedParent = new Module('parent.cjs');
+const constructedChild = new Module('child.cjs', constructedParent);
+test('Module constructor name', Module.name, 'Module');
+test('new Module creates a Module instance', constructedChild instanceof Module, true);
+test('new Module uses Module.prototype', Object.getPrototypeOf(constructedChild) === Module.prototype, true);
+test('Module prototype constructor backlink', Module.prototype.constructor === Module, true);
+test('new Module preserves id', constructedChild.id, 'child.cjs');
+test('new Module starts without filename', constructedChild.filename, null);
+test('new Module starts unloaded', constructedChild.loaded, false);
+test('new Module starts with empty exports', Object.keys(constructedChild.exports).length, 0);
+test('new Module exports inherit Object.prototype', Object.getPrototypeOf(constructedChild.exports) === Object.prototype, true);
+test('new Module preserves parent', constructedChild.parent === constructedParent, true);
+test('new Module registers with parent', constructedParent.children[0] === constructedChild, true);
+test('new Module registers once with parent', constructedParent.children.length, 1);
+test('new Module starts without children', constructedChild.children.length, 0);
+test('new Module exposes require', typeof constructedChild.require, 'function');
+
+const requireForCache = createRequire(import.meta.url);
+test('createRequire shares Module._cache', requireForCache.cache === Module._cache, true);
+test('require.cache has null prototype', Object.getPrototypeOf(requireForCache.cache), null);
+const realFsForCache = requireForCache('node:fs');
+const fakeFsForCache = {};
+try {
+  requireForCache.cache.fs = { exports: fakeFsForCache };
+  test('require.cache overrides bare builtins', requireForCache('fs') === fakeFsForCache, true);
+  test('node prefix bypasses require.cache', requireForCache('node:fs') === realFsForCache, true);
+} finally {
+  delete requireForCache.cache.fs;
+}
+
 
 test('import.meta exists', typeof import.meta, 'object');
 test('import.meta.url exists', typeof import.meta.url, 'string');

--- a/include/esm/commonjs.h
+++ b/include/esm/commonjs.h
@@ -8,17 +8,20 @@
 
 ant_value_t esm_require_cache(ant_t *js);
 ant_value_t esm_require_cache_lookup(ant_t *js, const char *key);
+ant_value_t esm_require_cache_store(ant_t *js, const char *key, ant_value_t module);
 ant_value_t esm_require_cached_exports(ant_t *js, ant_value_t cached);
 ant_value_t esm_require_namespace(ant_t *js, ant_value_t exports);
 ant_value_t esm_require_unwrap(ant_t *js, ant_value_t ns);
 
 ant_value_t esm_create_cjs_module(ant_t *js, const char *filename, ant_value_t parent);
-ant_value_t esm_cjs_require_paths(ant_t *js, ant_value_t *args, int nargs);
+ant_value_t esm_init_cjs_module(ant_t *js, ant_value_t obj, const char *id, ant_value_t parent);
+ant_value_t esm_create_require(ant_t *js, ant_value_t module);
+ant_value_t esm_create_require_from_path(ant_t *js, const char *filename);
 ant_value_t esm_cjs_require_module(ant_t *js, ant_value_t *args, int nargs);
 
 ant_value_t esm_load_commonjs_module(
   ant_t *js, const char *module_path,
-  const char *code, size_t code_len, ant_value_t ns
+  const char *code, size_t code_len, ant_value_t ns, ant_value_t module
 );
 
 void esm_cjs_update_children(

--- a/include/esm/commonjs.h
+++ b/include/esm/commonjs.h
@@ -7,11 +7,23 @@
 #include <stddef.h>
 
 ant_value_t esm_require_cache(ant_t *js);
+ant_value_t esm_require_cache_lookup(ant_t *js, const char *key);
+ant_value_t esm_require_cached_exports(ant_t *js, ant_value_t cached);
+ant_value_t esm_require_namespace(ant_t *js, ant_value_t exports);
+ant_value_t esm_require_unwrap(ant_t *js, ant_value_t ns);
+
+ant_value_t esm_create_cjs_module(ant_t *js, const char *filename, ant_value_t parent);
+ant_value_t esm_cjs_require_paths(ant_t *js, ant_value_t *args, int nargs);
+ant_value_t esm_cjs_require_module(ant_t *js, ant_value_t *args, int nargs);
 
 ant_value_t esm_load_commonjs_module(
-  ant_t *js,
-  const char *module_path, const char *code,
-  size_t code_len, ant_value_t ns
+  ant_t *js, const char *module_path,
+  const char *code, size_t code_len, ant_value_t ns
+);
+
+void esm_cjs_update_children(
+  ant_t *js, ant_value_t parent,
+  ant_value_t child, bool remove
 );
 
 #endif

--- a/include/internal.h
+++ b/include/internal.h
@@ -181,10 +181,16 @@ struct ant_isolate_t {
   struct {
     ant_value_t hooks;
     ant_value_t import_meta;
-    ant_value_t require_cache;
+    struct {
+      ant_value_t cache;
+      ant_value_t parent;
+      ant_value_t main;
+      ant_value_t constructor;
+      uint64_t generation;
+    } cjs;
     ant_esm_state_t *state;
     ant_module_t *module_stack;
-  } esm;
+  } modules;
 
   struct {
     const char *length;
@@ -748,7 +754,7 @@ static inline ant_value_t js_current_func_module_ns(ant_t *js) {
 }
 
 static inline ant_value_t js_module_eval_active_ns(ant_t *js) {
-  ant_module_t *ctx = js->esm.module_stack;
+  ant_module_t *ctx = js->modules.module_stack;
   if (ctx) return ctx->module_ns;
   ctx = js->active_async_coro ? js_active_tla_module_ctx(js) : NULL;
   if (ctx) return ctx->module_ns;
@@ -756,7 +762,7 @@ static inline ant_value_t js_module_eval_active_ns(ant_t *js) {
 }
 
 static inline ant_value_t js_module_eval_active_ctx(ant_t *js) {
-  ant_module_t *ctx = js->esm.module_stack;
+  ant_module_t *ctx = js->modules.module_stack;
   if (ctx) return ctx->module_ctx;
   ctx = js->active_async_coro ? js_active_tla_module_ctx(js) : NULL;
   return ctx ? ctx->module_ctx : js_mkundef();
@@ -777,7 +783,7 @@ static inline const char *js_module_eval_active_filename(ant_t *js) {
 }
 
 static inline ant_module_format_t js_module_eval_active_format(ant_t *js) {
-  ant_module_t *ctx = js->esm.module_stack;
+  ant_module_t *ctx = js->modules.module_stack;
   if (ctx) return ctx->format;
   ctx = js->active_async_coro ? js_active_tla_module_ctx(js) : NULL;
   return ctx ? ctx->format : MODULE_EVAL_FORMAT_UNKNOWN;

--- a/include/modules/napi.h
+++ b/include/modules/napi.h
@@ -169,6 +169,6 @@ typedef struct napi_module {
 
 napi_env ant_napi_get_env(ant_t *js);
 ant_value_t napi_process_dlopen_js(ant_t *js, ant_value_t *args, int nargs);
-ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_value_t ns);
+ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_value_t ns, ant_value_t module);
 
 #endif

--- a/src/ant.c
+++ b/src/ant.c
@@ -17420,7 +17420,7 @@ static void js_set_import_module_ctx(ant_t *js, ant_value_t module_ctx) {
 static ant_value_t js_get_current_import_meta(ant_t *js) {
   ant_value_t import_meta = js_get_module_ctx_import_meta(js, js_get_execution_module_ctx(js));
   if (vtype(import_meta) == kTypeObject) return import_meta;
-  return js->esm.import_meta;
+  return js->modules.import_meta;
 }
 
 static bool js_try_import_meta(ant_t *js, ant_value_t func_obj, ant_value_t *out) {
@@ -17618,26 +17618,26 @@ void js_setup_import_meta(ant_t *js, const char *filename) {
   if (is_err(import_meta) || vtype(import_meta) == kTypeUndefined) return;
 
   js_set_import_module_ctx(js, module_ctx);
-  js->esm.import_meta = import_meta;
+  js->modules.import_meta = import_meta;
 }
 
 void js_module_eval_ctx_push(ant_t *js, ant_module_t *ctx) {
   if (!js || !ctx) return;
 
-  ctx->prev = js->esm.module_stack;
-  ctx->prev_import_meta_prop = js->esm.import_meta;
-  js->esm.module_stack = ctx;
+  ctx->prev = js->modules.module_stack;
+  ctx->prev_import_meta_prop = js->modules.import_meta;
+  js->modules.module_stack = ctx;
 
   ant_value_t import_meta = js_get_module_ctx_import_meta(js, ctx->module_ctx);
-  if (vtype(import_meta) != kTypeUndefined) js->esm.import_meta = import_meta;
+  if (vtype(import_meta) != kTypeUndefined) js->modules.import_meta = import_meta;
 }
 
 void js_module_eval_ctx_pop(ant_t *js, ant_module_t *ctx) {
   if (!js || !ctx) return;
 
-  if (js->esm.module_stack == ctx) {
-    js->esm.import_meta = ctx->prev_import_meta_prop;
-    js->esm.module_stack = ctx->prev;
+  if (js->modules.module_stack == ctx) {
+    js->modules.import_meta = ctx->prev_import_meta_prop;
+    js->modules.module_stack = ctx->prev;
   }
 }
 
@@ -18641,10 +18641,14 @@ static ant_t *isolate_init(void *buf, size_t len) {
   js->global = mkobj(js, 0);
   js->this_val = js->global;
   js->new_target = js_mkundef();
-  js->esm.require_cache = js_mkundef();
-  js->esm.hooks = js_mkundef();
-  js->esm.import_meta = js_mkundef();
-  js->esm.state = NULL;
+  js->modules.cjs.cache = js_mkundef();
+  js->modules.cjs.parent = js_mkundef();
+  js->modules.cjs.main = js_mkundef();
+  js->modules.cjs.constructor = js_mkundef();
+  js->modules.cjs.generation = 0;
+  js->modules.hooks = js_mkundef();
+  js->modules.import_meta = js_mkundef();
+  js->modules.state = NULL;
   js->length_str = ANT_STRING("length");
 
   ant_value_t glob = js->global;

--- a/src/esm/commonjs.c
+++ b/src/esm/commonjs.c
@@ -1,5 +1,10 @@
 #include "esm/commonjs.h"
 #include "esm/loader.h"
+#include "loader_internal.h"
+#include "modules/module.h"
+#include "gc/roots.h"
+#include "esm/library.h"
+#include "esm/builtin_bundle.h"
 
 #include "internal.h"
 #include "reactor.h"
@@ -8,99 +13,240 @@
 #include "silver/compiler.h"
 #include "silver/engine.h"
 
-#include <libgen.h>
 #include <string.h>
 #include <stdlib.h>
 
 ant_value_t esm_require_cache(ant_t *js) {
-  if (!is_object_type(js->esm.require_cache)) {
-    js->esm.require_cache = js_mkobj(js);
-    js_set_proto_init(js->esm.require_cache, js_mknull());
+  if (is_object_type(js->modules.cjs.constructor))
+    return js_get(js, js->modules.cjs.constructor, "_cache");
+  if (!is_object_type(js->modules.cjs.cache)) {
+    js->modules.cjs.cache = js_mkobj(js);
+    js_set_proto_init(js->modules.cjs.cache, js_mknull());
   }
-  return js->esm.require_cache;
+  return js->modules.cjs.cache;
 }
 
-static ant_value_t cjs_module_exports_getter(ant_t *js, ant_value_t *args, int nargs) {
-  ant_value_t fn = js_getcurrentfunc(js);
-  ant_value_t state = js_get_slot(fn, SLOT_DATA);
-  if (!is_object_type(state)) return js_mkundef();
-  return js_get(js, state, "value");
+ant_value_t esm_require_cache_lookup(ant_t *js, const char *key) {
+  ant_value_t cache = esm_require_cache(js);
+  if (is_err(cache)) return cache;
+  if (vtype(cache) == kTypeNull || vtype(cache) == kTypeUndefined)
+    return js_mkerr_typed(js, JS_ERR_TYPE, "Cannot read properties of require cache");
+  return js_getprop_fallback_len(js, cache, key, strlen(key));
 }
 
-static ant_value_t cjs_module_exports_setter(ant_t *js, ant_value_t *args, int nargs) {
-  ant_value_t value = nargs > 0 ? args[0] : js_mkundef();
-  ant_value_t fn = js_getcurrentfunc(js);
-  ant_value_t state = js_get_slot(fn, SLOT_DATA);
-  
-  if (!is_object_type(state)) return js_mkundef();
-  js_set(js, state, "value", value);
-
-  ant_value_t ns = js_get(js, state, "namespace");
-  if (is_object_type(ns)) {
-    js_set_slot_wb(js, ns, SLOT_DEFAULT, value);
-    setprop_cstr(js, ns, "default", 7, value);
+ant_value_t esm_require_cache_store(ant_t *js, const char *key, ant_value_t module) {
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, module);
+  ant_value_t cache = esm_require_cache(js);
+  GC_ROOT_PIN(js, cache);
+  ant_value_t result = cache;
+  if (is_err(cache)) goto done;
+  if (!is_object_type(cache)) {
+    result = js_mkerr_typed(js, JS_ERR_TYPE, "Cannot write to require cache");
+    goto done;
   }
 
-  return js_mkundef();
+  ant_value_t object = js_as_obj(cache);
+  if (!is_proxy(object)) {
+    bool writable = js_obj_ptr(object)->flags.extensible;
+    ant_value_t current = object;
+    while (is_object_type(current)) {
+      if (is_proxy(current)) { writable = true; break; }
+      prop_meta_t meta;
+      if (lookup_string_prop_meta(js, current, key, strlen(key), &meta)) {
+        if (meta.has_getter || meta.has_setter) writable = meta.has_setter;
+        else writable = meta.writable && (current == object || writable);
+        break;
+      }
+      current = js_get_proto(js, current);
+    }
+    if (!writable) {
+      result = js_mkerr_typed(js, JS_ERR_TYPE, "Cannot write require cache entry '%s'", key);
+      goto done;
+    }
+  }
+  result = js_setprop(js, cache, js_mkstr(js, key, strlen(key)), module);
+  if (js->thrown_exists) result = mkval(kTypeError, 0);
+done:
+  GC_ROOT_RESTORE(js, mark);
+  return result;
 }
 
-static ant_value_t esm_cjs_require(ant_t *js, ant_value_t *args, int nargs) {
-  if (nargs < 1 || vtype(args[0]) != kTypeString)
-    return js_mkerr(js, "require() expects a string specifier");
+ant_value_t esm_require_cached_exports(ant_t *js, ant_value_t cached) {
+  if (is_err(cached)) return cached;
+  if (vtype(cached) == kTypeNull)
+    return js_mkerr_typed(js, JS_ERR_TYPE, "Cannot read properties of null cache entry");
+  return js_getprop_fallback_len(js, cached, "exports", 7);
+}
 
-  ant_value_t fn = js_getcurrentfunc(js);
-  ant_value_t data = js_get_slot(fn, SLOT_DATA);
-  const char *base_path = js_module_eval_active_filename(js);
+ant_value_t esm_init_cjs_module(ant_t *js, ant_value_t obj, const char *id, ant_value_t parent) {
+  char *directory = esm_path_dirname(id);
+  if (!directory) return js_mkerr(js, "Cannot allocate module directory");
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, obj);
+  GC_ROOT_PIN(js, parent);
+  js_set(js, obj, "id", js_mkstr(js, id, strlen(id)));
+  js_set(js, obj, "path", js_mkstr(js, directory, strlen(directory)));
+  free(directory);
+  js_set(js, obj, "filename", js_mknull());
+  ant_value_t exports = js_mkobj(js);
+  js_set_proto_init(exports, js->sym.object_proto);
+  js_set(js, obj, "exports", exports);
+  js_set(js, obj, "loaded", js_false);
+  js_set(js, obj, "children", js_mkarr(js));
+  js_set(js, obj, "parent", parent);
+  esm_cjs_update_children(js, parent, obj, false);
+  GC_ROOT_RESTORE(js, mark);
+  return obj;
+}
 
-  if (vtype(data) == kTypeString) {
-    ant_offset_t path_len = 0;
-    ant_offset_t path_off = vstr(js, data, &path_len);
-    base_path = (const char *)(uintptr_t)(path_off);
+ant_value_t esm_create_cjs_module(ant_t *js, const char *filename, ant_value_t parent) {
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, parent);
+  ant_value_t ctor = module_library(js);
+  ant_value_t obj = js_mkobj(js);
+  GC_ROOT_PIN(js, obj);
+  js_set_proto_wb(js, obj, js_get(js, ctor, "prototype"));
+  ant_value_t result = esm_init_cjs_module(js, obj, filename, parent);
+  if (!is_err(result)) {
+    ant_value_t directory = js_get(js, obj, "path");
+    result = esm_node_module_paths(js, js_getstr(js, directory, NULL));
+    if (!is_err(result)) {
+      js_set(js, obj, "filename", js_get(js, obj, "id"));
+      js_set(js, obj, "paths", result);
+      result = obj;
+    }
   }
+  if (is_err(result)) esm_cjs_update_children(js, parent, obj, true);
+  GC_ROOT_RESTORE(js, mark);
+  return result;
+}
 
-  ant_value_t ns = js_esm_import_sync_from_require(js, args[0], base_path);
-  if (is_err(ns)) return ns;
-
-  if (vtype(ns) == kTypeObject) {
-    ant_value_t default_export = js_get_slot(ns, SLOT_DEFAULT);
-    if (vtype(default_export) != kTypeUndefined) return default_export;
-  }
-  
+ant_value_t esm_require_namespace(ant_t *js, ant_value_t exports) {
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, exports);
+  ant_value_t ns = js_mkobj(js);
+  GC_ROOT_PIN(js, ns);
+  js_set_slot_wb(js, ns, SLOT_DEFAULT, exports);
+  js_set(js, ns, "default", exports);
+  GC_ROOT_RESTORE(js, mark);
   return ns;
 }
 
+ant_value_t esm_require_unwrap(ant_t *js, ant_value_t ns) {
+  if (is_err(ns)) return ns;
+  ant_value_t value;
+  if (is_object_type(ns) && js_try_get_own_data_prop(js, ns, "default", 7, &value)) return value;
+  return ns;
+}
+
+void esm_cjs_update_children(ant_t *js, ant_value_t parent, ant_value_t child, bool remove) {
+  if (!is_object_type(parent)) return;
+  ant_value_t children = js_get(js, parent, "children");
+  if (vtype(children) != kTypeArray) return;
+  ant_offset_t len = js_arr_len(js, children);
+  for (ant_offset_t i = 0; i < len; i++) {
+    if (js_arr_get(js, children, i) != child) continue;
+    if (remove) {
+      for (ant_offset_t j = i + 1; j < len; j++)
+        js_setprop(js, children, js_mknum((double)(j - 1)), js_arr_get(js, children, j));
+      js_setprop(js, children, js->length_str, js_mknum((double)(len - 1)));
+    }
+    return;
+  }
+  if (!remove) js_arr_push(js, children, child);
+}
+
+ant_value_t esm_cjs_require_module(ant_t *js, ant_value_t *args, int nargs) {
+  if (nargs < 1 || vtype(args[0]) != kTypeString)
+    return js_mkerr(js, "require() expects a string specifier");
+  ant_value_t parent = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  if (!is_object_type(parent)) parent = js->this_val;
+  ant_value_t filename = js_get(js, parent, "filename");
+  const char *base = vtype(filename) == kTypeString ? js_getstr(js, filename, NULL) : NULL;
+  GC_ROOT_SAVE(mark, js);
+  ant_value_t previous = js->modules.cjs.parent;
+  GC_ROOT_PIN(js, previous);
+  js->modules.cjs.parent = parent;
+  ant_value_t ns = js_esm_import_sync_from_require(js, args[0], base);
+  js->modules.cjs.parent = previous;
+  GC_ROOT_RESTORE(js, mark);
+  return esm_require_unwrap(js, ns);
+}
+
+static ant_value_t esm_cjs_require_paths(ant_t *js, ant_value_t *args, int nargs) {
+  if (!nargs || vtype(args[0]) != kTypeString)
+    return js_mkerr_typed(js, JS_ERR_TYPE, "require.resolve.paths expects a string");
+  size_t len;
+  const char *spec = js_getstr(js, args[0], &len);
+  if (js_esm_is_registered_library(spec, len) || esm_lookup_builtin_alias(spec, len)) return js_mknull();
+  ant_value_t module = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  ant_value_t directory = js_get(js, module, "path");
+  const char *path = js_getstr(js, directory, NULL);
+  if (!path) return js_mkerr(js, "Module has no search directory");
+  bool relative = spec[0] == '.' && (spec[1] == '/' || (spec[1] == '.' && spec[2] == '/'));
+#ifdef _WIN32
+  relative |= spec[0] == '.' && (spec[1] == '\\' || (spec[1] == '.' && spec[2] == '\\'));
+#endif
+  if (!relative) return esm_node_module_paths(js, path);
+  ant_value_t paths = js_mkarr(js);
+  js_arr_push(js, paths, directory);
+  return paths;
+}
+
 static ant_value_t esm_cjs_require_resolve(ant_t *js, ant_value_t *args, int nargs) {
-  if (nargs < 1 || vtype(args[0]) != kTypeString) {
+  if (nargs < 1 || vtype(args[0]) != kTypeString)
     return js_mkerr(js, "require.resolve() expects a string specifier");
+  ant_value_t module = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  ant_value_t filename = js_get(js, module, "filename");
+  const char *base = js_getstr(js, filename, NULL);
+  ant_value_t paths = nargs > 1 && is_object_type(args[1]) ? js_get(js, args[1], "paths") : js_mkundef();
+  ant_value_t resolved = js_mkundef();
+  if (vtype(paths) != kTypeArray) resolved = js_esm_resolve_specifier_require(js, args[0], base);
+  else {
+    ant_offset_t count = js_arr_len(js, paths);
+    for (ant_offset_t i = 0; i < count; i++) {
+      ant_value_t path = js_arr_get(js, paths, i);
+      if (vtype(path) != kTypeString) continue;
+      if (is_err(resolved)) {
+        js->thrown_exists = false;
+        js->thrown_value = js_mkundef();
+        js->thrown_stack = js_mkundef();
+      }
+      resolved = js_esm_resolve_specifier_require(js, args[0], js_getstr(js, path, NULL));
+      if (!is_err(resolved) && vtype(resolved) == kTypeString) break;
+    }
   }
-
-  ant_value_t fn = js_getcurrentfunc(js);
-  ant_value_t data = js_get_slot(fn, SLOT_DATA);
-  const char *base_path = js_module_eval_active_filename(js);
-
-  if (vtype(data) == kTypeString) {
-    ant_offset_t data_len = 0;
-    ant_offset_t data_off = vstr(js, data, &data_len);
-    base_path = (const char *)(uintptr_t)(data_off);
-  }
-
-  ant_value_t resolved = js_esm_resolve_specifier_require(js, args[0], base_path);
   if (is_err(resolved)) return resolved;
-  if (vtype(resolved) != kTypeString) return resolved;
+  if (vtype(resolved) != kTypeString) return js_mkerr(js, "Cannot resolve module");
+  char *path = esm_file_url_to_path(js, js_getstr(js, resolved, NULL));
+  if (!path) return resolved;
+  ant_value_t result = js_mkstr(js, path, strlen(path));
+  free(path);
+  return result;
+}
 
-  ant_offset_t len = 0;
-  ant_offset_t off = vstr(js, resolved, &len);
-  
-  const char *s = (const char *)(uintptr_t)(off);
-  static const char *prefix = "file://";
+ant_value_t esm_create_require(ant_t *js, ant_value_t module) {
+  if (is_err(module)) return module;
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, module);
+  ant_value_t require = js_heavy_mkfun(js, esm_cjs_require_module, module);
+  GC_ROOT_PIN(js, require);
+  ant_value_t resolve = js_heavy_mkfun(js, esm_cjs_require_resolve, module);
+  GC_ROOT_PIN(js, resolve);
+  js_set(js, resolve, "paths", js_heavy_mkfun(js, esm_cjs_require_paths, module));
+  js_set(js, require, "resolve", resolve);
+  js_set(js, require, "cache", esm_require_cache(js));
+  js_set(js, require, "main", js->modules.cjs.main);
+  GC_ROOT_RESTORE(js, mark);
+  return require;
+}
 
-  if ((size_t)len >= strlen(prefix) && strncmp(s, prefix, strlen(prefix)) == 0) {
-    const char *path_part = s + strlen(prefix);
-    size_t path_len = (size_t)len - strlen(prefix);
-    return js_mkstr(js, path_part, path_len);
-  }
-
-  return resolved;
+ant_value_t esm_create_require_from_path(ant_t *js, const char *filename) {
+  char *path = esm_file_url_to_path(js, filename);
+  ant_value_t module = esm_create_cjs_module(js, path ? path : filename, js_mkundef());
+  free(path);
+  return esm_create_require(js, module);
 }
 
 static bool copy_own_prop(
@@ -193,60 +339,46 @@ static ant_value_t esm_eval_commonjs_function(
 ant_value_t esm_load_commonjs_module(
   ant_t *js,
   const char *module_path, const char *code,
-  size_t code_len, ant_value_t ns
+  size_t code_len, ant_value_t ns, ant_value_t module_obj
 ) {
-  char *path_copy = strdup(module_path);
-  if (!path_copy) return js_mkerr(js, "OOM loading CommonJS module");
-
-  ant_value_t object_proto = js->sym.object_proto;
-  ant_value_t module_obj = js_mkobj(js);
-  ant_value_t exports_obj = js_mkobj(js);
-  ant_value_t exports_state = js_mkobj(js);
-  
-  if (is_object_type(object_proto)) {
-    js_set_proto_init(module_obj, object_proto);
-    js_set_proto_init(exports_obj, object_proto);
-    js_set_proto_init(exports_state, object_proto);
+  bool builtin = strncmp(module_path, "node:", 5) == 0 || strncmp(module_path, "ant:", 4) == 0;
+  bool pending = is_object_type(module_obj);
+  ant_value_t cached = builtin || pending ? js_mkundef() : esm_require_cache_lookup(js, module_path);
+  if (vtype(cached) != kTypeUndefined && !pending) {
+    ant_value_t exports = esm_require_cached_exports(js, cached);
+    ant_value_t result = is_err(exports) ? exports : esm_populate_cjs_namespace(js, ns, exports);
+    return is_err(result) ? result : exports;
   }
-  
-  js_set(js, exports_state, "value", exports_obj);
-  js_set(js, exports_state, "namespace", ns);
-  
-  js_set_getter_desc(
-    js, js_as_obj(module_obj), "exports", 7,
-    js_heavy_mkfun(js, cjs_module_exports_getter, exports_state),
-    JS_DESC_E | JS_DESC_C
-  );
-  
-  js_set_setter_desc(
-    js, js_as_obj(module_obj), "exports", 7,
-    js_heavy_mkfun(js, cjs_module_exports_setter, exports_state),
-    JS_DESC_E | JS_DESC_C
-  );
-  
+
+  GC_ROOT_SAVE(mark, js);
+  if (!pending) module_obj = esm_create_cjs_module(js, module_path, builtin ? js_mkundef() : js->modules.cjs.parent);
+  GC_ROOT_PIN(js, module_obj);
+  if (is_err(module_obj)) {
+    GC_ROOT_RESTORE(js, mark);
+    return module_obj;
+  }
+  ant_value_t exports_obj = js_get(js, module_obj, "exports");
+  GC_ROOT_PIN(js, exports_obj);
   js_set_slot_wb(js, ns, SLOT_DEFAULT, exports_obj);
   setprop_cstr(js, ns, "default", 7, exports_obj);
-  js_set(js, module_obj, "loaded", js_false);
-  js_set(js, module_obj, "id", js_mkstr(js, module_path, strlen(module_path)));
-  js_set(js, module_obj, "filename", js_mkstr(js, module_path, strlen(module_path)));
 
-  ant_value_t require_fn = js_heavy_mkfun(
-    js, esm_cjs_require,
-    js_mkstr(js, module_path, strlen(module_path))
-  );
-  
-  ant_value_t require_resolve_fn = js_heavy_mkfun(
-    js, esm_cjs_require_resolve,
-    js_mkstr(js, module_path, strlen(module_path))
-  );
-  
-  js_set(js, require_fn, "resolve", require_resolve_fn);
-  js_set(js, require_fn, "cache", esm_require_cache(js));
-  js_set(js, esm_require_cache(js), module_path, module_obj);
-
-  char *dir = dirname(path_copy);
-  ant_value_t dirname_val = js_mkstr(js, dir, strlen(dir));
-  ant_value_t filename_val = js_mkstr(js, module_path, strlen(module_path));
+  bool is_main = js->modules.module_stack && !js->modules.module_stack->prev &&
+    vtype(js->modules.cjs.parent) == kTypeUndefined;
+  if (is_main) {
+    js->modules.cjs.main = module_obj;
+    js_set(js, js_get(js, js_glob(js), "process"), "mainModule", module_obj);
+    js_set(js, module_obj, "id", js_mkstr(js, ".", 1));
+  }
+  ant_value_t require_fn = esm_create_require(js, module_obj);
+  GC_ROOT_PIN(js, require_fn);
+  ant_value_t registration = builtin || pending ? js_mkundef() : esm_require_cache_store(js, module_path, module_obj);
+  if (is_err(registration)) {
+    esm_cjs_update_children(js, js_get(js, module_obj, "parent"), module_obj, true);
+    GC_ROOT_RESTORE(js, mark);
+    return registration;
+  }
+  ant_value_t dirname_val = js_get(js, module_obj, "path");
+  ant_value_t filename_val = js_get(js, module_obj, "filename");
 
   const char *prev_filename = js->filename;
   js_set_filename(js, module_path);
@@ -258,7 +390,9 @@ ant_value_t esm_load_commonjs_module(
   );
   
   if (vtype(result) == kTypePromise) js_run_event_loop(js);
-  if (!is_err(result) && !js->thrown_exists) js_set(js, module_obj, "loaded", js_true);
+  if (!is_err(result) && !js->thrown_exists) {
+    js_set(js, module_obj, "loaded", js_true);
+  }
   ant_value_t exports_val = js_get(js, module_obj, "exports");
   
   if (!is_err(result) && !js->thrown_exists) {
@@ -266,11 +400,13 @@ ant_value_t esm_load_commonjs_module(
     if (is_err(ns_res)) result = ns_res;
   }
 
-  if (is_err(result) || js->thrown_exists)
-    js_delete_prop(js, esm_require_cache(js), module_path, strlen(module_path));
+  if (!pending && (is_err(result) || js->thrown_exists)) {
+    if (!builtin) js_delete_prop(js, esm_require_cache(js), module_path, strlen(module_path));
+    esm_cjs_update_children(js, js_get(js, module_obj, "parent"), module_obj, true);
+  }
 
   js_set_filename(js, prev_filename);
-  free(path_copy);
+  GC_ROOT_RESTORE(js, mark);
 
   if (is_err(result)) return result;
   return exports_val;

--- a/src/esm/hooks.c
+++ b/src/esm/hooks.c
@@ -25,7 +25,7 @@ static bool esm_has_url_scheme(const char *s) {
 }
 
 bool esm_hooks_present(ant_t *js) {
-  return vtype(js->esm.hooks) == kTypeArray && js_arr_len(js, js->esm.hooks) > 0;
+  return vtype(js->modules.hooks) == kTypeArray && js_arr_len(js, js->modules.hooks) > 0;
 }
 
 typedef struct {
@@ -372,7 +372,7 @@ ant_value_t esm_import_via_hooks(
   js_set(js, ctx, "conditions", conditions);
   js_set(js, ctx, "importAttributes", is_object_type(attrs) ? attrs : js_mkobj(js));
 
-  ant_value_t hooks = js->esm.hooks;
+  ant_value_t hooks = js->modules.hooks;
   GC_ROOT_PIN(js, hooks);
   int top = (int)js_arr_len(js, hooks) - 1;
 

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -53,7 +53,7 @@ typedef enum {
 } esm_package_type_t;
 
 static char *esm_resolve_node_module(ant_t *js, const char *specifier, const char *base_path);
-static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod);
+static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod, ant_value_t require_module);
 static bool esm_is_path_sep(char ch) {
   return ch == '/' || ch == '\\';
 }
@@ -113,6 +113,45 @@ static bool esm_path_ascend(char *path) {
   else if (esm_has_windows_drive_letter(path) && slash == path + 2) slash[1] = '\0';
   else *slash = '\0';
   return true;
+}
+
+char *esm_path_dirname(const char *path) {
+  char *directory = strdup(path);
+  if (!directory) return NULL;
+  if (!esm_path_is_root(directory) && !esm_path_ascend(directory)) {
+    free(directory);
+    return strdup(".");
+  }
+  return directory;
+}
+
+ant_value_t esm_node_module_paths(ant_t *js, const char *directory) {
+  static const char suffix[] = "node_modules";
+  char *current = esm_make_absolute_path(directory);
+  if (!current) return js_mkerr(js, "Cannot resolve module search directory");
+  size_t capacity = strlen(current) + sizeof(suffix) + 1;
+  char *candidate = malloc(capacity);
+  if (!candidate) {
+    free(current);
+    return js_mkerr(js, "Cannot allocate module search path");
+  }
+
+  GC_ROOT_SAVE(mark, js);
+  ant_value_t paths = js_mkarr(js);
+  GC_ROOT_PIN(js, paths);
+  do {
+    const char *base = esm_path_last_sep_const(current);
+    base = base ? base + 1 : current;
+    if (strcmp(base, suffix) == 0) continue;
+    size_t length = strlen(current);
+    const char *separator = esm_is_path_sep(current[length - 1]) ? "" : "/";
+    snprintf(candidate, capacity, "%s%s%s", current, separator, suffix);
+    js_arr_push(js, paths, js_mkstr(js, candidate, strlen(candidate)));
+  } while (esm_path_ascend(current));
+  GC_ROOT_RESTORE(js, mark);
+  free(candidate);
+  free(current);
+  return paths;
 }
 
 char *esm_file_url_to_path(ant_t *js, const char *specifier) {
@@ -495,7 +534,7 @@ static ant_value_t esm_require_esm_exports(ant_t *js, ant_value_t ns) {
   return wrapper;
 }
 
-static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_value_t value) {
+static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_value_t value, ant_value_t require_module) {
   if (is_err(value)) {
     mod->is_loading = false;
     return value;
@@ -526,14 +565,25 @@ static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_v
   js_set(js, ns, "default", value);
   js_set_slot(ns, SLOT_DEFAULT, value);
 
-  if (mod->kind == ESM_MODULE_KIND_JSON) {
+  if (mod->kind == ESM_MODULE_KIND_JSON && !is_object_type(require_module)) {
     ant_value_t entry = esm_require_cache_lookup(js, mod->resolved_path);
     if (vtype(entry) == kTypeUndefined) {
       entry = esm_create_cjs_module(js, mod->resolved_path, js->modules.cjs.parent);
       GC_ROOT_PIN(js, entry);
-      js_set(js, entry, "exports", value);
-      js_set(js, entry, "loaded", js_true);
-      js_set(js, esm_require_cache(js), mod->resolved_path, entry);
+      if (!is_err(entry)) {
+        js_set(js, entry, "exports", value);
+        js_set(js, entry, "loaded", js_true);
+        ant_value_t stored = esm_require_cache_store(js, mod->resolved_path, entry);
+        if (is_err(stored)) {
+          esm_cjs_update_children(js, js->modules.cjs.parent, entry, true);
+          entry = stored;
+        }
+      }
+    }
+    if (is_err(entry)) {
+      mod->is_loading = false;
+      GC_ROOT_RESTORE(js, root_mark);
+      return entry;
     }
   }
 
@@ -1264,7 +1314,7 @@ ant_module_format_t esm_decide_module_format(ant_t *js, const char *resolved_pat
 static ant_value_t esm_eval_ambiguous_js_source(
   ant_t *js,
   const char *resolved_path, const char *js_code,
-  size_t js_len, ant_value_t ns, ant_module_format_t *format
+  size_t js_len, ant_value_t ns, ant_module_format_t *format, ant_value_t require_module
 ) {
   bool saved_thrown_exists = js->thrown_exists;
   ant_value_t saved_thrown_value = js->thrown_value;
@@ -1279,7 +1329,7 @@ static ant_value_t esm_eval_ambiguous_js_source(
     js->thrown_stack = saved_thrown_stack;
     *format = MODULE_EVAL_FORMAT_CJS;
     if (js->modules.module_stack) js->modules.module_stack->format = *format;
-    return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns);
+    return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns, require_module);
   }
 
   if (program->flags & FN_MODULE_SYNTAX) {
@@ -1302,20 +1352,20 @@ static ant_value_t esm_eval_ambiguous_js_source(
   parse_arena_rewind(parse_mark);
   *format = MODULE_EVAL_FORMAT_CJS;
   if (js->modules.module_stack) js->modules.module_stack->format = *format;
-  return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns);
+  return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns, require_module);
 }
 
 static ant_value_t esm_eval_module_with_format(
   ant_t *js,
   const char *resolved_path, const char *js_code,
-  size_t js_len, ant_value_t ns, ant_module_format_t *format
+  size_t js_len, ant_value_t ns, ant_module_format_t *format, ant_value_t require_module
 ) {
   if (*format == MODULE_EVAL_FORMAT_UNKNOWN) return esm_eval_ambiguous_js_source(
     js, resolved_path, js_code, 
-    js_len, ns, format
+    js_len, ns, format, require_module
   );
   if (*format == MODULE_EVAL_FORMAT_CJS) 
-    return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns);
+    return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns, require_module);
   return js_eval_bytecode_module(js, js_code, js_len);
 }
 
@@ -1337,7 +1387,7 @@ ant_value_t js_esm_eval_module_source(
   
   ant_value_t result = esm_eval_module_with_format(
     js, resolved_path, js_code, 
-    js_len, ns, &format
+    js_len, ns, &format, js_mkundef()
   );
 
   js_module_eval_ctx_pop(js, &eval_ctx);
@@ -1449,19 +1499,23 @@ static esm_module_t *esm_create_module(
   return mod;
 }
 
+static void esm_remove_module(ant_esm_state_t *state, esm_module_t *module) {
+  HASH_DEL(state->modules, module);
+  state->module_count--;
+  if (state->last_tla_module == module) state->last_tla_module = NULL;
+  free(module->path);
+  free(module->cache_key);
+  free(module->resolved_path);
+  free(module->url_content);
+  if (module->owns_embedded) free((void *)module->embedded_code);
+  free(module);
+}
+
 void js_esm_cleanup_module_cache(ant_t *js) {
   ant_esm_state_t *st = js ? js->modules.state : NULL;
   if (st) {
     esm_module_t *current, *tmp;
-    HASH_ITER(hh, st->modules, current, tmp) {
-      HASH_DEL(st->modules, current);
-      if (current->path) free(current->path);
-      if (current->cache_key) free(current->cache_key);
-      if (current->resolved_path) free(current->resolved_path);
-      if (current->url_content) free(current->url_content);
-      if (current->owns_embedded) free((void *)current->embedded_code);
-      free(current);
-    }
+    HASH_ITER(hh, st->modules, current, tmp) esm_remove_module(st, current);
     st->module_count = 0;
     st->last_tla_module = NULL;
   }
@@ -1537,10 +1591,10 @@ static ant_value_t esm_load_image(ant_t *js, const char *path) {
   return obj;
 }
 
-static ant_value_t esm_load_value_module(ant_t *js, esm_module_t *mod) {
-  if (mod->kind == ESM_MODULE_KIND_JSON) {
+static ant_value_t esm_load_value_module(ant_t *js, esm_module_t *mod, ant_value_t require_module) {
+  if (mod->kind == ESM_MODULE_KIND_JSON && !is_object_type(require_module)) {
     ant_value_t entry = esm_require_cache_lookup(js, mod->resolved_path);
-    if (vtype(entry) != kTypeUndefined) return js_get(js, entry, "exports");
+    if (vtype(entry) != kTypeUndefined) return esm_require_cached_exports(js, entry);
   }
   if (!mod->embedded_code) {
     switch (mod->kind) {
@@ -1728,7 +1782,7 @@ static ant_value_t esm_load_static_dependency(
       }
     }
     free(specifier);
-    return esm_load_module(js, dep);
+    return esm_load_module(js, dep, js_mkundef());
   }
 
   bool loaded = false;
@@ -1763,7 +1817,7 @@ static ant_value_t esm_load_static_dependency(
     }
   }
 
-  ant_value_t result = esm_load_module(js, dep);
+  ant_value_t result = esm_load_module(js, dep, js_mkundef());
   free(resolved_path);
   free(specifier);
   return result;
@@ -1790,7 +1844,7 @@ static ant_value_t esm_instantiate_static_dependencies(
   return js_mkundef();
 }
 
-static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
+static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod, ant_value_t require_module) {
   if (mod->is_loaded) return mod->namespace_obj;
   if (mod->is_loading) return mod->namespace_obj;
 
@@ -1800,7 +1854,7 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
     case ESM_MODULE_KIND_JSON:
     case ESM_MODULE_KIND_TEXT:
     case ESM_MODULE_KIND_IMAGE:
-      return esm_complete_value_module(js, mod, esm_load_value_module(js, mod));
+      return esm_complete_value_module(js, mod, esm_load_value_module(js, mod, require_module), require_module);
     case ESM_MODULE_KIND_NATIVE: {
       ant_value_t ns = esm_make_namespace_object(js);
       mod->namespace_obj = ns;
@@ -1812,7 +1866,7 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
       }
       
       js_module_ctx_link_namespace(js, module_ctx, ns);
-      ant_value_t native_exports = napi_load_native_module(js, mod->resolved_path, ns);
+      ant_value_t native_exports = napi_load_native_module(js, mod->resolved_path, ns, require_module);
       
       if (is_err(native_exports)) {
         mod->is_loading = false;
@@ -1947,7 +2001,7 @@ static ant_value_t esm_load_module(ant_t *js, esm_module_t *mod) {
     ? esm_eval_parsed_record(js, &record, js_code, js_len)
     : esm_eval_module_with_format(
       js, mod->resolved_path, js_code,
-      js_len, ns, &mod->format
+      js_len, ns, &mod->format, require_module
     );
 
   free(content);
@@ -1990,7 +2044,7 @@ ant_value_t esm_get_or_load_ex(
     );
     if (!mod) return js_mkerr(js, "Cannot create module");
   }
-  return esm_load_module(js, mod);
+  return esm_load_module(js, mod, js_mkundef());
 }
 
 bool js_esm_bundle_active(ant_t *js) {
@@ -2228,47 +2282,53 @@ ant_value_t js_esm_import_sync_cstr_from_require(
   if (existing && (existing->is_loaded || existing->is_loading) &&
       (existing->format == MODULE_EVAL_FORMAT_CJS || existing->kind == ESM_MODULE_KIND_JSON ||
        existing->kind == ESM_MODULE_KIND_NATIVE)) {
-    size_t size = strlen(resolved_path) + 80;
-    reload_key = malloc(size);
+    // Reload through a temporary record to preserve existing import namespaces.
+    unsigned long long generation = (unsigned long long)++js->modules.cjs.generation;
+    int length = snprintf(NULL, 0, "ant:require:%llu:%s", generation, resolved_path);
+    size_t size = length < 0 ? 0 : (size_t)length + 1;
+    reload_key = size ? malloc(size) : NULL;
     if (!reload_key) {
       free(resolved_path);
       free(spec_copy);
       return js_mkerr(js, "Cannot allocate require cache key");
     }
-    snprintf(reload_key, size, "ant:require:%llu:%s", (unsigned long long)++js->modules.cjs.generation, resolved_path);
+    snprintf(reload_key, size, "ant:require:%llu:%s", generation, resolved_path);
   }
 
   const char *module_key = reload_key ? reload_key : resolved_path;
-  ant_value_t ns = esm_get_or_load(
-    js, spec_copy, resolved_path, module_key,
-    MODULE_EVAL_FORMAT_UNKNOWN, NULL, 0
-  );
-
-  esm_module_t *loaded_mod = esm_find_module(js, module_key);
   GC_ROOT_SAVE(mark, js);
+  ant_value_t entry = esm_create_cjs_module(js, resolved_path, js->modules.cjs.parent);
+  GC_ROOT_PIN(js, entry);
+  ant_value_t ns = entry;
   GC_ROOT_PIN(js, ns);
-  if (!is_err(ns) && loaded_mod && loaded_mod->format == MODULE_EVAL_FORMAT_ESM) {
+  esm_module_t *loaded_mod = NULL;
+  if (is_err(entry)) goto require_done;
+  ns = esm_require_cache_store(js, resolved_path, entry);
+  if (is_err(ns)) {
+    esm_cjs_update_children(js, js->modules.cjs.parent, entry, true);
+    goto require_done;
+  }
+
+  loaded_mod = esm_find_module(js, module_key);
+  if (!loaded_mod) loaded_mod = esm_create_module(
+    js, spec_copy, resolved_path, module_key,
+    MODULE_EVAL_FORMAT_UNKNOWN, NULL, 0, false, ESM_MODULE_KIND_NONE
+  );
+  ns = loaded_mod ? esm_load_module(js, loaded_mod, entry) : js_mkerr(js, "Cannot create module");
+  if (is_err(ns)) {
+    js_delete_prop(js, esm_require_cache(js), resolved_path, strlen(resolved_path));
+    esm_cjs_update_children(js, js->modules.cjs.parent, entry, true);
+  } else if (loaded_mod && loaded_mod->format == MODULE_EVAL_FORMAT_ESM) {
     ant_value_t exports = esm_require_esm_exports(js, ns);
-    GC_ROOT_PIN(js, exports);
-    ant_value_t entry = esm_create_cjs_module(js, resolved_path, js->modules.cjs.parent);
-    GC_ROOT_PIN(js, entry);
     js_set(js, entry, "exports", exports);
     js_set(js, entry, "loaded", js_true);
-    js_set(js, esm_require_cache(js), resolved_path, entry);
     ns = esm_require_namespace(js, exports);
+  } else if (js_get(js, entry, "loaded") != js_true) {
+    js_set(js, entry, "exports", esm_require_unwrap(js, ns));
+    js_set(js, entry, "loaded", js_true);
   }
-  if (reload_key && loaded_mod) {
-    ant_esm_state_t *st = js->modules.state;
-    if (st->last_tla_module == loaded_mod) st->last_tla_module = NULL;
-    HASH_DEL(st->modules, loaded_mod);
-    st->module_count--;
-    free(loaded_mod->path);
-    free(loaded_mod->cache_key);
-    free(loaded_mod->resolved_path);
-    free(loaded_mod->url_content);
-    if (loaded_mod->owns_embedded) free((void *)loaded_mod->embedded_code);
-    free(loaded_mod);
-  }
+require_done:
+  if (reload_key && loaded_mod) esm_remove_module(js->modules.state, loaded_mod);
   free(reload_key);
   GC_ROOT_RESTORE(js, mark);
 

--- a/src/esm/loader.c
+++ b/src/esm/loader.c
@@ -459,6 +459,42 @@ static ant_value_t esm_make_namespace_object(ant_t *js) {
   return ns;
 }
 
+static ant_value_t esm_require_export_getter(ant_t *js, ant_value_t *args, int nargs) {
+  ant_value_t data = js_get_slot(js_getcurrentfunc(js), SLOT_DATA);
+  return js_get(js, js_arr_get(js, data, 0), js_getstr(js, js_arr_get(js, data, 1), NULL));
+}
+
+static ant_value_t esm_require_esm_exports(ant_t *js, ant_value_t ns) {
+  ant_value_t special;
+  if (js_try_get_own_data_prop(js, ns, "module.exports", 14, &special)) return special;
+  ant_value_t def;
+  if (!js_try_get_own_data_prop(js, ns, "default", 7, &def) ||
+      js_try_get_own_data_prop(js, ns, "__esModule", 10, &special)) return ns;
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, ns);
+  ant_value_t wrapper = esm_make_namespace_object(js);
+  GC_ROOT_PIN(js, wrapper);
+  js_set_proto_init(wrapper, js_mknull());
+  ant_value_t keys = js_own_property_keys(js, ns, false, true);
+  GC_ROOT_PIN(js, keys);
+  ant_value_t data = js_mkundef();
+  GC_ROOT_PIN(js, data);
+  for (ant_offset_t i = 0; i < js_arr_len(js, keys); i++) {
+    ant_value_t key = js_arr_get(js, keys, i);
+    if (vtype(key) != kTypeString) continue;
+    data = js_mkarr(js);
+    js_arr_push(js, data, ns);
+    js_arr_push(js, data, key);
+    size_t len;
+    const char *name = js_getstr(js, key, &len);
+    js_set_getter_desc(js, wrapper, name, len, js_heavy_mkfun(js, esm_require_export_getter, data), JS_DESC_E);
+  }
+  js_set(js, wrapper, "__esModule", js_true);
+  js_set_slot(wrapper, SLOT_MODULE_LOADING, js_mkundef());
+  GC_ROOT_RESTORE(js, mark);
+  return wrapper;
+}
+
 static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_value_t value) {
   if (is_err(value)) {
     mod->is_loading = false;
@@ -489,6 +525,17 @@ static ant_value_t esm_complete_value_module(ant_t *js, esm_module_t *mod, ant_v
 
   js_set(js, ns, "default", value);
   js_set_slot(ns, SLOT_DEFAULT, value);
+
+  if (mod->kind == ESM_MODULE_KIND_JSON) {
+    ant_value_t entry = esm_require_cache_lookup(js, mod->resolved_path);
+    if (vtype(entry) == kTypeUndefined) {
+      entry = esm_create_cjs_module(js, mod->resolved_path, js->modules.cjs.parent);
+      GC_ROOT_PIN(js, entry);
+      js_set(js, entry, "exports", value);
+      js_set(js, entry, "loaded", js_true);
+      js_set(js, esm_require_cache(js), mod->resolved_path, entry);
+    }
+  }
 
   mod->namespace_obj = ns;
   mod->default_export = value;
@@ -756,7 +803,7 @@ static char *esm_resolve_exports_target(
   }
 
   if (yyjson_is_obj(target)) {
-    ant_esm_state_t *st = js ? js->esm.state : NULL;
+    ant_esm_state_t *st = js ? js->modules.state : NULL;
     if (st && st->active_conditions) {
       for (int i = 0; i < st->active_condition_count; i++) {
         yyjson_val *cond_target = yyjson_obj_get(target, st->active_conditions[i]);
@@ -1059,7 +1106,7 @@ static char *esm_resolve_relative_path(ant_t *js, const char *specifier, const c
 static char *esm_resolve_path_cond_uncached(ant_t *js, const char *specifier, const char *base_path, bool prefer_require) {
   if (!specifier || !specifier[0]) return NULL;
 
-  const ant_bundle_t *vfs = js && js->esm.state ? js->esm.state->bundle : NULL;
+  const ant_bundle_t *vfs = js && js->modules.state ? js->modules.state->bundle : NULL;
   if (vfs) {
     const char *hit = ant_bundle_resolve(vfs, base_path, specifier, prefer_require);
     if (hit) return strdup(hit);
@@ -1083,7 +1130,7 @@ static char *esm_resolve_path_cond_uncached(ant_t *js, const char *specifier, co
 }
 
 static char *esm_resolve_path_cond(ant_t *js, const char *specifier, const char *base_path, bool prefer_require) {
-  ant_esm_state_t *st = js ? js->esm.state : NULL;
+  ant_esm_state_t *st = js ? js->modules.state : NULL;
   if (st && st->active_conditions)
     return esm_resolve_path_cond_uncached(js, specifier, base_path, prefer_require);
 
@@ -1231,13 +1278,13 @@ static ant_value_t esm_eval_ambiguous_js_source(
     js->thrown_value = saved_thrown_value;
     js->thrown_stack = saved_thrown_stack;
     *format = MODULE_EVAL_FORMAT_CJS;
-    if (js->esm.module_stack) js->esm.module_stack->format = *format;
+    if (js->modules.module_stack) js->modules.module_stack->format = *format;
     return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns);
   }
 
   if (program->flags & FN_MODULE_SYNTAX) {
     *format = MODULE_EVAL_FORMAT_ESM;
-    if (js->esm.module_stack) js->esm.module_stack->format = *format;
+    if (js->modules.module_stack) js->modules.module_stack->format = *format;
     
     sv_func_t *func = js_compile_parsed_bytecode(
       js, program, js_code, 
@@ -1254,7 +1301,7 @@ static ant_value_t esm_eval_ambiguous_js_source(
 
   parse_arena_rewind(parse_mark);
   *format = MODULE_EVAL_FORMAT_CJS;
-  if (js->esm.module_stack) js->esm.module_stack->format = *format;
+  if (js->modules.module_stack) js->modules.module_stack->format = *format;
   return esm_load_commonjs_module(js, resolved_path, js_code, js_len, ns);
 }
 
@@ -1282,7 +1329,7 @@ ant_value_t js_esm_eval_module_source(
   
   ant_value_t prep_res = esm_prepare_eval_ctx(
     js, resolved_path, ns, format, 
-    js->esm.module_stack == NULL, NULL, &eval_ctx
+    js->modules.module_stack == NULL, NULL, &eval_ctx
   );
   
   if (is_err(prep_res)) return prep_res;
@@ -1312,7 +1359,7 @@ esm_module_kind_t esm_classify_kind_for_path(const char *resolved_path) {
 }
 
 esm_module_t *esm_find_module(ant_t *js, const char *module_key) {
-  ant_esm_state_t *st = js->esm.state;
+  ant_esm_state_t *st = js->modules.state;
   if (!st) return NULL;
 
   char *cache_key = esm_make_cache_key(module_key);
@@ -1403,7 +1450,7 @@ static esm_module_t *esm_create_module(
 }
 
 void js_esm_cleanup_module_cache(ant_t *js) {
-  ant_esm_state_t *st = js ? js->esm.state : NULL;
+  ant_esm_state_t *st = js ? js->modules.state : NULL;
   if (st) {
     esm_module_t *current, *tmp;
     HASH_ITER(hh, st->modules, current, tmp) {
@@ -1491,6 +1538,10 @@ static ant_value_t esm_load_image(ant_t *js, const char *path) {
 }
 
 static ant_value_t esm_load_value_module(ant_t *js, esm_module_t *mod) {
+  if (mod->kind == ESM_MODULE_KIND_JSON) {
+    ant_value_t entry = esm_require_cache_lookup(js, mod->resolved_path);
+    if (vtype(entry) != kTypeUndefined) return js_get(js, entry, "exports");
+  }
   if (!mod->embedded_code) {
     switch (mod->kind) {
       case ESM_MODULE_KIND_JSON: return esm_load_json(js, mod->resolved_path);
@@ -1541,7 +1592,7 @@ static void esm_handle_module_promise(
 ) {
   if (vtype(result) != kTypePromise) return;
 
-  ant_esm_state_t *state = js->esm.state;
+  ant_esm_state_t *state = js->modules.state;
   if (!state || state->dynamic_import_depth <= 0) {
     js_run_event_loop(js);
     return;
@@ -1943,7 +1994,7 @@ ant_value_t esm_get_or_load_ex(
 }
 
 bool js_esm_bundle_active(ant_t *js) {
-  return js && js->esm.state && js->esm.state->bundle;
+  return js && js->modules.state && js->modules.state->bundle;
 }
 
 bool js_esm_bundle_activate(ant_t *js, const struct ant_bundle *bundle) {
@@ -2110,6 +2161,17 @@ ant_value_t js_esm_import_sync_cstr_from_require(
     spec_len = strlen(spec_copy);
   }
 
+  bool bare_builtin = !strchr(spec_copy, ':') &&
+    (js_esm_is_registered_library(spec_copy, spec_len) || esm_lookup_builtin_alias(spec_copy, spec_len));
+  if (bare_builtin) {
+    ant_value_t cached = esm_require_cache_lookup(js, spec_copy);
+    if (is_err(cached) || vtype(cached) != kTypeUndefined) {
+      ant_value_t exports = is_err(cached) ? cached : esm_require_cached_exports(js, cached);
+      free(spec_copy);
+      return is_err(exports) ? exports : esm_require_namespace(js, exports);
+    }
+  }
+
   bundle = esm_lookup_builtin_alias(spec_copy, spec_len);
   if (bundle) {
     module = esm_lookup_builtin_module(bundle->module_id);
@@ -2146,50 +2208,69 @@ ant_value_t js_esm_import_sync_cstr_from_require(
     return err;
   }
 
-  ant_value_t cached = js_get(js, esm_require_cache(js), resolved_path);
+  ant_value_t cached = esm_require_cache_lookup(js, resolved_path);
   if (is_err(cached)) {
     free(resolved_path);
     free(spec_copy);
     return cached;
   }
   
-  if (is_object_type(cached)) {
-    ant_value_t exports = js_get(js, cached, "exports");
-    ant_value_t ns = is_err(exports) ? exports : esm_make_namespace_object(js);
-    if (!is_err(exports)) {
-      js_set_slot_wb(js, ns, SLOT_DEFAULT, exports);
-      setprop_cstr(js, ns, "default", 7, exports);
-    }
+  if (vtype(cached) != kTypeUndefined) {
+    esm_cjs_update_children(js, js->modules.cjs.parent, cached, false);
+    ant_value_t exports = esm_require_cached_exports(js, cached);
     free(resolved_path);
     free(spec_copy);
-    return ns;
+    return is_err(exports) ? exports : esm_require_namespace(js, exports);
   }
 
   esm_module_t *existing = esm_find_module(js, resolved_path);
-  if (existing && existing->is_loaded &&
-      (existing->format == MODULE_EVAL_FORMAT_CJS || existing->kind == ESM_MODULE_KIND_JSON)) {
-    existing->is_loaded = false;
-    existing->namespace_obj = js_mkundef();
-    existing->default_export = js_mkundef();
+  char *reload_key = NULL;
+  if (existing && (existing->is_loaded || existing->is_loading) &&
+      (existing->format == MODULE_EVAL_FORMAT_CJS || existing->kind == ESM_MODULE_KIND_JSON ||
+       existing->kind == ESM_MODULE_KIND_NATIVE)) {
+    size_t size = strlen(resolved_path) + 80;
+    reload_key = malloc(size);
+    if (!reload_key) {
+      free(resolved_path);
+      free(spec_copy);
+      return js_mkerr(js, "Cannot allocate require cache key");
+    }
+    snprintf(reload_key, size, "ant:require:%llu:%s", (unsigned long long)++js->modules.cjs.generation, resolved_path);
   }
 
+  const char *module_key = reload_key ? reload_key : resolved_path;
   ant_value_t ns = esm_get_or_load(
-    js, spec_copy,
-    resolved_path,
-    resolved_path,
-    MODULE_EVAL_FORMAT_UNKNOWN,
-    NULL, 0
+    js, spec_copy, resolved_path, module_key,
+    MODULE_EVAL_FORMAT_UNKNOWN, NULL, 0
   );
-  
-  esm_module_t *loaded_mod = esm_find_module(js, resolved_path);
-  if (!is_err(ns) && loaded_mod && loaded_mod->kind == ESM_MODULE_KIND_JSON) {
-    ant_value_t entry = js_mkobj(js);
-    js_set(js, entry, "id", js_mkstr(js, resolved_path, strlen(resolved_path)));
-    js_set(js, entry, "filename", js_mkstr(js, resolved_path, strlen(resolved_path)));
-    js_set(js, entry, "exports", js_get_slot(ns, SLOT_DEFAULT));
+
+  esm_module_t *loaded_mod = esm_find_module(js, module_key);
+  GC_ROOT_SAVE(mark, js);
+  GC_ROOT_PIN(js, ns);
+  if (!is_err(ns) && loaded_mod && loaded_mod->format == MODULE_EVAL_FORMAT_ESM) {
+    ant_value_t exports = esm_require_esm_exports(js, ns);
+    GC_ROOT_PIN(js, exports);
+    ant_value_t entry = esm_create_cjs_module(js, resolved_path, js->modules.cjs.parent);
+    GC_ROOT_PIN(js, entry);
+    js_set(js, entry, "exports", exports);
     js_set(js, entry, "loaded", js_true);
     js_set(js, esm_require_cache(js), resolved_path, entry);
+    ns = esm_require_namespace(js, exports);
   }
+  if (reload_key && loaded_mod) {
+    ant_esm_state_t *st = js->modules.state;
+    if (st->last_tla_module == loaded_mod) st->last_tla_module = NULL;
+    HASH_DEL(st->modules, loaded_mod);
+    st->module_count--;
+    free(loaded_mod->path);
+    free(loaded_mod->cache_key);
+    free(loaded_mod->resolved_path);
+    free(loaded_mod->url_content);
+    if (loaded_mod->owns_embedded) free((void *)loaded_mod->embedded_code);
+    free(loaded_mod);
+  }
+  free(reload_key);
+  GC_ROOT_RESTORE(js, mark);
 
   free(resolved_path);
   free(spec_copy);
@@ -2309,7 +2390,7 @@ ant_value_t js_esm_make_file_url(ant_t *js, const char *path) {
 }
 
 void gc_mark_esm(ant_t *js, gc_mark_fn mark) {
-ant_esm_state_t *st = js->esm.state;
+ant_esm_state_t *st = js->modules.state;
 if (!st) return;
 
 esm_module_t *mod = NULL, *tmp = NULL;
@@ -2359,7 +2440,7 @@ ant_value_t js_esm_resolve_specifier(ant_t *js, ant_value_t specifier, const cha
     return result;
   }
 
-  const ant_bundle_t *vfs = js && js->esm.state ? js->esm.state->bundle : NULL;
+  const ant_bundle_t *vfs = js && js->modules.state ? js->modules.state->bundle : NULL;
   const char *materialized = vfs ? ant_bundle_materialized_path(vfs, resolved_path) : NULL;
   
   ant_value_t result = js_esm_make_file_url(js, materialized ? materialized : resolved_path);
@@ -2410,7 +2491,7 @@ ant_value_t js_esm_resolve_specifier_require(ant_t *js, ant_value_t specifier, c
     return result;
   }
 
-  const ant_bundle_t *vfs = js && js->esm.state ? js->esm.state->bundle : NULL;
+  const ant_bundle_t *vfs = js && js->modules.state ? js->modules.state->bundle : NULL;
   const char *materialized = vfs ? ant_bundle_materialized_path(vfs, resolved_path) : NULL;
   
   ant_value_t result = js_esm_make_file_url(js, materialized ? materialized : resolved_path);

--- a/src/esm/loader_cache.c
+++ b/src/esm/loader_cache.c
@@ -42,12 +42,12 @@ typedef struct esm_package_dir_cache_entry {
 
 ant_esm_state_t *esm_state(ant_t *js) {
   if (!js) return NULL;
-  if (js->esm.state) return js->esm.state;
+  if (js->modules.state) return js->modules.state;
 
   ant_esm_state_t *st = calloc(1, sizeof(*st));
   if (!st) return NULL;
 
-  js->esm.state = st;
+  js->modules.state = st;
   return st;
 }
 
@@ -269,7 +269,7 @@ yyjson_doc *esm_package_json_cache_read(ant_t *js, const char *pkg_json_path, bo
 }
 
 void esm_loader_cache_cleanup(ant_t *js) {
-  ant_esm_state_t *st = js ? js->esm.state : NULL;
+  ant_esm_state_t *st = js ? js->modules.state : NULL;
   if (!st) return;
 
   esm_package_json_cache_entry_t *pkg_current, *pkg_tmp;
@@ -313,5 +313,5 @@ void esm_loader_cache_cleanup(ant_t *js) {
   }
 
   free(st);
-  js->esm.state = NULL;
+  js->modules.state = NULL;
 }

--- a/src/esm/loader_internal.h
+++ b/src/esm/loader_internal.h
@@ -54,6 +54,7 @@ const char *esm_default_base_path(ant_t *js);
 
 char *esm_path_to_file_url(const char *path);
 char *esm_make_absolute_path(const char *path);
+char *esm_path_dirname(const char *path);
 char *esm_file_url_to_path(ant_t *js, const char *specifier);
 char *esm_resolve_path(ant_t *js, const char *specifier, const char *base_path);
 char *esm_resolve_path_require(ant_t *js, const char *specifier, const char *base_path);
@@ -61,6 +62,7 @@ char *esm_resolve_path_require(ant_t *js, const char *specifier, const char *bas
 ant_module_format_t esm_decide_module_format(ant_t *js, const char *resolved_path);
 esm_module_kind_t esm_classify_kind_for_path(const char *resolved_path);
 esm_module_t *esm_find_module(ant_t *js, const char *module_key);
+ant_value_t esm_node_module_paths(ant_t *js, const char *directory);
 
 ant_value_t esm_read_file(
   ant_t *js,

--- a/src/gc/objects.c
+++ b/src/gc/objects.c
@@ -804,9 +804,12 @@ static void gc_mark_roots(ant_t *js) {
   for (size_t i = 0; i < ANT_PRIMORDIAL_COUNT; i++)
     gc_mark_value(js, js->primordial_values[i]);
   
-  gc_mark_value(js, js->esm.require_cache);
-  gc_mark_value(js, js->esm.hooks);
-  gc_mark_value(js, js->esm.import_meta);
+  gc_mark_value(js, js->modules.cjs.cache);
+  gc_mark_value(js, js->modules.cjs.parent);
+  gc_mark_value(js, js->modules.cjs.main);
+  gc_mark_value(js, js->modules.cjs.constructor);
+  gc_mark_value(js, js->modules.hooks);
+  gc_mark_value(js, js->modules.import_meta);
   
   gc_mark_value(js, js->sym.object_proto);
   gc_mark_value(js, js->sym.array_proto);
@@ -829,7 +832,7 @@ static void gc_mark_roots(ant_t *js) {
   gc_mark_value(js, js->thrown_stack);
   gc_mark_value(js, js->length_str);
 
-  for (ant_module_t *ctx = js->esm.module_stack; ctx; ctx = ctx->prev) {
+  for (ant_module_t *ctx = js->modules.module_stack; ctx; ctx = ctx->prev) {
     gc_mark_value(js, ctx->module_ns);
     gc_mark_value(js, ctx->module_ctx);
     gc_mark_value(js, ctx->prev_import_meta_prop);

--- a/src/main.c
+++ b/src/main.c
@@ -307,7 +307,7 @@ static void eval_code(
     result = js_eval_bytecode(js, script, len);
   } else {
     ant_value_t ns = js_mkobj(js);
-    result = is_err(ns) ? ns : esm_load_commonjs_module(js, tag, script, len, ns);
+    result = is_err(ns) ? ns : esm_load_commonjs_module(js, tag, script, len, ns, js_mkundef());
   }
   
   js_run_event_loop(js);

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -161,11 +161,14 @@ static ant_value_t builtin_module_constructor(ant_t *js, ant_value_t *args, int 
 ant_value_t module_library(ant_t *js) {
   if (is_object_type(js->modules.cjs.constructor)) return js->modules.cjs.constructor;
   ant_value_t cache = esm_require_cache(js);
+  GC_ROOT_SAVE(root_mark, js);
   ant_value_t proto = js_mkobj(js);
+  GC_ROOT_PIN(js, proto);
   
   js_set_proto_init(proto, js->sym.object_proto);
   ant_value_t lib = js_make_ctor(js, builtin_module_constructor, proto, "Module", 6);
   js->modules.cjs.constructor = lib;
+  GC_ROOT_RESTORE(js, root_mark);
   
   js_set(js, lib, "_cache", cache);
   js->modules.cjs.cache = js_mkundef();

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -21,31 +21,6 @@ static void push_builtin_name(const char *name, void *ud) {
   js_arr_push(ctx->js, ctx->arr, js_mkstr(ctx->js, name, strlen(name)));
 }
 
-static ant_value_t builtin_createRequire_call(ant_t *js, ant_value_t *args, int nargs) {
-  if (nargs < 1 || vtype(args[0]) != kTypeString)
-    return js_mkerr(js, "require() expects a string specifier");
-
-  ant_value_t fn = js_getcurrentfunc(js);
-  ant_value_t data = js_get_slot(fn, SLOT_DATA);
-  const char *base_path = js_module_eval_active_filename(js);
-
-  if (vtype(data) == kTypeString) {
-    ant_offset_t plen = 0;
-    ant_offset_t poff = vstr(js, data, &plen);
-    base_path = (const char *)(uintptr_t)(poff);
-  }
-
-  ant_value_t ns = js_esm_import_sync_from_require(js, args[0], base_path);
-  if (is_err(ns)) return ns;
-
-  if (vtype(ns) == kTypeObject) {
-    ant_value_t default_export = js_get_slot(ns, SLOT_DEFAULT);
-    if (vtype(default_export) != kTypeUndefined) return default_export;
-  }
-  
-  return ns;
-}
-
 static ant_value_t resolve_strip_file_url(ant_t *js, ant_value_t resolved) {
   if (is_err(resolved) || vtype(resolved) != kTypeString) return resolved;
 
@@ -126,12 +101,25 @@ static ant_value_t builtin_createRequire(ant_t *js, ant_value_t *args, int nargs
     path_len -= prefix_len;
   }
 
+  GC_ROOT_SAVE(mark, js);
   ant_value_t path_val = js_mkstr(js, path, path_len);
-  ant_value_t require_fn = js_heavy_mkfun(js, builtin_createRequire_call, path_val);
+  
+  GC_ROOT_PIN(js, path_val);
+  ant_value_t parent = esm_create_cjs_module(js, path, js_mkundef());
+  
+  GC_ROOT_PIN(js, parent);
+  ant_value_t require_fn = js_heavy_mkfun(js, esm_cjs_require_module, parent);
+  
+  GC_ROOT_PIN(js, require_fn);
   ant_value_t resolve_fn = js_heavy_mkfun(js, builtin_createRequire_resolve, path_val);
+  
+  GC_ROOT_PIN(js, resolve_fn);
+  js_set(js, resolve_fn, "paths", js_heavy_mkfun(js, esm_cjs_require_paths, path_val));
   js_set(js, require_fn, "resolve", resolve_fn);
   js_set(js, require_fn, "cache", esm_require_cache(js));
+  js_set(js, require_fn, "main", js->modules.cjs.main);
 
+  GC_ROOT_RESTORE(js, mark);
   return require_fn;
 }
 
@@ -180,17 +168,17 @@ static ant_value_t builtin_module_isBuiltin(ant_t *js, ant_value_t *args, int na
 static ant_value_t builtin_module_deregisterHooks(ant_t *js, ant_value_t *args, int nargs) {
   ant_value_t self = js_getcurrentfunc(js);
   ant_value_t hook = js_get_slot(self, SLOT_DATA);
-  if (vtype(hook) == kTypeUndefined || vtype(js->esm.hooks) != kTypeArray) return js_mkundef();
+  if (vtype(hook) == kTypeUndefined || vtype(js->modules.hooks) != kTypeArray) return js_mkundef();
 
   GC_ROOT_SAVE(root_mark, js);
   ant_value_t remaining = js_mkarr(js);
   GC_ROOT_PIN(js, remaining);
 
-  ant_offset_t len = js_arr_len(js, js->esm.hooks);
+  ant_offset_t len = js_arr_len(js, js->modules.hooks);
   bool removed = false;
 
   for (ant_offset_t i = 0; i < len; i++) {
-    ant_value_t entry = js_arr_get(js, js->esm.hooks, i);
+    ant_value_t entry = js_arr_get(js, js->modules.hooks, i);
     if (!removed && entry == hook) {
       removed = true;
       continue;
@@ -198,7 +186,7 @@ static ant_value_t builtin_module_deregisterHooks(ant_t *js, ant_value_t *args, 
     js_arr_push(js, remaining, entry);
   }
 
-  js->esm.hooks = remaining;
+  js->modules.hooks = remaining;
   js_set_slot(self, SLOT_DATA, js_mkundef());
 
   GC_ROOT_RESTORE(js, root_mark);
@@ -223,8 +211,8 @@ static ant_value_t builtin_module_registerHooks(ant_t *js, ant_value_t *args, in
   if (hook_member_invalid(load_fn))
     return js_mkerr_typed(js, JS_ERR_TYPE, "The 'load' hook must be a function");
 
-  if (vtype(js->esm.hooks) != kTypeArray) js->esm.hooks = js_mkarr(js);
-  js_arr_push(js, js->esm.hooks, args[0]);
+  if (vtype(js->modules.hooks) != kTypeArray) js->modules.hooks = js_mkarr(js);
+  js_arr_push(js, js->modules.hooks, args[0]);
 
   GC_ROOT_SAVE(root_mark, js);
   ant_value_t dereg_obj = js_mkobj(js);
@@ -240,9 +228,27 @@ static ant_value_t builtin_module_registerHooks(ant_t *js, ant_value_t *args, in
   return out;
 }
 
+static ant_value_t builtin_module_constructor(ant_t *js, ant_value_t *args, int nargs) {
+  const char *id = nargs && vtype(args[0]) == kTypeString ? js_getstr(js, args[0], NULL) : "";
+  ant_value_t obj = esm_create_cjs_module(js, id, nargs > 1 ? args[1] : js_mkundef());
+  js_set(js, obj, "filename", js_mknull());
+  js_delete_prop(js, obj, "paths", 5);
+  return obj;
+}
+
 ant_value_t module_library(ant_t *js) {
-  ant_value_t lib = js_mkobj(js);
+  if (is_object_type(js->modules.cjs.constructor)) return js->modules.cjs.constructor;
+  ant_value_t cache = esm_require_cache(js);
+  ant_value_t proto = js_mkobj(js);
   
+  js_set_proto_init(proto, js->sym.object_proto);
+  ant_value_t lib = js_make_ctor(js, builtin_module_constructor, proto, "Module", 6);
+  js->modules.cjs.constructor = lib;
+  
+  js_set(js, lib, "_cache", cache);
+  js_set(js, lib, "Module", lib);
+  js_set(js, proto, "require", js_mkfun(esm_cjs_require_module));
+
   js_set(js, lib, "createRequire", js_mkfun(builtin_createRequire));
   js_set(js, lib, "registerHooks", js_mkfun(builtin_module_registerHooks));
   js_set(js, lib, "isBuiltin", js_mkfun(builtin_module_isBuiltin));

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -39,88 +39,10 @@ static ant_value_t resolve_strip_file_url(ant_t *js, ant_value_t resolved) {
   return resolved;
 }
 
-// require.resolve(specifier, options?)
-static ant_value_t builtin_createRequire_resolve(ant_t *js, ant_value_t *args, int nargs) {
-  if (nargs < 1 || vtype(args[0]) != kTypeString)
-    return js_mkerr(js, "require.resolve() expects a string specifier");
-
-  ant_value_t fn = js_getcurrentfunc(js);
-  ant_value_t data = js_get_slot(fn, SLOT_DATA);
-  const char *base_path = js_module_eval_active_filename(js);
-
-  if (vtype(data) == kTypeString) {
-    ant_offset_t dlen = 0;
-    ant_offset_t doff = vstr(js, data, &dlen);
-    base_path = (const char *)(uintptr_t)(doff);
-  }
-
-  ant_value_t paths_val = (nargs >= 2 && is_object_type(args[1]))
-    ? js_get(js, args[1], "paths") : js_mkundef();
-
-  if (vtype(paths_val) != kTypeArray) {
-    ant_value_t resolved = js_esm_resolve_specifier_require(js, args[0], base_path);
-    return resolve_strip_file_url(js, resolved);
-  }
-
-  ant_offset_t path_count = js_arr_len(js, paths_val);
-  for (ant_offset_t i = 0; i < path_count; i++) {
-    ant_value_t p = js_arr_get(js, paths_val, i);
-    if (vtype(p) != kTypeString) continue;
-    
-    char *dir = js_getstr(js, p, NULL);
-    if (!dir) continue;
-    
-    ant_value_t resolved = js_esm_resolve_specifier_require(js, args[0], dir);
-    if (!is_err(resolved) && vtype(resolved) == kTypeString)
-      return resolve_strip_file_url(js, resolved);
-  }
-
-  return js_mkerr(js, "Cannot resolve module");
-}
-
-// createRequire(filename)
 static ant_value_t builtin_createRequire(ant_t *js, ant_value_t *args, int nargs) {
-  if (nargs < 1) return js_mkerr(js, "createRequire() requires a filename argument");
-
-  ant_value_t filename_val = args[0];
-  if (vtype(filename_val) != kTypeString)
-    return js_mkerr(js, "createRequire() filename must be a string");
-
-  size_t fname_len;
-  char *fname = js_getstr(js, filename_val, &fname_len);
-  if (!fname) return js_mkerr(js, "createRequire() invalid filename");
-
-  const char *path = fname;
-  size_t path_len = fname_len;
-  
-  static const char *file_prefix = "file://";
-  size_t prefix_len = strlen(file_prefix);
-
-  if (path_len >= prefix_len && strncmp(path, file_prefix, prefix_len) == 0) {
-    path += prefix_len;
-    path_len -= prefix_len;
-  }
-
-  GC_ROOT_SAVE(mark, js);
-  ant_value_t path_val = js_mkstr(js, path, path_len);
-  
-  GC_ROOT_PIN(js, path_val);
-  ant_value_t parent = esm_create_cjs_module(js, path, js_mkundef());
-  
-  GC_ROOT_PIN(js, parent);
-  ant_value_t require_fn = js_heavy_mkfun(js, esm_cjs_require_module, parent);
-  
-  GC_ROOT_PIN(js, require_fn);
-  ant_value_t resolve_fn = js_heavy_mkfun(js, builtin_createRequire_resolve, path_val);
-  
-  GC_ROOT_PIN(js, resolve_fn);
-  js_set(js, resolve_fn, "paths", js_heavy_mkfun(js, esm_cjs_require_paths, path_val));
-  js_set(js, require_fn, "resolve", resolve_fn);
-  js_set(js, require_fn, "cache", esm_require_cache(js));
-  js_set(js, require_fn, "main", js->modules.cjs.main);
-
-  GC_ROOT_RESTORE(js, mark);
-  return require_fn;
+  if (nargs < 1 || vtype(args[0]) != kTypeString)
+    return js_mkerr_typed(js, JS_ERR_TYPE, "createRequire() requires a filename string");
+  return esm_create_require_from_path(js, js_getstr(js, args[0], NULL));
 }
 
 // Module._resolveFilename(request, parent)
@@ -229,11 +151,11 @@ static ant_value_t builtin_module_registerHooks(ant_t *js, ant_value_t *args, in
 }
 
 static ant_value_t builtin_module_constructor(ant_t *js, ant_value_t *args, int nargs) {
+  if (nargs && vtype(args[0]) != kTypeUndefined && vtype(args[0]) != kTypeString)
+    return js_mkerr_typed(js, JS_ERR_TYPE, "Module id must be a string");
+  if (!is_object_type(js->this_val)) return js_mkerr_typed(js, JS_ERR_TYPE, "Module requires an object receiver");
   const char *id = nargs && vtype(args[0]) == kTypeString ? js_getstr(js, args[0], NULL) : "";
-  ant_value_t obj = esm_create_cjs_module(js, id, nargs > 1 ? args[1] : js_mkundef());
-  js_set(js, obj, "filename", js_mknull());
-  js_delete_prop(js, obj, "paths", 5);
-  return obj;
+  return esm_init_cjs_module(js, js->this_val, id, nargs > 1 ? args[1] : js_mkundef());
 }
 
 ant_value_t module_library(ant_t *js) {
@@ -246,6 +168,7 @@ ant_value_t module_library(ant_t *js) {
   js->modules.cjs.constructor = lib;
   
   js_set(js, lib, "_cache", cache);
+  js->modules.cjs.cache = js_mkundef();
   js_set(js, lib, "Module", lib);
   js_set(js, proto, "require", js_mkfun(esm_cjs_require_module));
 

--- a/src/napi/loader.c
+++ b/src/napi/loader.c
@@ -22,6 +22,8 @@
 #define NAPI_DEFAULT_DLOPEN_FLAGS NAPI_RTLD_LAZY
 
 #include "napi_internal.h"
+#include "esm/commonjs.h"
+#include "gc/roots.h"
 
 static napi_native_lib_t *g_napi_native_libs = NULL;
 static napi_module *g_pending_napi_module = NULL;
@@ -109,12 +111,14 @@ ant_value_t napi_process_dlopen_js(ant_t *js, ant_value_t *args, int nargs) {
 ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_value_t ns) {
   if (!module_path) return js_mkerr(js, "native module path is null");
 
-  ant_value_t module_obj = js_mkobj(js);
-  ant_value_t exports_obj = js_mkobj(js);
-  js_set(js, module_obj, "exports", exports_obj);
-  js_set(js, module_obj, "filename", js_mkstr(js, module_path, strlen(module_path)));
-  js_set(js, module_obj, "id", js_mkstr(js, module_path, strlen(module_path)));
-  js_set(js, module_obj, "loaded", js_false);
+  GC_ROOT_SAVE(mark, js);
+  ant_value_t module_obj = esm_create_cjs_module(js, module_path, js->modules.cjs.parent);
+  
+  GC_ROOT_PIN(js, module_obj);
+  js_set(js, esm_require_cache(js), module_path, module_obj);
+  
+  ant_value_t result = js_mkundef();
+  GC_ROOT_PIN(js, result);
 
   ant_value_t process_obj = js_get(js, js_glob(js), "process");
   ant_value_t dlopen_fn = is_object_type(process_obj) ? js_get(js, process_obj, "dlopen") : js_mkundef();
@@ -122,19 +126,21 @@ ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_valu
   if (is_callable(dlopen_fn)) {
     ant_value_t argv[2] = {module_obj, js_mkstr(js, module_path, strlen(module_path))};
     ant_value_t dl_res = sv_vm_call(js->vm, js, dlopen_fn, process_obj, argv, 2, NULL, false);
-    if (is_err(dl_res) || js->thrown_exists) return js_throw(js, js->thrown_value);
+    if (is_err(dl_res) || js->thrown_exists) { result = js_throw(js, js->thrown_value); goto cleanup; }
   } else {
     ant_value_t load_res = napi_dlopen_common(js, module_obj, module_path, NAPI_DEFAULT_DLOPEN_FLAGS);
-    if (is_err(load_res)) return load_res;
+    if (is_err(load_res)) { result = load_res; goto cleanup; }
   }
 
+  js_set(js, module_obj, "loaded", js_true);
   ant_value_t exports_val = js_get(js, module_obj, "exports");
-  if (!is_object_type(ns)) return exports_val;
+  result = exports_val;
+  if (!is_object_type(ns)) goto cleanup;
 
   setprop_cstr(js, ns, "default", 7, exports_val);
   js_set_slot(ns, SLOT_DEFAULT, exports_val);
 
-  if (!is_object_type(exports_val)) return exports_val;
+  if (!is_object_type(exports_val)) goto cleanup;
   ant_iter_t iter = js_prop_iter_begin(js, exports_val);
   const char *key = NULL;
   size_t key_len = 0;
@@ -143,10 +149,15 @@ ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_valu
   while (js_prop_iter_next(&iter, &key, &key_len, &value)) {
     if (key_len == 7 && memcmp(key, "default", 7) == 0) continue;
     setprop_cstr(js, ns, key, key_len, value);
-  }
-  js_prop_iter_end(&iter);
+  } js_prop_iter_end(&iter);
 
-  return exports_val;
+cleanup:
+  if (is_err(result)) {
+    js_delete_prop(js, esm_require_cache(js), module_path, strlen(module_path));
+    esm_cjs_update_children(js, js->modules.cjs.parent, module_obj, true);
+  }
+  GC_ROOT_RESTORE(js, mark);
+  return result;
 }
 
 NAPI_EXTERN void NAPI_CDECL napi_module_register(napi_module *mod) {

--- a/src/napi/loader.c
+++ b/src/napi/loader.c
@@ -108,17 +108,21 @@ ant_value_t napi_process_dlopen_js(ant_t *js, ant_value_t *args, int nargs) {
   return js_mkundef();
 }
 
-ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_value_t ns) {
+ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_value_t ns, ant_value_t module_obj) {
   if (!module_path) return js_mkerr(js, "native module path is null");
 
   GC_ROOT_SAVE(mark, js);
-  ant_value_t module_obj = esm_create_cjs_module(js, module_path, js->modules.cjs.parent);
-  
+  bool pending = is_object_type(module_obj);
+  if (!pending) module_obj = esm_create_cjs_module(js, module_path, js->modules.cjs.parent);
+
   GC_ROOT_PIN(js, module_obj);
-  js_set(js, esm_require_cache(js), module_path, module_obj);
-  
-  ant_value_t result = js_mkundef();
+  ant_value_t result = is_err(module_obj) || pending ? module_obj : esm_require_cache_store(js, module_path, module_obj);
   GC_ROOT_PIN(js, result);
+  if (is_err(result)) {
+    if (!is_err(module_obj)) esm_cjs_update_children(js, js->modules.cjs.parent, module_obj, true);
+    GC_ROOT_RESTORE(js, mark);
+    return result;
+  }
 
   ant_value_t process_obj = js_get(js, js_glob(js), "process");
   ant_value_t dlopen_fn = is_object_type(process_obj) ? js_get(js, process_obj, "dlopen") : js_mkundef();
@@ -126,10 +130,16 @@ ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_valu
   if (is_callable(dlopen_fn)) {
     ant_value_t argv[2] = {module_obj, js_mkstr(js, module_path, strlen(module_path))};
     ant_value_t dl_res = sv_vm_call(js->vm, js, dlopen_fn, process_obj, argv, 2, NULL, false);
-    if (is_err(dl_res) || js->thrown_exists) { result = js_throw(js, js->thrown_value); goto cleanup; }
+    if (is_err(dl_res) || js->thrown_exists) {
+      result = js->thrown_exists ? js_throw(js, js->thrown_value) : dl_res;
+      goto cleanup;
+    }
   } else {
     ant_value_t load_res = napi_dlopen_common(js, module_obj, module_path, NAPI_DEFAULT_DLOPEN_FLAGS);
-    if (is_err(load_res)) { result = load_res; goto cleanup; }
+    if (is_err(load_res)) {
+      result = load_res;
+      goto cleanup;
+    }
   }
 
   js_set(js, module_obj, "loaded", js_true);
@@ -149,10 +159,11 @@ ant_value_t napi_load_native_module(ant_t *js, const char *module_path, ant_valu
   while (js_prop_iter_next(&iter, &key, &key_len, &value)) {
     if (key_len == 7 && memcmp(key, "default", 7) == 0) continue;
     setprop_cstr(js, ns, key, key_len, value);
-  } js_prop_iter_end(&iter);
+  }
+  js_prop_iter_end(&iter);
 
 cleanup:
-  if (is_err(result)) {
+  if (!pending && is_err(result)) {
     js_delete_prop(js, esm_require_cache(js), module_path, strlen(module_path));
     esm_cjs_update_children(js, js->modules.cjs.parent, module_obj, true);
   }

--- a/src/silver/ops/async.h
+++ b/src/silver/ops/async.h
@@ -80,13 +80,13 @@ static inline void sv_async_init_activation(
 }
 
 static inline ant_value_t sv_capture_tla_module_ctx(ant_t *js, coroutine_t *coro) {
-  if (!js || !coro || !js->esm.module_stack || vtype(js->esm.module_stack->module_ns) != kTypeObject)
+  if (!js || !coro || !js->modules.module_stack || vtype(js->modules.module_stack->module_ns) != kTypeObject)
     return js_mkundef();
 
   ant_module_t *ctx = calloc(1, sizeof(ant_module_t));
   if (!ctx) return js_mkerr(js, "out of memory for TLA module context");
 
-  *ctx = *js->esm.module_stack;
+  *ctx = *js->modules.module_stack;
   ctx->prev = NULL;
   ctx->prev_import_meta_prop = js_mkundef();
   coro->module_eval_ctx = ctx;

--- a/tests/test_require_cache_cleanup.cjs
+++ b/tests/test_require_cache_cleanup.cjs
@@ -1,0 +1,73 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Module = require('node:module');
+
+class DerivedModule extends Module {}
+assert(new DerivedModule('derived.cjs') instanceof DerivedModule);
+for (const id of [null, 1, false, {}]) assert.throws(() => new Module(id), TypeError);
+assert.strictEqual(new Module().filename, null);
+assert.strictEqual(Object.hasOwn(new Module(), 'paths'), false);
+
+const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ant-cache-cleanup-')));
+const requireFromTmp = Module.createRequire(path.join(tmp, 'entry.cjs'));
+const originalCache = Module._cache;
+const file = path.join(tmp, 'loaded.cjs');
+const counter = '__antCacheCleanupLoads';
+try {
+  fs.writeFileSync(file, `globalThis.${counter} = (globalThis.${counter} || 0) + 1; module.exports = 42;`);
+  assert.deepStrictEqual(requireFromTmp.resolve.paths('./child'), [tmp]);
+  assert.deepStrictEqual(requireFromTmp.resolve.paths('../child'), [tmp]);
+  assert.strictEqual(requireFromTmp.resolve.paths('node:fs'), null);
+
+  const esm = path.join(tmp, 'side-effect.mjs');
+  fs.writeFileSync(esm, `globalThis.${counter} = 1; export default 1;`);
+  Module._cache = Object.freeze({});
+  assert.throws(() => requireFromTmp(esm), TypeError);
+  assert.strictEqual(globalThis[counter], undefined, 'cache failure must precede ESM execution');
+  const sentinel = new Error('cache set failed');
+  for (const cache of [Object.freeze({}), new Proxy({}, { set() { throw sentinel; } })]) {
+    Module._cache = cache;
+    assert.throws(() => requireFromTmp(file));
+    assert.strictEqual(globalThis[counter], undefined, 'cache failure must precede module execution');
+  }
+  const inheritedReadOnly = Object.create(null);
+  Object.defineProperty(inheritedReadOnly, file, { value: undefined, writable: false });
+  Module._cache = Object.create(inheritedReadOnly);
+  assert.throws(() => requireFromTmp(file), TypeError);
+  assert.strictEqual(globalThis[counter], undefined);
+
+  let publications = 0;
+  let published;
+  const inheritedSetter = Object.create(null);
+  Object.defineProperty(inheritedSetter, file, { set(value) { publications++; published = value; } });
+  Module._cache = Object.preventExtensions(Object.create(inheritedSetter));
+  assert.strictEqual(requireFromTmp(file), 42);
+  assert.strictEqual(published.exports, 42);
+  assert.strictEqual(published.loaded, true);
+  assert.strictEqual(publications, 1);
+
+  Module._cache = originalCache;
+  const wrapper = path.join(tmp, 'wrapper.cjs');
+  fs.writeFileSync(wrapper, 'module.exports = (options) => require.resolve("fixture", options);');
+  const good = path.join(tmp, 'good');
+  const bad = path.join(tmp, 'bad');
+  fs.mkdirSync(path.join(good, 'node_modules', 'fixture'), { recursive: true });
+  fs.mkdirSync(bad);
+  const target = path.join(good, 'node_modules', 'fixture', 'index.js');
+  fs.writeFileSync(target, 'module.exports = 1;');
+  const options = { paths: [bad, good] };
+  assert.strictEqual(requireFromTmp.resolve('fixture', options), target);
+  assert.strictEqual(requireFromTmp(wrapper)(options), target);
+  assert.throws(() => requireFromTmp.resolve('missing-fixture', { paths: [bad, null] }));
+  const ancestors = requireFromTmp.resolve.paths('fixture');
+  assert.strictEqual(ancestors[0], path.join(tmp, 'node_modules'));
+  assert.strictEqual(ancestors.includes(path.join(tmp, 'node_modules', 'node_modules')), false);
+  console.log('require cache cleanup regressions passed');
+} finally {
+  Module._cache = originalCache;
+  for (const key of Object.keys(originalCache)) if (key.startsWith(tmp + path.sep)) delete originalCache[key];
+  delete globalThis[counter];
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/tests/test_require_cache_interop.mjs
+++ b/tests/test_require_cache_interop.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ant-cache-interop-')));
+const require = createRequire(path.join(tmp, 'entry.cjs'));
+const file = path.join(tmp, 'value.cjs');
+const esm = path.join(tmp, 'value.mjs');
+try {
+  fs.writeFileSync(file, 'module.exports = { value: 1 };');
+  const imported = await import(pathToFileURL(file).href);
+  assert.strictEqual(require(file), imported.default);
+  fs.writeFileSync(file, 'module.exports = { value: 2 };');
+  delete require.cache[file];
+  assert.strictEqual(require(file).value, 2);
+  assert.strictEqual(await import(pathToFileURL(file).href), imported);
+  assert.strictEqual(imported.default.value, 1);
+  const later = path.join(tmp, 'later.cjs');
+  fs.writeFileSync(later, 'module.exports = { value: 3 };');
+  const required = require(later);
+  const laterImport = await import(pathToFileURL(later).href);
+  assert.strictEqual(laterImport.default, required);
+  fs.writeFileSync(esm, 'export default 42; export const value = 7;');
+  const requiredESM = require(esm);
+  assert.strictEqual(requiredESM.default, 42);
+  assert.strictEqual(requiredESM.value, 7);
+  assert.strictEqual(requiredESM.__esModule, true);
+  assert.strictEqual(require.cache[esm].exports, requiredESM);
+  delete require.cache[esm];
+  assert.strictEqual(require(esm).default, requiredESM.default);
+  const importedESM = await import(pathToFileURL(esm).href);
+  assert.strictEqual(Object.hasOwn(importedESM, '__esModule'), false);
+  const json = path.join(tmp, 'data.json');
+  fs.writeFileSync(json, '{"value":4}');
+  const importedJSON = await import(pathToFileURL(json).href, { with: { type: 'json' } });
+  assert.strictEqual(require(json), importedJSON.default);
+  console.log('require.cache interop tests passed');
+} finally {
+  for (const key of Object.keys(require.cache)) if (key.startsWith(tmp + path.sep)) delete require.cache[key];
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/tests/test_require_cache_interop.mjs
+++ b/tests/test_require_cache_interop.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { createRequire } from 'node:module';
+import { createRequire, Module } from 'node:module';
 import { pathToFileURL } from 'node:url';
 const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ant-cache-interop-')));
 const require = createRequire(path.join(tmp, 'entry.cjs'));
@@ -36,6 +36,22 @@ try {
   fs.writeFileSync(json, '{"value":4}');
   const importedJSON = await import(pathToFileURL(json).href, { with: { type: 'json' } });
   assert.strictEqual(require(json), importedJSON.default);
+  const failingJSON = path.join(tmp, 'failing.json');
+  fs.writeFileSync(failingJSON, '{}');
+  const savedCache = Module._cache;
+  const sentinel = new Error('JSON cache lookup failed');
+  try {
+    Module._cache = new Proxy(savedCache, {
+      get(target, key) {
+        if (key === failingJSON) throw sentinel;
+        return target[key];
+      },
+    });
+    let caught;
+    try { await import(pathToFileURL(failingJSON).href, { with: { type: 'json' } }); }
+    catch (error) { caught = error; }
+    assert.strictEqual(caught, sentinel);
+  } finally { Module._cache = savedCache; }
   console.log('require.cache interop tests passed');
 } finally {
   for (const key of Object.keys(require.cache)) if (key.startsWith(tmp + path.sep)) delete require.cache[key];

--- a/tests/test_require_cache_parity.cjs
+++ b/tests/test_require_cache_parity.cjs
@@ -1,0 +1,113 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Module = require('node:module');
+const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'ant-cache-parity-')));
+const req = Module.createRequire(path.join(tmp, 'entry.cjs'));
+const write = (name, source) => {
+  const filename = path.join(tmp, name);
+  fs.writeFileSync(filename, source);
+  return filename;
+};
+try {
+  const constructedParent = new Module('/tmp/parent.cjs');
+  const constructedChild = new Module('/tmp/child.cjs', constructedParent);
+  assert(constructedChild instanceof Module);
+  assert.strictEqual(constructedChild.id, '/tmp/child.cjs');
+  assert.strictEqual(constructedChild.filename, null);
+  assert.strictEqual(constructedChild.loaded, false);
+  assert.strictEqual(constructedChild.parent, constructedParent);
+  assert.strictEqual(constructedParent.children[0], constructedChild);
+  assert.deepStrictEqual(constructedChild.exports, {});
+  assert.strictEqual(typeof constructedChild.require, 'function');
+  assert.strictEqual(Module, Module.Module);
+  assert.strictEqual(Module._cache, require.cache);
+  assert(module instanceof Module);
+  assert.strictEqual(require.cache[__filename], module);
+  assert.strictEqual(require.main, module);
+  assert.strictEqual(module.id, '.');
+  assert.strictEqual(module.loaded, false);
+  assert(Array.isArray(module.children));
+  assert(Array.isArray(module.paths));
+  assert.strictEqual(module.path, __dirname);
+  assert.strictEqual(module.require('node:fs'), fs);
+
+  assert.strictEqual(Object.keys(require.cache).some(key => key.startsWith('node:') || key.startsWith('ant:')), false);
+  assert.strictEqual(Object.getPrototypeOf(module.exports), Object.prototype);
+  const fake = {};
+  require.cache.fs = { exports: fake };
+  assert.strictEqual(require('fs'), fake);
+  assert.strictEqual(req('fs'), fake);
+  assert.strictEqual(require('node:fs'), fs);
+  delete require.cache.fs;
+  const file = write('value.cjs', 'module.exports = undefined;');
+  assert.strictEqual(req(file), undefined);
+  assert.strictEqual(req(file), undefined);
+  req.cache[file] = { exports: undefined };
+  assert.strictEqual(req(file), undefined);
+  req.cache[file] = { exports: null };
+  assert.strictEqual(req(file), null);
+  req.cache[file] = Object.create({ exports: 99 });
+  assert.strictEqual(req(file), 99);
+  req.cache[file] = null;
+  assert.throws(() => req(file), TypeError);
+  delete req.cache[file];
+
+  const parent = write('parent.cjs', 'exports.module = module; exports.child = require("./child.cjs"); require("./child.cjs");');
+  const child = write('child.cjs', 'module.exports = module;');
+  const p = req(parent);
+  assert(p.module instanceof Module);
+  assert.strictEqual(p.module.children.length, 1);
+  assert.strictEqual(p.module.children[0], p.child);
+  assert.strictEqual(p.child.parent, p.module);
+  assert.strictEqual(p.child.require('./parent.cjs'), p);
+  assert.deepStrictEqual(p.child.paths, Module.createRequire(child).resolve.paths('not-a-builtin').slice(0, p.child.paths.length));
+
+  const failParent = write('fail-parent.cjs', 'try { require("./fail.cjs"); } catch {} module.exports = module;');
+  write('fail.cjs', 'throw new Error("fail");');
+  assert.strictEqual(req(failParent).children.length, 0);
+
+  const native = write('addon.node', '');
+  const originalDlopen = process.dlopen;
+  let nativeLoads = 0;
+  try {
+    process.dlopen = (entry, filename) => {
+      assert.strictEqual(filename, native);
+      assert.strictEqual(Module._cache[filename], entry);
+      assert.strictEqual(entry.loaded, false);
+      assert(entry instanceof Module);
+      entry.exports = { load: ++nativeLoads };
+    };
+    const firstNative = req(native);
+    assert.strictEqual(req(native), firstNative);
+    assert.strictEqual(req.cache[native].loaded, true);
+    delete req.cache[native];
+    assert.strictEqual(req(native).load, 2);
+  } finally { process.dlopen = originalDlopen; }
+
+  const replacement = Object.create(null);
+  replacement[file] = { exports: 123 };
+  const saved = Module._cache;
+  try {
+    Module._cache = replacement;
+    assert.strictEqual(req(file), 123);
+    assert.strictEqual(req.cache, saved);
+    assert.strictEqual(Module.createRequire(file).cache, replacement);
+    Module._cache = Object.create(replacement);
+    assert.strictEqual(req(file), 123);
+    Module._cache = null;
+    assert.throws(() => req(file), TypeError);
+  } finally { Module._cache = saved; }
+
+  // Reassigning one require.cache property does not replace the loader cache.
+  const old = req.cache;
+  req.cache = {};
+  assert.strictEqual(Module._cache, old);
+  req.cache = old;
+  console.log('require.cache parity tests passed');
+} finally {
+  delete require.cache.fs;
+  for (const key of Object.keys(Module._cache)) if (key.startsWith(tmp + path.sep)) delete Module._cache[key];
+  fs.rmSync(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CommonJS module support with module metadata, parent/child relationships, and reliable loading state.
  * Added broader `require.cache` compatibility, including cache overrides, reassignment, and cleanup after failed loads.
  * Enhanced `createRequire` and `require.resolve`, including custom lookup paths.
  * Improved interoperability between `require()` and `import()` for CommonJS, ESM, JSON, and native modules.
  * Added ESM export access through `require()`, including default and named exports.

* **Tests**
  * Added comprehensive coverage for module construction, caching, resolution, and cross-format interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->