### PR TITLE
promote cold-tier code from its own prologue

### DIFF
--- a/docs/exec-plans/active/osr-size-scaled-tiering.md
+++ b/docs/exec-plans/active/osr-size-scaled-tiering.md
@@ -69,13 +69,19 @@ the background compile both engines rely on.
 2. One absolute ceiling, `SV_JIT_MAX_CODE_BYTES` (64 KiB), lives in
    `jit_is_eligible` so the OSR and call paths agree.
 3. OSR compiles of bodies over `JIT_OSR_COLD_COMPILE_MIN_BYTES` (512) use the
-   level-1 MIR context (`SV_JIT_TIER_COLD`) and set `jit_code_cold`. Both
-   call-path entry points call `sv_jit_maybe_tier_up()`, which recompiles on
-   the hot context (`SV_JIT_TIER_HOT`) once `call_count` passes
-   `SV_JIT_THRESHOLD`. Call-path compiles that happen to use the cheap
-   context are *not* marked cold; an earlier draft did, and every such
-   function re-tiered every 100 calls forever (Richards fell from 5775 to
-   183).
+   level-1 MIR context (`SV_JIT_TIER_COLD`) and set `jit_code_cold`. The
+   cold code promotes itself: `jit_setup_frame` emits a prologue that bumps
+   `call_count` on every entry and, past `SV_JIT_THRESHOLD`, calls
+   `jit_helper_tier_up` and tail-calls the hot entry it returns. The first
+   cut hooked the interpreter's two call paths instead, which missed direct
+   calls from compiled code entirely (post-merge review of #102: a compiled
+   driver called the cold kernel 200 times without promotion). Call-path
+   compiles that happen to use the cheap context are *not* marked cold; an
+   earlier draft did, and every such function re-tiered every 100 calls
+   forever (Richards fell from 5775 to 183).
+   `sv_jit_osr_threshold_for` is a static inline in `silver/jit.h` because
+   the bytecode compiler calls it on builds without the native JIT
+   (`packages/wasm` links `jit_stub.c`; the first cut broke that build).
 
 Compile cost that motivated step 3 (MIR, this machine):
 

--- a/docs/repo/runtime-invariants.md
+++ b/docs/repo/runtime-invariants.md
@@ -66,10 +66,12 @@ OSR is never refused on bytecode size alone. Each function's back-edge
 threshold (`jit_osr_threshold`) is scaled by its size in
 [runtime.c](../../src/jit/runtime.c); the only size ceiling is
 `SV_JIT_MAX_CODE_BYTES` in `jit_is_eligible`, shared by the OSR and call
-paths. Large OSR compiles use the cheap MIR context and set `jit_code_cold`;
-only `sv_jit_maybe_tier_up()` may recompile such code hot, and only code
-compiled with `SV_JIT_TIER_COLD` may carry the flag, otherwise the call path
-re-tiers forever. See the
+paths. Large OSR compiles use the cheap MIR context and set `jit_code_cold`. Such
+code promotes itself: its prologue (`jit_setup_frame`) counts entries and
+calls `jit_helper_tier_up` past `SV_JIT_THRESHOLD`, so promotion happens on
+every entry path, including direct calls from other compiled code that never
+touch the interpreter. Only code compiled with `SV_JIT_TIER_COLD` may carry
+the flag; the helper returns NULL once it is clear. See the
 [OSR size-scaled tiering plan](../exec-plans/active/osr-size-scaled-tiering.md)
 and [its regression](../../tests/test_jit_osr_large_function.cjs).
 

--- a/include/silver/call.h
+++ b/include/silver/call.h
@@ -509,7 +509,6 @@ static inline ant_value_t sv_call_resolve_closure(
   if (!closure->func->is_generator) {
     sv_func_t *fn = closure->func;
     if (fn->jit_code) {
-      sv_jit_maybe_tier_up(js, fn, closure);
       sv_jit_enter(js);
       ant_value_t result = ((sv_jit_func_t)fn->jit_code)(
         vm, ctx->this_val, ctx->new_target,

--- a/include/silver/feedback.h
+++ b/include/silver/feedback.h
@@ -102,12 +102,8 @@ static inline void sv_jit_on_bailout_at(sv_func_t *fn, const char *reason, int b
   fn->call_count = SV_JIT_THRESHOLD - SV_JIT_RECOMPILE_DELAY;
 }
 
-void sv_jit_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure);
-static inline void sv_jit_on_bailout(sv_func_t *fn) { sv_jit_on_bailout_at(fn, "direct", -1); }
-
-static inline void sv_jit_maybe_tier_up(ant_t *js, sv_func_t *fn, sv_closure_t *closure) {
-  if (__builtin_expect(fn->jit_code_cold, 0) && ++fn->call_count > SV_JIT_THRESHOLD)
-    sv_jit_tier_up(js, fn, closure);
+static inline void sv_jit_on_bailout(sv_func_t *fn) { 
+  sv_jit_on_bailout_at(fn, "direct", -1);
 }
 
 static inline uint8_t sv_tfb_classify(ant_value_t v) {

--- a/include/silver/jit.h
+++ b/include/silver/jit.h
@@ -6,18 +6,21 @@
 // TODO: constexpr
 #define SV_JIT_OSR_THRESHOLD 500
 #define SV_JIT_MAX_CODE_BYTES (64 * 1024)
-
-uint32_t sv_jit_osr_threshold_for(int code_len);
-
-void sv_jit_init(ant_t *js);
-void sv_jit_destroy(ant_t *js);
-void sv_jit_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure);
+#define SV_JIT_OSR_THRESHOLD_SCALE_BYTES 512
 
 typedef enum {
   SV_JIT_TIER_AUTO, // hot context if the function looped, cheap otherwise
   SV_JIT_TIER_COLD, // cheap context; marks jit_code_cold for later re-tier
   SV_JIT_TIER_HOT,  // hot context regardless of history
 } sv_jit_tier_t;
+
+void sv_jit_init(ant_t *js);
+void sv_jit_destroy(ant_t *js);
+
+sv_jit_func_t sv_jit_tier_up(
+  ant_t *js, sv_func_t *func, 
+  sv_closure_t *closure
+);
 
 sv_jit_func_t sv_jit_compile(
   ant_t *js, sv_func_t *func, 
@@ -34,5 +37,18 @@ ant_value_t sv_jit_try_osr(
   sv_frame_t *frame, sv_func_t *func,
   int bc_offset
 );
+
+static inline uint32_t sv_jit_osr_threshold_for(int code_len) {
+  if (code_len <= 0) return SV_JIT_OSR_THRESHOLD;
+  
+  uint64_t t =
+    (uint64_t)SV_JIT_OSR_THRESHOLD * (uint64_t)code_len / 
+    (uint64_t)SV_JIT_OSR_THRESHOLD_SCALE_BYTES;
+  
+  if (t < SV_JIT_OSR_THRESHOLD) t = SV_JIT_OSR_THRESHOLD;
+  if (t > UINT32_MAX / 2) t = UINT32_MAX / 2;
+  
+  return (uint32_t)t;
+}
 
 #endif

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -9,9 +9,12 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
       .js = js,
       .func = func,
       .hint_closure = hint_closure,
+      .cold_tier = tier == SV_JIT_TIER_COLD,
   };
+  
   jit_compile_t *c = &compile;
   if (c->func->jit_compile_failed || c->func->jit_compiling) return NULL;
+  
   if (c->func->jit_code == NULL && c->func->jit_compiled_tfb_ver != 0 &&
       c->func->tfb_version == c->func->jit_compiled_tfb_ver) {
     c->func->jit_compile_failed = true;

--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -174,6 +174,8 @@ typedef struct jit_compile {
   MIR_item_t imp_delete;
   MIR_item_t imp_set_name;
   MIR_item_t imp_stack_ovf_err;
+  MIR_item_t imp_tier_up;
+  MIR_item_t tier_up_proto;
   MIR_item_t imp_normalize_this;
   MIR_item_t jit_func;
   MIR_reg_t r_vm;
@@ -268,6 +270,7 @@ typedef struct jit_compile {
   int *local_by_reg;
   int integer_local_site;
   bool forward_arguments;
+  bool cold_tier;
   bool element_available;
   bool ok;
   int call_n;

--- a/src/jit/jit_internal.h
+++ b/src/jit/jit_internal.h
@@ -26,10 +26,7 @@
 
 static constexpr int JIT_VSTACK_SLACK = 4;
 static constexpr int JIT_PARAM_HOIST_CAP = 8;
-
-static constexpr int JIT_OSR_THRESHOLD_SCALE_BYTES = 512;
 static constexpr int JIT_OSR_COLD_COMPILE_MIN_BYTES = 512;
-
 static constexpr uint32_t JIT_HOT_COMPILE_BACKEDGE_THRESHOLD = SV_JIT_OSR_THRESHOLD / 8;
 
 typedef struct {

--- a/src/jit/runtime.c
+++ b/src/jit/runtime.c
@@ -1,4 +1,7 @@
 #include "jit_internal.h"
+
+void *jit_helper_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure);
+
 void jit_load_externals_once(sv_jit_ctx_t *jc) {
   if (jc == NULL || jc->externals_loaded) return;
 #define LOAD_EXT(name)                           \
@@ -105,6 +108,7 @@ void jit_load_externals_once(sv_jit_ctx_t *jc) {
   LOAD_EXT(jit_helper_set_name);
   LOAD_EXT(jit_helper_stack_overflow);
   LOAD_EXT(jit_helper_stack_overflow_error);
+  LOAD_EXT(jit_helper_tier_up);
   LOAD_EXT(jit_helper_normalize_sloppy_this);
 #undef LOAD_EXT
   jc->externals_loaded = true;
@@ -187,24 +191,23 @@ ant_value_t sv_jit_try_compile_and_call(
   return result;
 }
 
-uint32_t sv_jit_osr_threshold_for(int code_len) {
-  if (code_len <= 0) return SV_JIT_OSR_THRESHOLD;
-  uint64_t t = (uint64_t)SV_JIT_OSR_THRESHOLD * (uint64_t)code_len /
-               (uint64_t)JIT_OSR_THRESHOLD_SCALE_BYTES;
-  if (t < SV_JIT_OSR_THRESHOLD) t = SV_JIT_OSR_THRESHOLD;
-  if (t > UINT32_MAX / 2) t = UINT32_MAX / 2;
-  return (uint32_t)t;
-}
-
-void sv_jit_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure) {
+sv_jit_func_t sv_jit_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure) {
   func->jit_code_cold = false;
   sv_jit_func_t hot = sv_jit_compile_tier(js, func, closure, SV_JIT_TIER_HOT);
+  
   if (sv_jit_warn_unlikely) fprintf(
     stderr, "jit: tier-up %s func=%s code_len=%d\n",
     hot ? "compiled" : "compile-failed",
     func->debug->name ? func->debug->name : "<anonymous>", func->code_len
   );
+  
   if (hot) func->jit_code = (void *)hot;
+  return hot;
+}
+
+void *jit_helper_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure) {
+  if (!func->jit_code_cold) return NULL;
+  return (void *)sv_jit_tier_up(js, func, closure);
 }
 
 ant_value_t sv_jit_try_osr(

--- a/src/jit/setup_frame.c
+++ b/src/jit/setup_frame.c
@@ -92,6 +92,54 @@ bool jit_setup_frame(jit_compile_t *c) {
     MIR_append_insn(c->ctx, c->jit_func, no_overflow);
   }
 
+  if (c->cold_tier) {
+    MIR_label_t body = MIR_new_label(c->ctx);
+    MIR_reg_t r_fn = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "tier_fn");
+    MIR_reg_t r_calls = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "tier_calls");
+    MIR_reg_t r_hot = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "tier_hot");
+    MIR_reg_t r_res = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_JSVAL, "tier_res");
+    MIR_op_t call_count = MIR_new_mem_op(c->ctx, MIR_T_U32,
+                                         (MIR_disp_t)offsetof(sv_func_t, call_count), r_fn, 0, 1);
+    mir_load_imm(c->ctx, c->jit_func, r_fn, (uint64_t)(uintptr_t)c->func);
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_insn(c->ctx, MIR_MOV, MIR_new_reg_op(c->ctx, r_calls), call_count));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_insn(c->ctx, MIR_ADD, MIR_new_reg_op(c->ctx, r_calls),
+                                 MIR_new_reg_op(c->ctx, r_calls), MIR_new_int_op(c->ctx, 1)));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_insn(c->ctx, MIR_MOV, call_count, MIR_new_reg_op(c->ctx, r_calls)));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_insn(c->ctx, MIR_UBLE, MIR_new_label_op(c->ctx, body),
+                                 MIR_new_reg_op(c->ctx, r_calls),
+                                 MIR_new_int_op(c->ctx, SV_JIT_THRESHOLD)));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_call_insn(c->ctx, 6,
+                                      MIR_new_ref_op(c->ctx, c->tier_up_proto),
+                                      MIR_new_ref_op(c->ctx, c->imp_tier_up),
+                                      MIR_new_reg_op(c->ctx, r_hot),
+                                      MIR_new_reg_op(c->ctx, c->r_js),
+                                      MIR_new_reg_op(c->ctx, r_fn),
+                                      MIR_new_reg_op(c->ctx, c->r_closure)));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_insn(c->ctx, MIR_BEQ, MIR_new_label_op(c->ctx, body),
+                                 MIR_new_reg_op(c->ctx, r_hot), MIR_new_int_op(c->ctx, 0)));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_call_insn(c->ctx, 10,
+                                      MIR_new_ref_op(c->ctx, c->self_proto),
+                                      MIR_new_reg_op(c->ctx, r_hot),
+                                      MIR_new_reg_op(c->ctx, r_res),
+                                      MIR_new_reg_op(c->ctx, c->r_vm),
+                                      MIR_new_reg_op(c->ctx, c->r_this),
+                                      MIR_new_reg_op(c->ctx, c->r_new_target),
+                                      MIR_new_reg_op(c->ctx, c->r_super_val),
+                                      MIR_new_reg_op(c->ctx, c->r_args),
+                                      MIR_new_reg_op(c->ctx, c->r_argc),
+                                      MIR_new_reg_op(c->ctx, c->r_closure)));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_ret_insn(c->ctx, 1, MIR_new_reg_op(c->ctx, r_res)));
+    MIR_append_insn(c->ctx, c->jit_func, body);
+  }
+
   c->vs = (jit_vstack_t){0};
   c->vs.max = c->func->max_stack + JIT_VSTACK_SLACK;
   c->vs.regs = calloc((size_t)c->vs.max, sizeof(MIR_reg_t));

--- a/src/jit/setup_prototypes.c
+++ b/src/jit/setup_prototypes.c
@@ -387,6 +387,13 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
                                          MIR_T_I64, "vm",
                                          MIR_T_I64, "js");
 
+  MIR_type_t tier_ret = MIR_T_I64;
+  c->tier_up_proto = MIR_new_proto(c->ctx, "tier_up_proto",
+                                   1, &tier_ret, 3,
+                                   MIR_T_I64, "js",
+                                   MIR_T_I64, "func",
+                                   MIR_T_P, "closure");
+
   c->define_field_proto = MIR_new_proto(c->ctx, "df_proto",
                                         0, NULL, 6,
                                         MIR_T_I64, "vm",
@@ -633,8 +640,7 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
   c->imp_closure = MIR_new_import(c->ctx, "jit_helper_closure");
   c->imp_in = MIR_new_import(c->ctx, "jit_helper_in");
   c->imp_get_length = MIR_new_import(c->ctx, "jit_helper_get_length");
-  c->imp_get_length_inline =
-      MIR_new_import(c->ctx, "jit_helper_get_length_inline");
+  c->imp_get_length_inline = MIR_new_import(c->ctx, "jit_helper_get_length_inline");
   c->imp_define_field = MIR_new_import(c->ctx, "jit_helper_define_field");
   c->imp_define_method_comp = MIR_new_import(c->ctx, "jit_helper_define_method_comp");
   c->imp_seq = MIR_new_import(c->ctx, "jit_helper_seq");
@@ -642,8 +648,7 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
   c->imp_ne = MIR_new_import(c->ctx, "jit_helper_ne");
   c->imp_sne = MIR_new_import(c->ctx, "jit_helper_sne");
   c->imp_put_field = MIR_new_import(c->ctx, "jit_helper_put_field_ic");
-  c->imp_shape_transition =
-      MIR_new_import(c->ctx, "jit_helper_shape_transition");
+  c->imp_shape_transition = MIR_new_import(c->ctx, "jit_helper_shape_transition");
   c->imp_remember_obj = MIR_new_import(c->ctx, "gc_remember_add");
   c->imp_get_elem = MIR_new_import(c->ctx, "jit_helper_get_elem");
   c->imp_put_elem = MIR_new_import(c->ctx, "jit_helper_put_elem");
@@ -660,8 +665,7 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
   c->imp_throw_error = MIR_new_import(c->ctx, "jit_helper_throw_error");
   c->imp_set_proto = MIR_new_import(c->ctx, "jit_helper_set_proto");
   c->imp_get_elem2 = MIR_new_import(c->ctx, "jit_helper_get_elem2");
-  c->imp_get_elem_inline =
-      MIR_new_import(c->ctx, "jit_helper_get_elem_inline");
+  c->imp_get_elem_inline = MIR_new_import(c->ctx, "jit_helper_get_elem_inline");
   c->imp_band = MIR_new_import(c->ctx, "jit_helper_band");
   c->imp_bor = MIR_new_import(c->ctx, "jit_helper_bor");
   c->imp_bxor = MIR_new_import(c->ctx, "jit_helper_bxor");
@@ -678,6 +682,6 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
   c->imp_delete = MIR_new_import(c->ctx, "jit_helper_delete");
   c->imp_set_name = MIR_new_import(c->ctx, "jit_helper_set_name");
   c->imp_stack_ovf_err = MIR_new_import(c->ctx, "jit_helper_stack_overflow_error");
-  c->imp_normalize_this =
-      MIR_new_import(c->ctx, "jit_helper_normalize_sloppy_this");
+  c->imp_tier_up = MIR_new_import(c->ctx, "jit_helper_tier_up");
+  c->imp_normalize_this = MIR_new_import(c->ctx, "jit_helper_normalize_sloppy_this");
 }

--- a/src/silver/engine.c
+++ b/src/silver/engine.c
@@ -1093,7 +1093,6 @@ static inline ant_value_t sv_try_direct_closure_jit(
     sv_tfb_record_call_target(caller_func, (int)(caller_ip - caller_func->code), callee);
 
   if (callee->jit_code) {
-    sv_jit_maybe_tier_up(js, callee, closure);
     if (caller_frame && caller_ip) caller_frame->ip = caller_ip + 3;
     sv_jit_enter(js);
     ant_value_t jit_result = ((sv_jit_func_t)callee->jit_code)(

--- a/tests/test_jit_osr_large_function.cjs
+++ b/tests/test_jit_osr_large_function.cjs
@@ -1,9 +1,12 @@
 // Regression for issue #101: a once-called function whose bytecode exceeds
 // the old 512-byte OSR gate must still be OSR-compiled from its hot loop,
 // on the cheap tier first, and re-tiered hot once it is also hot by calls.
+// Promotion is driven by the cold code's own prologue, so it must also
+// happen when every call comes from compiled code (direct JIT calls never
+// pass through the interpreter's call path).
 const { spawnSync } = require('child_process');
 
-const source = String.raw`
+const kernel = String.raw`
 function benchNbody(n, steps) {
   var bodies = [];
   for (var i = 0; i < n; i++) {
@@ -40,28 +43,51 @@ function benchNbody(n, steps) {
   for (var i = 0; i < n; i++) e += bodies[i][0] * bodies[i][0] + bodies[i][1] * bodies[i][1];
   return Math.round(e * 1000) / 1000;
 }
+`;
+
+const source = kernel + String.raw`
 if (benchNbody(300, 30) !== 209259.692) throw new Error('nbody checksum mismatch');
 for (let i = 0; i < 150; i++) benchNbody(4, 1);
 if (benchNbody(300, 3) !== 209250.582) throw new Error('nbody checksum mismatch after tier-up');
 console.log('done');
 `;
 
-const result = spawnSync(process.execPath, ['-e', source], {
-  env: { ...process.env, ANT_DEBUG: 'dump/vm:op-warn' },
-  encoding: 'utf8',
-});
+function run(source) {
+  const result = spawnSync(process.execPath, ['-e', source], {
+    env: { ...process.env, ANT_DEBUG: 'dump/vm:op-warn' },
+    encoding: 'utf8',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`child failed:\n${result.stderr}\n${result.stdout}`);
+  return result.stderr.split('\n');
+}
 
-if (result.error) throw result.error;
-if (result.status !== 0) throw new Error(`child failed:\n${result.stderr}\n${result.stdout}`);
+function expectTierUp(lines, label) {
+  const osr = lines.find(line => line.startsWith('jit: osr compiled func=benchNbody'));
+  if (!osr) throw new Error(`${label}: expected an OSR compile of benchNbody, got:\n${lines.join('\n')}`);
+  const size = Number(/code_len=(\d+)/.exec(osr)[1]);
+  if (!(size > 512)) throw new Error(`${label}: fixture must exceed the old 512-byte gate, got ${size}`);
+  if (!osr.includes('tier=cold')) throw new Error(`${label}: large OSR compile should use the cold tier: ${osr}`);
+  if (!lines.some(line => line.startsWith('jit: tier-up compiled func=benchNbody')))
+    throw new Error(`${label}: expected a hot re-tier of benchNbody, got:\n${lines.join('\n')}`);
+  if (lines.some(line => line.includes('jit: bailout') && line.includes('benchNbody')))
+    throw new Error(`${label}: unexpected bailout:\n${lines.join('\n')}`);
+}
 
-const lines = result.stderr.split('\n');
-const osr = lines.find(line => line.startsWith('jit: osr compiled func=benchNbody'));
-if (!osr) throw new Error(`expected an OSR compile of benchNbody, got:\n${result.stderr}`);
-const size = Number(/code_len=(\d+)/.exec(osr)[1]);
-if (!(size > 512)) throw new Error(`fixture must exceed the old 512-byte gate, got ${size}`);
-if (!osr.includes('tier=cold')) throw new Error(`large OSR compile should use the cold tier: ${osr}`);
-if (!lines.some(line => line.startsWith('jit: tier-up compiled func=benchNbody')))
-  throw new Error(`expected a hot re-tier of benchNbody after 150 calls, got:\n${result.stderr}`);
-if (lines.some(line => line.includes('jit: bailout') && line.includes('benchNbody')))
-  throw new Error(`unexpected bailout:\n${result.stderr}`);
+expectTierUp(run(source), 'interpreter caller');
+
+// Same kernel, but every call after the first comes from a JIT-compiled
+// driver that calls benchNbody's code pointer directly.
+const compiledCaller = kernel + String.raw`
+function compiledDriver() {
+  var checksum = 0;
+  for (var i = 0; i < 1000; i++) checksum += i;
+  checksum += benchNbody(300, 30);
+  for (var j = 0; j < 200; j++) checksum += benchNbody(4, 1);
+  return checksum;
+}
+if (Math.round(compiledDriver() * 1000) / 1000 !== 791187.692) throw new Error('compiled driver checksum mismatch');
+console.log('done');
+`;
+expectTierUp(run(compiledCaller), 'compiled caller');
 console.log('jit-osr-large-function: ok');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved JIT optimization for large functions by promoting frequently executed code from a colder tier to a faster tier automatically.
  - Tier promotion now works consistently across interpreter calls and direct calls from already compiled code.
  - OSR thresholds now scale with function size, supporting more balanced optimization behavior.

- **Bug Fixes**
  - Fixed cases where direct compiled-code calls could bypass tier promotion.
  - Added coverage to verify successful promotion without bailouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->