### PR TITLE
promote cold-tier code from inside a running loop

### DIFF
--- a/docs/exec-plans/active/osr-size-scaled-tiering.md
+++ b/docs/exec-plans/active/osr-size-scaled-tiering.md
@@ -211,11 +211,85 @@ rejection or an overflow and refuses to report success for a binary it
 cannot run, and `tests/test_jit_vstack_depth.cjs` asserts that each
 JIT-eligible case actually compiled.
 
+### In-loop promotion (the last follow-up)
+
+A once-called function that never leaves its OSR'd cold loop used to stay
+on level-1 code for the whole call. Cold-tier code now reads the monotonic
+clock at entry, counts back-edges in a register (`r_promote`,
+`emit_control.c`), and every 4096 of them asks `jit_helper_promote_due`
+whether this run has spent `JIT_COLD_PROMOTE_COMPILE_MULTIPLE` (8)
+estimated hot-compile times (`JIT_HOT_COMPILE_NS_PER_BYTE` x `code_len`)
+on cold code. If so it takes a second resume trampoline into
+`jit_helper_promote_resume`. That unpublishes the cold code,
+leaves `jit_code_cold` set as the "next compile is hot" mark, primes
+`back_edge_count` to one below the OSR threshold and resumes the interpreter
+at the jump. The interpreter re-executes the back-edge, `sv_jit_try_osr`
+sees the mark and compiles `SV_JIT_TIER_HOT`, and the hot code OSR-enters at
+the loop head. It is not a deopt: no bailout count, no recompile delay, and
+`sv_jit_compile_tier` skips its "no new feedback" refusal for hot-tier
+recompiles.
+
+The budget is the cost model, not a guess. The hot compile costs ~50 us per
+bytecode byte (30 ms for the 592-byte kernel, 262 ms for a 5 KB body) and
+cold code is ~1.2x slower, so promotion only pays if the loop keeps running
+for about five more compile-times; elapsed cold time is the best available
+predictor of that. A first cut budgeted back-edges instead of time and lost
+30 ms on every loop between one and 2.5 budgets long, because a count
+cannot know the per-iteration cost. Measured on the kernel:
+
+| run | cold only | count budget | time budget (8x) |
+|---|---|---|---|
+| 30 steps, 53 ms cold | 53 ms | 53 ms | 54 ms |
+| 120 steps, ~175 ms cold | 172 to 182 ms | 202 to 207 ms | 178 ms (no promotion) |
+| 400 steps, ~540 ms cold | 541 ms | | 552 ms (promotes at ~45%) |
+| 600 steps, ~815 ms cold | 801 to 831 ms | 743 to 750 ms | 794 ms (promotes at ~30%) |
+
+The time budget trades some of the long-loop win for never losing on
+medium loops; 8x is deliberately conservative. bench-v8 is unchanged.
+Regression: the long-loop case in `tests/test_jit_osr_large_function.cjs`.
+
+Review of this change (three-axis, before commit) found and fixed: the
+OSR-site entry counter had moved below the point where the prologue clears
+`vm->jit_osr.active`, so a call-count tier-up firing at an OSR entry
+restarted the function from bytecode 0 (reproduced: 101 entries instead of
+61); the promote trampoline spilled through `lbuf`/`args_buf` that are only
+allocated when a deopt-capable op exists, so a cold loop of plain method
+calls segfaulted at the budget (cold tier now forces both); a cold-code
+deopt left `jit_code_cold` set and so bought a hot recompile of the same
+bailout (cleared on deopt, predicate named `sv_jit_promote_pending`).
+Known limits left open: the budget is per activation, so a kernel entered
+repeatedly for sub-budget runs never promotes (8 x 160 ms calls: 1289 ms vs
+1056 ms hot); promotion is a pure ~40 ms loss on loops the hot tier cannot
+speed up (helper-bound bodies such as integer `%`); each backward jump
+emits a full spill block, +12% cold compile time at 12 loops.
+
+Two pre-existing cliffs surfaced while probing this, neither caused here
+and both left as follow-ups:
+
+- A hot loop followed by `var` declarations that are only assigned later
+  (`function f(n) { for (...) {...} var p0 = ..., p1 = ...; return ... }`)
+  never OSR-enters: the entry guard requires every `SV_TI_NUM` local to hold
+  a number, those still hold `undefined` at the loop head, and the
+  interpreter retries every threshold for the whole loop. A 12M-iteration
+  double loop runs 240 ms this way against 17 ms once the trailing locals
+  are removed and 15 ms in node. Either accept `undefined` for locals that
+  are provably dead at the entry point, or back off retries exponentially
+  after a rejection (JSC's `ftlOSREntryRetryThreshold`).
+- `s = (s + i * 7) % 1000003` runs at 15 ns per iteration in hot code (185
+  ms for 12M against 35 ms in node): integer `%` goes through a helper call
+  rather than an inline remainder.
+- The N-body kernel's checksum diverges from node's at 1000 steps
+  (221407.95 vs 221407.165) on every tier including the interpreter, so it
+  is a libm or contraction difference amplified by a chaotic system, not a
+  JIT bug; tests pin step counts where both engines agree. Regression: the long-loop case in
+`tests/test_jit_osr_large_function.cjs`.
+
 ## Validation status
 
 - `tests/test_jit_osr_large_function.cjs` (new): once-called >512-byte body
-  is OSR-compiled on the cold tier and re-tiered hot after 150 calls, with
-  checksums matching node.
+  is OSR-compiled on the cold tier and re-tiered hot after 150 calls, also
+  when every call comes from compiled code, and promoted from inside a
+  single long loop, with checksums matching node.
 - `tests/test_jit_vstack_depth.cjs` (new): 120-operand calls, literals and
   expressions compile and run correctly through the JIT.
 - `tests/test_labeled_jump_for_of_close.cjs` (new): labeled break/continue
@@ -232,8 +306,6 @@ JIT-eligible case actually compiled.
 - Typed-array element fast path in `src/jit/emit_properties.c`.
 - MIR level-3 compile time is superlinear in body size (262 ms for 5 KB);
   worth profiling before raising `JIT_OSR_COLD_COMPILE_MIN_BYTES`.
-- Tier-up only fires from the call path. A once-called function that stays in
-  its OSR'd cold loop never re-tiers; V8 solves this with OSR-from-Maglev.
 - Ant closes abandoned generators only through GC pressure (~850 MB RSS for
   2M short generator loops vs 58 MB in node); unrelated to this plan but
   visible in its probes.

--- a/docs/exec-plans/active/osr-size-scaled-tiering.md
+++ b/docs/exec-plans/active/osr-size-scaled-tiering.md
@@ -216,11 +216,19 @@ JIT-eligible case actually compiled.
 A once-called function that never leaves its OSR'd cold loop used to stay
 on level-1 code for the whole call. Cold-tier code now reads the monotonic
 clock at entry, counts back-edges in a register (`r_promote`,
-`emit_control.c`), and every 4096 of them asks `jit_helper_promote_due`
-whether this run has spent `JIT_COLD_PROMOTE_COMPILE_MULTIPLE` (8)
-estimated hot-compile times (`JIT_HOT_COMPILE_NS_PER_BYTE` x `code_len`)
-on cold code. If so it takes a second resume trampoline into
-`jit_helper_promote_resume`. That unpublishes the cold code,
+`emit_control.c`), and every 4096 of them calls `jit_helper_promote_due`,
+which banks the cold time since the last check on `sv_func_t.jit_cold_ns`
+(reset at each cold compile) and hands back a fresh `t0`, or 0 once the
+function has spent `JIT_COLD_PROMOTE_COMPILE_MULTIPLE` (8) estimated
+hot-compile times (`JIT_HOT_COMPILE_NS_PER_BYTE` x `code_len`) on cold
+code across any number of activations. Banking per check rather than per
+frame is what lets a kernel called repeatedly for sub-budget runs promote,
+the common driver-loop shape: eight 120-step calls went from 1329 ms cold
+to 1195 ms, promoting during the second call, against 1092 ms hot from
+the start. Idle time between calls is never charged. When the budget is
+spent it takes a second resume trampoline into `jit_helper_promote_resume`.
+`sizeof(sv_func_t)` is 216 for the field; a saturating 32-bit variant in
+64 ns units fit the tail padding but was rejected for its truncation. That unpublishes the cold code,
 leaves `jit_code_cold` set as the "next compile is hot" mark, primes
 `back_edge_count` to one below the OSR threshold and resumes the interpreter
 at the jump. The interpreter re-executes the back-edge, `sv_jit_try_osr`
@@ -257,9 +265,7 @@ allocated when a deopt-capable op exists, so a cold loop of plain method
 calls segfaulted at the budget (cold tier now forces both); a cold-code
 deopt left `jit_code_cold` set and so bought a hot recompile of the same
 bailout (cleared on deopt, predicate named `sv_jit_promote_pending`).
-Known limits left open: the budget is per activation, so a kernel entered
-repeatedly for sub-budget runs never promotes (8 x 160 ms calls: 1289 ms vs
-1056 ms hot); promotion is a pure ~40 ms loss on loops the hot tier cannot
+Known limits left open: promotion is a pure ~40 ms loss on loops the hot tier cannot
 speed up (helper-bound bodies such as integer `%`); each backward jump
 emits a full spill block, +12% cold compile time at 12 loops.
 

--- a/docs/repo/runtime-invariants.md
+++ b/docs/repo/runtime-invariants.md
@@ -67,11 +67,19 @@ threshold (`jit_osr_threshold`) is scaled by its size in
 [runtime.c](../../src/jit/runtime.c); the only size ceiling is
 `SV_JIT_MAX_CODE_BYTES` in `jit_is_eligible`, shared by the OSR and call
 paths. Large OSR compiles use the cheap MIR context and set `jit_code_cold`. Such
-code promotes itself: its prologue (`jit_setup_frame`) counts entries and
-calls `jit_helper_tier_up` past `SV_JIT_THRESHOLD`, so promotion happens on
-every entry path, including direct calls from other compiled code that never
-touch the interpreter. Only code compiled with `SV_JIT_TIER_COLD` may carry
-the flag; the helper returns NULL once it is clear. See the
+code promotes itself: its prologue (`jit_setup_frame`) counts entries that
+run the body and calls `jit_helper_tier_up` past `SV_JIT_THRESHOLD`, so
+promotion happens on every entry path, including direct calls from other
+compiled code that never touch the interpreter. The counter sits behind the
+OSR entry guards so a rejected OSR entry does not count; the interpreter
+retries those every OSR threshold, and counting them turned a function that
+never enters compiled code into a wasted hot compile. Only code compiled with
+`SV_JIT_TIER_COLD` sets
+the flag, and `sv_jit_on_bailout_at` clears it. With `jit_code == NULL` it
+means cold code handed a loop back for promotion
+(`sv_jit_promote_pending()`, set by `jit_helper_promote_resume`): the next
+OSR compile must be `SV_JIT_TIER_HOT`, and that compile is exempt from the
+"no new feedback" refusal in `sv_jit_compile_tier`. See the
 [OSR size-scaled tiering plan](../exec-plans/active/osr-size-scaled-tiering.md)
 and [its regression](../../tests/test_jit_osr_large_function.cjs).
 

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -359,6 +359,7 @@ struct sv_func {
   
   sv_call_target_fb_t *call_target_fb;
   uint64_t gc_epoch;
+  int64_t jit_cold_ns;
 
   int code_len;
   int const_count;

--- a/include/silver/feedback.h
+++ b/include/silver/feedback.h
@@ -67,6 +67,7 @@ static inline void sv_jit_on_bailout_at(sv_func_t *fn, const char *reason, int b
     fn->jit_bailout_count++;
 
   fn->jit_code = NULL;
+  fn->jit_code_cold = false;
   fn->back_edge_count = 0;
 
   if (sv_jit_warn_unlikely) {

--- a/include/silver/glue.h
+++ b/include/silver/glue.h
@@ -232,6 +232,16 @@ ant_value_t jit_helper_closure(
   sv_upvalue_t **open_upvalues
 );
 
+ant_value_t jit_helper_promote_resume(
+  sv_vm_t *vm, sv_closure_t *closure,
+  ant_value_t this_val, ant_value_t new_target, ant_value_t super_val,
+  ant_value_t *args, int argc,
+  ant_value_t *vstack, int64_t vstack_sp,
+  ant_value_t *params, int64_t n_params,
+  ant_value_t *locals, int64_t n_locals,
+  int64_t bc_offset
+);
+
 ant_value_t jit_helper_bailout_resume(
   sv_vm_t *vm, sv_closure_t *closure,
   ant_value_t this_val, ant_value_t new_target, ant_value_t super_val,

--- a/include/silver/jit.h
+++ b/include/silver/jit.h
@@ -38,6 +38,10 @@ ant_value_t sv_jit_try_osr(
   int bc_offset
 );
 
+static inline bool sv_jit_promote_pending(const sv_func_t *func) {
+  return func->jit_code_cold && func->jit_code == NULL;
+}
+
 static inline uint32_t sv_jit_osr_threshold_for(int code_len) {
   if (code_len <= 0) return SV_JIT_OSR_THRESHOLD;
   

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -440,6 +440,7 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
 
   c->func->jit_compiled_tfb_ver = c->func->tfb_version;
   c->func->jit_code_cold = tier == SV_JIT_TIER_COLD;
+  if (tier == SV_JIT_TIER_COLD) c->func->jit_cold_ns = 0;
   
   if (sv_jit_warn_unlikely) fprintf(
     stderr, "jit: compiled func=%s code_len=%d max_stack=%d tier=%s\n",

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -1,5 +1,49 @@
 #include "compile.h"
 
+static void jit_emit_resume_tramp(jit_compile_t *c, MIR_label_t tramp, MIR_item_t imp,
+                                const char *res_name) {
+  MIR_append_insn(c->ctx, c->jit_func, tramp);
+
+  if (c->r_jit_open_upvalues) {
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_call_insn(c->ctx, 4,
+                                      MIR_new_ref_op(c->ctx, c->adopt_open_upvalues_proto),
+                                      MIR_new_ref_op(c->ctx, c->imp_adopt_open_upvalues),
+                                      MIR_new_reg_op(c->ctx, c->r_vm),
+                                      MIR_new_reg_op(c->ctx, c->r_jit_open_upvalues)));
+  }
+
+  MIR_reg_t r_resume_res = MIR_new_func_reg(c->ctx, c->jit_func->u.func,
+                                            MIR_JSVAL, res_name);
+  if (c->has_captured_params && !c->writes_params) {
+    mir_emit_fill_uncaptured_param_slots_from_args(
+        c->ctx, c->jit_func, c->r_slotbuf, c->r_args, c->r_argc, c->captured_params, c->param_count);
+  }
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_call_insn(c->ctx, 17,
+                                    MIR_new_ref_op(c->ctx, c->resume_proto),
+                                    MIR_new_ref_op(c->ctx, imp),
+                                    MIR_new_reg_op(c->ctx, r_resume_res),
+                                    MIR_new_reg_op(c->ctx, c->r_vm),
+                                    MIR_new_reg_op(c->ctx, c->r_closure),
+                                    MIR_new_reg_op(c->ctx, c->r_this_curr),
+                                    c->feat.needs_new_target ? MIR_new_reg_op(c->ctx, c->r_new_target)
+                                      : MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)),
+                                    c->feat.needs_super ? MIR_new_reg_op(c->ctx, c->r_super_val)
+                                      : MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)),
+                                    MIR_new_reg_op(c->ctx, c->r_args),
+                                    MIR_new_reg_op(c->ctx, c->r_argc),
+                                    MIR_new_reg_op(c->ctx, c->r_args_buf),
+                                    MIR_new_reg_op(c->ctx, c->r_bailout_sp),
+                                    c->params_in_slotbuf ? MIR_new_reg_op(c->ctx, c->r_slotbuf) : MIR_new_uint_op(c->ctx, 0),
+                                    MIR_new_int_op(c->ctx, c->params_in_slotbuf ? c->param_count : 0),
+                                    MIR_new_reg_op(c->ctx, c->r_lbuf),
+                                    MIR_new_int_op(c->ctx, c->n_locals),
+                                    MIR_new_reg_op(c->ctx, c->r_bailout_off)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                MIR_new_ret_insn(c->ctx, 1, MIR_new_reg_op(c->ctx, r_resume_res)));
+}
+
 sv_jit_func_t sv_jit_compile(ant_t *js, sv_func_t *func, sv_closure_t *hint_closure) {
   return sv_jit_compile_tier(js, func, hint_closure, SV_JIT_TIER_AUTO);
 }
@@ -15,7 +59,8 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
   jit_compile_t *c = &compile;
   if (c->func->jit_compile_failed || c->func->jit_compiling) return NULL;
   
-  if (c->func->jit_code == NULL && c->func->jit_compiled_tfb_ver != 0 &&
+  if (tier != SV_JIT_TIER_HOT &&
+      c->func->jit_code == NULL && c->func->jit_compiled_tfb_ver != 0 &&
       c->func->tfb_version == c->func->jit_compiled_tfb_ver) {
     c->func->jit_compile_failed = true;
     return NULL;
@@ -339,48 +384,8 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
     jit_emit_exit_ret(c, MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)));
   }
 
-  if (c->needs_bailout) {
-    MIR_append_insn(c->ctx, c->jit_func, c->bailout_tramp);
-
-    if (c->r_jit_open_upvalues) {
-      MIR_append_insn(c->ctx, c->jit_func,
-                      MIR_new_call_insn(c->ctx, 4,
-                                        MIR_new_ref_op(c->ctx, c->adopt_open_upvalues_proto),
-                                        MIR_new_ref_op(c->ctx, c->imp_adopt_open_upvalues),
-                                        MIR_new_reg_op(c->ctx, c->r_vm),
-                                        MIR_new_reg_op(c->ctx, c->r_jit_open_upvalues)));
-    }
-
-    MIR_reg_t r_resume_res = MIR_new_func_reg(c->ctx, c->jit_func->u.func,
-                                              MIR_JSVAL, "resume_res");
-    if (c->has_captured_params && !c->writes_params) {
-      mir_emit_fill_uncaptured_param_slots_from_args(
-          c->ctx, c->jit_func, c->r_slotbuf, c->r_args, c->r_argc, c->captured_params, c->param_count);
-    }
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_call_insn(c->ctx, 17,
-                                      MIR_new_ref_op(c->ctx, c->resume_proto),
-                                      MIR_new_ref_op(c->ctx, c->imp_resume),
-                                      MIR_new_reg_op(c->ctx, r_resume_res),
-                                      MIR_new_reg_op(c->ctx, c->r_vm),
-                                      MIR_new_reg_op(c->ctx, c->r_closure),
-                                      MIR_new_reg_op(c->ctx, c->r_this_curr),
-                                      c->feat.needs_new_target ? MIR_new_reg_op(c->ctx, c->r_new_target)
-                                        : MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)),
-                                      c->feat.needs_super ? MIR_new_reg_op(c->ctx, c->r_super_val)
-                                        : MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)),
-                                      MIR_new_reg_op(c->ctx, c->r_args),
-                                      MIR_new_reg_op(c->ctx, c->r_argc),
-                                      MIR_new_reg_op(c->ctx, c->r_args_buf),
-                                      MIR_new_reg_op(c->ctx, c->r_bailout_sp),
-                                      c->params_in_slotbuf ? MIR_new_reg_op(c->ctx, c->r_slotbuf) : MIR_new_uint_op(c->ctx, 0),
-                                      MIR_new_int_op(c->ctx, c->params_in_slotbuf ? c->param_count : 0),
-                                      MIR_new_reg_op(c->ctx, c->r_lbuf),
-                                      MIR_new_int_op(c->ctx, c->n_locals),
-                                      MIR_new_reg_op(c->ctx, c->r_bailout_off)));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_ret_insn(c->ctx, 1, MIR_new_reg_op(c->ctx, r_resume_res)));
-  }
+  if (c->needs_bailout) jit_emit_resume_tramp(c, c->bailout_tramp, c->imp_resume, "resume_res");
+  if (c->needs_promote) jit_emit_resume_tramp(c, c->promote_tramp, c->imp_promote_resume, "promote_res");
 
   MIR_finish_func(c->ctx);
   MIR_finish_module(c->ctx);
@@ -439,7 +444,8 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
   if (sv_jit_warn_unlikely) fprintf(
     stderr, "jit: compiled func=%s code_len=%d max_stack=%d tier=%s\n",
     c->func->debug->name ? c->func->debug->name : "<anonymous>",
-    c->func->code_len, c->func->max_stack, jit_compile_hot ? "hot" : "cheap"
+    c->func->code_len, c->func->max_stack, 
+    tier == SV_JIT_TIER_COLD ? "cold" : jit_compile_hot ? "hot" : "cheap"
   );
   
   return generated;

--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -47,6 +47,8 @@ typedef struct jit_compile {
   MIR_item_t str_flush_local_proto;
   MIR_item_t truthy_proto;
   MIR_item_t resume_proto;
+  MIR_item_t promote_now_proto;
+  MIR_item_t promote_due_proto;
   MIR_item_t closure_proto;
   MIR_item_t close_upval_proto;
   MIR_item_t upval_barrier_proto;
@@ -124,6 +126,9 @@ typedef struct jit_compile {
   MIR_item_t imp_to_propkey;
   MIR_item_t imp_to_string;
   MIR_item_t imp_resume;
+  MIR_item_t imp_promote_resume;
+  MIR_item_t imp_promote_now;
+  MIR_item_t imp_promote_due;
   MIR_item_t imp_close_upval;
   MIR_item_t imp_upval_barrier;
   MIR_item_t imp_adopt_open_upvalues;
@@ -211,6 +216,9 @@ typedef struct jit_compile {
   MIR_reg_t r_bailout_off;
   MIR_reg_t r_bailout_sp;
   MIR_label_t bailout_tramp;
+  MIR_label_t promote_tramp;
+  MIR_reg_t r_promote;
+  MIR_reg_t r_promote_t0;
   MIR_reg_t cached_index_key;
   MIR_reg_t cached_index_value;
   MIR_reg_t cached_element_object;
@@ -243,6 +251,7 @@ typedef struct jit_compile {
   jit_inline_ext_t inline_ext;
   bool normalize_sloppy_this;
   bool needs_bailout;
+  bool needs_promote;
   int param_count;
   bool writes_params;
   bool *captured_params;
@@ -259,6 +268,7 @@ typedef struct jit_compile {
   bool needs_lbuf;
   bool use_jit_upvalue_list;
   jit_bailout_emit_t bailout_ctx;
+  jit_bailout_emit_t promote_ctx;
   jit_label_map_t lm;
   osr_entry_map_t osr_map;
   jit_try_entry_t jit_try_stack[JIT_TRY_MAX];

--- a/src/jit/emit_control.c
+++ b/src/jit/emit_control.c
@@ -1,5 +1,32 @@
 #include "compile.h"
 
+static void jit_emit_promote_check(jit_compile_t *c, MIR_label_t loop) {
+  MIR_reg_t r_due = c->r_tmp2;
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_ADD, MIR_new_reg_op(c->ctx, c->r_promote),
+                               MIR_new_reg_op(c->ctx, c->r_promote), MIR_new_int_op(c->ctx, 1)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_AND, MIR_new_reg_op(c->ctx, r_due),
+                               MIR_new_reg_op(c->ctx, c->r_promote),
+                               MIR_new_int_op(c->ctx, JIT_COLD_PROMOTE_CHECK_EVERY - 1)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_BNE, MIR_new_label_op(c->ctx, loop),
+                               MIR_new_reg_op(c->ctx, r_due), MIR_new_int_op(c->ctx, 0)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_call_insn(c->ctx, 5,
+                                    MIR_new_ref_op(c->ctx, c->promote_due_proto),
+                                    MIR_new_ref_op(c->ctx, c->imp_promote_due),
+                                    MIR_new_reg_op(c->ctx, r_due),
+                                    MIR_new_uint_op(c->ctx, (uint64_t)(uintptr_t)c->func),
+                                    MIR_new_reg_op(c->ctx, c->r_promote_t0)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_BEQ, MIR_new_label_op(c->ctx, loop),
+                               MIR_new_reg_op(c->ctx, r_due), MIR_new_int_op(c->ctx, 0)));
+  mir_emit_bailout_jump_typed(c->ctx, c->jit_func, c->bc_off, c->vs.sp, &c->promote_ctx,
+                              -1, SLOT_BOXED, -1, SLOT_BOXED);
+  c->needs_promote = true;
+}
+
 void jit_emit_control(jit_compile_t *c) {
   switch (c->op) {
     case OP_JMP:
@@ -8,6 +35,7 @@ void jit_emit_control(jit_compile_t *c) {
       bool short_op = (c->op == OP_JMP8);
       int target = c->bc_off + c->sz + (short_op ? (int8_t)sv_get_i8(c->ip + 1) : sv_get_i32(c->ip + 1));
       MIR_label_t lbl = label_for_branch(c->ctx, &c->lm, target, c->vs.sp);
+      if (c->cold_tier && target <= c->bc_off) jit_emit_promote_check(c, lbl);
       MIR_append_insn(c->ctx, c->jit_func,
                       MIR_new_insn(c->ctx, MIR_JMP, MIR_new_label_op(c->ctx, lbl)));
       break;

--- a/src/jit/emit_control.c
+++ b/src/jit/emit_control.c
@@ -19,9 +19,16 @@ static void jit_emit_promote_check(jit_compile_t *c, MIR_label_t loop) {
                                     MIR_new_reg_op(c->ctx, r_due),
                                     MIR_new_uint_op(c->ctx, (uint64_t)(uintptr_t)c->func),
                                     MIR_new_reg_op(c->ctx, c->r_promote_t0)));
+  MIR_label_t due = MIR_new_label(c->ctx);
   MIR_append_insn(c->ctx, c->jit_func,
-                  MIR_new_insn(c->ctx, MIR_BEQ, MIR_new_label_op(c->ctx, loop),
+                  MIR_new_insn(c->ctx, MIR_BEQ, MIR_new_label_op(c->ctx, due),
                                MIR_new_reg_op(c->ctx, r_due), MIR_new_int_op(c->ctx, 0)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_MOV, MIR_new_reg_op(c->ctx, c->r_promote_t0),
+                               MIR_new_reg_op(c->ctx, r_due)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_JMP, MIR_new_label_op(c->ctx, loop)));
+  MIR_append_insn(c->ctx, c->jit_func, due);
   mir_emit_bailout_jump_typed(c->ctx, c->jit_func, c->bc_off, c->vs.sp, &c->promote_ctx,
                               -1, SLOT_BOXED, -1, SLOT_BOXED);
   c->needs_promote = true;

--- a/src/jit/jit_internal.h
+++ b/src/jit/jit_internal.h
@@ -27,6 +27,11 @@
 static constexpr int JIT_VSTACK_SLACK = 4;
 static constexpr int JIT_PARAM_HOIST_CAP = 8;
 static constexpr int JIT_OSR_COLD_COMPILE_MIN_BYTES = 512;
+
+static constexpr int64_t JIT_HOT_COMPILE_NS_PER_BYTE = 50000;
+static constexpr int64_t JIT_COLD_PROMOTE_COMPILE_MULTIPLE = 8;
+static constexpr int64_t JIT_COLD_PROMOTE_CHECK_EVERY = 4096;
+
 static constexpr uint32_t JIT_HOT_COMPILE_BACKEDGE_THRESHOLD = SV_JIT_OSR_THRESHOLD / 8;
 
 typedef struct {

--- a/src/jit/runtime.c
+++ b/src/jit/runtime.c
@@ -13,10 +13,14 @@ int64_t jit_helper_promote_now(void) {
 }
 
 int64_t jit_helper_promote_due(sv_func_t *func, int64_t t0) {
-  int64_t budget = 
-    JIT_COLD_PROMOTE_COMPILE_MULTIPLE * 
+  int64_t budget =
+    JIT_COLD_PROMOTE_COMPILE_MULTIPLE *
     JIT_HOT_COMPILE_NS_PER_BYTE * (int64_t)func->code_len;
-  return jit_helper_promote_now() - t0 >= budget;
+  
+  int64_t now = jit_helper_promote_now();
+  func->jit_cold_ns += now - t0;
+  
+  return func->jit_cold_ns >= budget ? 0 : now;
 }
 
 void jit_load_externals_once(sv_jit_ctx_t *jc) {

--- a/src/jit/runtime.c
+++ b/src/jit/runtime.c
@@ -1,6 +1,23 @@
 #include "jit_internal.h"
+#include <time.h>
 
-void *jit_helper_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure);
+void *jit_helper_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure) {
+  if (!func->jit_code_cold) return NULL;
+  return (void *)sv_jit_tier_up(js, func, closure);
+}
+
+int64_t jit_helper_promote_now(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+}
+
+int64_t jit_helper_promote_due(sv_func_t *func, int64_t t0) {
+  int64_t budget = 
+    JIT_COLD_PROMOTE_COMPILE_MULTIPLE * 
+    JIT_HOT_COMPILE_NS_PER_BYTE * (int64_t)func->code_len;
+  return jit_helper_promote_now() - t0 >= budget;
+}
 
 void jit_load_externals_once(sv_jit_ctx_t *jc) {
   if (jc == NULL || jc->externals_loaded) return;
@@ -56,6 +73,9 @@ void jit_load_externals_once(sv_jit_ctx_t *jc) {
   LOAD_EXT(jit_helper_to_propkey);
   LOAD_EXT(js_template_to_string);
   LOAD_EXT(jit_helper_bailout_resume);
+  LOAD_EXT(jit_helper_promote_resume);
+  LOAD_EXT(jit_helper_promote_now);
+  LOAD_EXT(jit_helper_promote_due);
   LOAD_EXT(jit_helper_close_upval);
   LOAD_EXT(jit_helper_upval_barrier);
   LOAD_EXT(jit_helper_adopt_open_upvalues);
@@ -205,11 +225,6 @@ sv_jit_func_t sv_jit_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure) 
   return hot;
 }
 
-void *jit_helper_tier_up(ant_t *js, sv_func_t *func, sv_closure_t *closure) {
-  if (!func->jit_code_cold) return NULL;
-  return (void *)sv_jit_tier_up(js, func, closure);
-}
-
 ant_value_t sv_jit_try_osr(
     sv_vm_t *vm, ant_t *js,
     sv_frame_t *frame, sv_func_t *func,
@@ -246,20 +261,25 @@ ant_value_t sv_jit_try_osr(
   if (func->jit_code) {
     jit = (sv_jit_func_t)func->jit_code;
   } else {
-    bool prefer_cold = func->code_len > JIT_OSR_COLD_COMPILE_MIN_BYTES;
-    jit = sv_jit_compile_tier(js, func, closure,
-                              prefer_cold ? SV_JIT_TIER_COLD : SV_JIT_TIER_AUTO);
+    sv_jit_tier_t tier = sv_jit_promote_pending(func) ? SV_JIT_TIER_HOT
+     : func->code_len > JIT_OSR_COLD_COMPILE_MIN_BYTES 
+     ? SV_JIT_TIER_COLD : SV_JIT_TIER_AUTO;
+    
+    jit = sv_jit_compile_tier(js, func, closure, tier);
+    
     if (sv_jit_warn_unlikely) fprintf(
       stderr, "jit: osr %s func=%s code_len=%d threshold=%u tier=%s\n",
       jit ? "compiled" : "compile-failed",
       func->debug->name ? func->debug->name : "<anonymous>",
       func->code_len, func->jit_osr_threshold,
-      prefer_cold ? "cold" : "auto"
+      tier == SV_JIT_TIER_HOT ? "hot" : tier == SV_JIT_TIER_COLD ? "cold" : "auto"
     );
+    
     if (!jit) {
       if (synthetic_closure) gc_pop_roots(js, root_mark);
       return SV_JIT_RETRY_INTERP;
     }
+    
     func->jit_code = (void *)jit;
     sv_jit_compile_callees(js, func);
   }

--- a/src/jit/setup_frame.c
+++ b/src/jit/setup_frame.c
@@ -8,6 +8,61 @@ static void jit_discard_setup_module(jit_compile_t *c) {
   MIR_remove_module(c->ctx, c->mod);
 }
 
+static void jit_emit_cold_entry_counter(jit_compile_t *c, const char *site) {
+  if (!c->cold_tier) return;
+  char fn_name[32], calls_name[32], hot_name[32], res_name[32];
+  snprintf(fn_name, sizeof fn_name, "tier_fn_%s", site);
+  snprintf(calls_name, sizeof calls_name, "tier_calls_%s", site);
+  snprintf(hot_name, sizeof hot_name, "tier_hot_%s", site);
+  snprintf(res_name, sizeof res_name, "tier_res_%s", site);
+
+  MIR_label_t body = MIR_new_label(c->ctx);
+  MIR_reg_t r_fn = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, fn_name);
+  MIR_reg_t r_calls = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, calls_name);
+  MIR_reg_t r_hot = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, hot_name);
+  MIR_reg_t r_res = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_JSVAL, res_name);
+  MIR_op_t call_count = MIR_new_mem_op(c->ctx, MIR_T_U32,
+                                       (MIR_disp_t)offsetof(sv_func_t, call_count), r_fn, 0, 1);
+  mir_load_imm(c->ctx, c->jit_func, r_fn, (uint64_t)(uintptr_t)c->func);
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_MOV, MIR_new_reg_op(c->ctx, r_calls), call_count));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_ADD, MIR_new_reg_op(c->ctx, r_calls),
+                               MIR_new_reg_op(c->ctx, r_calls), MIR_new_int_op(c->ctx, 1)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_MOV, call_count, MIR_new_reg_op(c->ctx, r_calls)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_UBLE, MIR_new_label_op(c->ctx, body),
+                               MIR_new_reg_op(c->ctx, r_calls),
+                               MIR_new_int_op(c->ctx, SV_JIT_THRESHOLD)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_call_insn(c->ctx, 6,
+                                    MIR_new_ref_op(c->ctx, c->tier_up_proto),
+                                    MIR_new_ref_op(c->ctx, c->imp_tier_up),
+                                    MIR_new_reg_op(c->ctx, r_hot),
+                                    MIR_new_reg_op(c->ctx, c->r_js),
+                                    MIR_new_reg_op(c->ctx, r_fn),
+                                    MIR_new_reg_op(c->ctx, c->r_closure)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_insn(c->ctx, MIR_BEQ, MIR_new_label_op(c->ctx, body),
+                               MIR_new_reg_op(c->ctx, r_hot), MIR_new_int_op(c->ctx, 0)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_call_insn(c->ctx, 10,
+                                    MIR_new_ref_op(c->ctx, c->self_proto),
+                                    MIR_new_reg_op(c->ctx, r_hot),
+                                    MIR_new_reg_op(c->ctx, r_res),
+                                    MIR_new_reg_op(c->ctx, c->r_vm),
+                                    MIR_new_reg_op(c->ctx, c->r_this),
+                                    MIR_new_reg_op(c->ctx, c->r_new_target),
+                                    MIR_new_reg_op(c->ctx, c->r_super_val),
+                                    MIR_new_reg_op(c->ctx, c->r_args),
+                                    MIR_new_reg_op(c->ctx, c->r_argc),
+                                    MIR_new_reg_op(c->ctx, c->r_closure)));
+  MIR_append_insn(c->ctx, c->jit_func,
+                  MIR_new_ret_insn(c->ctx, 1, MIR_new_reg_op(c->ctx, r_res)));
+  MIR_append_insn(c->ctx, c->jit_func, body);
+}
+
 bool jit_setup_frame(jit_compile_t *c) {
   char fname[128];
   snprintf(fname, sizeof(fname), "jit_%s_%p",
@@ -90,54 +145,6 @@ bool jit_setup_frame(jit_compile_t *c) {
     MIR_append_insn(c->ctx, c->jit_func,
                     MIR_new_ret_insn(c->ctx, 1, MIR_new_reg_op(c->ctx, r_ovf_err)));
     MIR_append_insn(c->ctx, c->jit_func, no_overflow);
-  }
-
-  if (c->cold_tier) {
-    MIR_label_t body = MIR_new_label(c->ctx);
-    MIR_reg_t r_fn = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "tier_fn");
-    MIR_reg_t r_calls = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "tier_calls");
-    MIR_reg_t r_hot = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "tier_hot");
-    MIR_reg_t r_res = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_JSVAL, "tier_res");
-    MIR_op_t call_count = MIR_new_mem_op(c->ctx, MIR_T_U32,
-                                         (MIR_disp_t)offsetof(sv_func_t, call_count), r_fn, 0, 1);
-    mir_load_imm(c->ctx, c->jit_func, r_fn, (uint64_t)(uintptr_t)c->func);
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_insn(c->ctx, MIR_MOV, MIR_new_reg_op(c->ctx, r_calls), call_count));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_insn(c->ctx, MIR_ADD, MIR_new_reg_op(c->ctx, r_calls),
-                                 MIR_new_reg_op(c->ctx, r_calls), MIR_new_int_op(c->ctx, 1)));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_insn(c->ctx, MIR_MOV, call_count, MIR_new_reg_op(c->ctx, r_calls)));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_insn(c->ctx, MIR_UBLE, MIR_new_label_op(c->ctx, body),
-                                 MIR_new_reg_op(c->ctx, r_calls),
-                                 MIR_new_int_op(c->ctx, SV_JIT_THRESHOLD)));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_call_insn(c->ctx, 6,
-                                      MIR_new_ref_op(c->ctx, c->tier_up_proto),
-                                      MIR_new_ref_op(c->ctx, c->imp_tier_up),
-                                      MIR_new_reg_op(c->ctx, r_hot),
-                                      MIR_new_reg_op(c->ctx, c->r_js),
-                                      MIR_new_reg_op(c->ctx, r_fn),
-                                      MIR_new_reg_op(c->ctx, c->r_closure)));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_insn(c->ctx, MIR_BEQ, MIR_new_label_op(c->ctx, body),
-                                 MIR_new_reg_op(c->ctx, r_hot), MIR_new_int_op(c->ctx, 0)));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_call_insn(c->ctx, 10,
-                                      MIR_new_ref_op(c->ctx, c->self_proto),
-                                      MIR_new_reg_op(c->ctx, r_hot),
-                                      MIR_new_reg_op(c->ctx, r_res),
-                                      MIR_new_reg_op(c->ctx, c->r_vm),
-                                      MIR_new_reg_op(c->ctx, c->r_this),
-                                      MIR_new_reg_op(c->ctx, c->r_new_target),
-                                      MIR_new_reg_op(c->ctx, c->r_super_val),
-                                      MIR_new_reg_op(c->ctx, c->r_args),
-                                      MIR_new_reg_op(c->ctx, c->r_argc),
-                                      MIR_new_reg_op(c->ctx, c->r_closure)));
-    MIR_append_insn(c->ctx, c->jit_func,
-                    MIR_new_ret_insn(c->ctx, 1, MIR_new_reg_op(c->ctx, r_res)));
-    MIR_append_insn(c->ctx, c->jit_func, body);
   }
 
   c->vs = (jit_vstack_t){0};
@@ -265,6 +272,7 @@ bool jit_setup_frame(jit_compile_t *c) {
     mir_i64_to_d(c->ctx, c->jit_func, c->r_d_one, c->r_bool, c->r_d_slot);
   }
 
+  if (c->cold_tier) c->feat.needs_args_buf = true;
   c->r_args_buf = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "args_buf");
   if (c->feat.needs_args_buf) {
     int scratch_slots = SV_JIT_ARGS_BUF_CAP;
@@ -485,7 +493,7 @@ bool jit_setup_frame(jit_compile_t *c) {
         c->captured_params, c->param_count, c->writes_params);
   }
 
-  c->needs_lbuf = c->needs_bailout || c->feat.needs_close_upval || c->has_captures;
+  c->needs_lbuf = c->needs_bailout || c->feat.needs_close_upval || c->has_captures || c->cold_tier;
   c->r_lbuf = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "lbuf");
   if (c->use_unified_slotbuf && c->n_locals > 0) {
     MIR_append_insn(c->ctx, c->jit_func,
@@ -517,19 +525,35 @@ bool jit_setup_frame(jit_compile_t *c) {
   }
 
   c->bailout_ctx = (jit_bailout_emit_t){
-      .val = c->r_bailout_val,
-      .off = c->r_bailout_off,
-      .sp = c->r_bailout_sp,
-      .tramp = c->bailout_tramp,
-      .args_buf = c->r_args_buf,
-      .vstack = &c->vs,
-      .local_regs = c->local_regs,
-      .local_d_regs = c->local_d_regs,
-      .dnum_locals = c->dnum_locals,
-      .n_locals = c->n_locals,
-      .lbuf = c->r_lbuf,
-      .d_slot = c->r_d_slot,
+    .val = c->r_bailout_val,
+    .off = c->r_bailout_off,
+    .sp = c->r_bailout_sp,
+    .tramp = c->bailout_tramp,
+    .args_buf = c->r_args_buf,
+    .vstack = &c->vs,
+    .local_regs = c->local_regs,
+    .local_d_regs = c->local_d_regs,
+    .dnum_locals = c->dnum_locals,
+    .n_locals = c->n_locals,
+    .lbuf = c->r_lbuf,
+    .d_slot = c->r_d_slot,
   };
+  
+  if (c->cold_tier) {
+    c->promote_tramp = MIR_new_label(c->ctx);
+    c->promote_ctx = c->bailout_ctx;
+    c->promote_ctx.tramp = c->promote_tramp;
+    c->r_promote = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "promote_edges");
+    c->r_promote_t0 = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "promote_t0");
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_insn(c->ctx, MIR_MOV, MIR_new_reg_op(c->ctx, c->r_promote),
+                                 MIR_new_int_op(c->ctx, 0)));
+    MIR_append_insn(c->ctx, c->jit_func,
+                    MIR_new_call_insn(c->ctx, 3,
+                                      MIR_new_ref_op(c->ctx, c->promote_now_proto),
+                                      MIR_new_ref_op(c->ctx, c->imp_promote_now),
+                                      MIR_new_reg_op(c->ctx, c->r_promote_t0)));
+  }
 
   if (c->feat.needs_tco_args) {
     MIR_append_insn(c->ctx, c->jit_func,
@@ -694,6 +718,7 @@ bool jit_setup_frame(jit_compile_t *c) {
       }
     }
 
+    jit_emit_cold_entry_counter(c, "osr");
     if (c->has_captured_params && c->r_jit_open_upvalues) {
       MIR_append_insn(c->ctx, c->jit_func,
                       MIR_new_call_insn(c->ctx, 7,
@@ -782,6 +807,7 @@ bool jit_setup_frame(jit_compile_t *c) {
 
     MIR_append_insn(c->ctx, c->jit_func, normal_entry);
   }
+  jit_emit_cold_entry_counter(c, "call");
 
   memset(c->jit_try_stack, 0, sizeof(c->jit_try_stack));
   c->jit_try_depth = 0;

--- a/src/jit/setup_prototypes.c
+++ b/src/jit/setup_prototypes.c
@@ -387,6 +387,13 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
                                          MIR_T_I64, "vm",
                                          MIR_T_I64, "js");
 
+  MIR_type_t i64_ret = MIR_T_I64;
+  c->promote_now_proto = MIR_new_proto(c->ctx, "promote_now_proto", 1, &i64_ret, 0);
+  c->promote_due_proto = MIR_new_proto(c->ctx, "promote_due_proto",
+                                       1, &i64_ret, 2,
+                                       MIR_T_I64, "func",
+                                       MIR_T_I64, "t0");
+
   MIR_type_t tier_ret = MIR_T_I64;
   c->tier_up_proto = MIR_new_proto(c->ctx, "tier_up_proto",
                                    1, &tier_ret, 3,
@@ -632,6 +639,9 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
   c->imp_to_propkey = MIR_new_import(c->ctx, "jit_helper_to_propkey");
   c->imp_to_string = MIR_new_import(c->ctx, "js_template_to_string");
   c->imp_resume = MIR_new_import(c->ctx, "jit_helper_bailout_resume");
+  c->imp_promote_resume = MIR_new_import(c->ctx, "jit_helper_promote_resume");
+  c->imp_promote_now = MIR_new_import(c->ctx, "jit_helper_promote_now");
+  c->imp_promote_due = MIR_new_import(c->ctx, "jit_helper_promote_due");
   c->imp_close_upval = MIR_new_import(c->ctx, "jit_helper_close_upval");
   c->imp_upval_barrier = MIR_new_import(c->ctx, "jit_helper_upval_barrier");
   c->imp_adopt_open_upvalues = MIR_new_import(c->ctx, "jit_helper_adopt_open_upvalues");

--- a/src/silver/glue.c
+++ b/src/silver/glue.c
@@ -9,6 +9,7 @@
 #include "gc/roots.h"
 #include "tokens.h"
 #include "silver/glue.h"
+#include "silver/jit.h"
 #include "modules/regex.h"
 #include "modules/collections.h"
 
@@ -1214,7 +1215,7 @@ void jit_helper_adopt_open_upvalues(sv_vm_t *vm, sv_upvalue_t **open_upvalues) {
   }
 }
 
-ant_value_t jit_helper_bailout_resume(
+static ant_value_t jit_resume_in_interpreter(
   sv_vm_t *vm, sv_closure_t *closure,
   ant_value_t this_val, ant_value_t new_target, ant_value_t super_val,
   ant_value_t *args, int argc,
@@ -1223,10 +1224,6 @@ ant_value_t jit_helper_bailout_resume(
   ant_value_t *locals, int64_t n_locals,
   int64_t bc_offset
 ) {
-  if (!closure || !closure->func) return mkval(kTypeError, 0);
-  sv_func_t *fn = closure->func;
-  sv_jit_on_bailout_at(fn, "resume", (int)bc_offset);
-
   vm->jit_resume.active     = true;
   vm->jit_resume.ip_offset  = (int)bc_offset;
   vm->jit_resume.params     = params;
@@ -1239,6 +1236,55 @@ ant_value_t jit_helper_bailout_resume(
   return sv_execute_closure_entry(
     vm, closure, mkref(kTypeFunction, closure),
     super_val, new_target, this_val, args, argc, NULL
+  );
+}
+
+ant_value_t jit_helper_bailout_resume(
+  sv_vm_t *vm, sv_closure_t *closure,
+  ant_value_t this_val, ant_value_t new_target, ant_value_t super_val,
+  ant_value_t *args, int argc,
+  ant_value_t *vstack, int64_t vstack_sp,
+  ant_value_t *params, int64_t n_params,
+  ant_value_t *locals, int64_t n_locals,
+  int64_t bc_offset
+) {
+  if (!closure || !closure->func) return mkval(kTypeError, 0);
+  sv_jit_on_bailout_at(closure->func, "resume", (int)bc_offset);
+  
+  return jit_resume_in_interpreter(
+    vm, closure, this_val, new_target, super_val,
+    args, argc, vstack, vstack_sp, params, n_params,
+    locals, n_locals, bc_offset
+  );
+}
+
+ant_value_t jit_helper_promote_resume(
+  sv_vm_t *vm, sv_closure_t *closure,
+  ant_value_t this_val, ant_value_t new_target, ant_value_t super_val,
+  ant_value_t *args, int argc,
+  ant_value_t *vstack, int64_t vstack_sp,
+  ant_value_t *params, int64_t n_params,
+  ant_value_t *locals, int64_t n_locals,
+  int64_t bc_offset
+) {
+  if (!closure || !closure->func) return mkval(kTypeError, 0);
+  sv_func_t *fn = closure->func;
+
+  if (fn->jit_code_cold) {
+    fn->jit_code = NULL;
+    if (sv_jit_warn_unlikely) fprintf(
+      stderr, "jit: promote func=%s at bc=%d\n", 
+      fn->debug->name ? fn->debug->name : "<anonymous>", (int)bc_offset
+    );
+  }
+  
+  if (sv_jit_promote_pending(fn) || fn->jit_code)
+    fn->back_edge_count = fn->jit_osr_threshold > 0 ? fn->jit_osr_threshold - 1 : 0;
+  
+  return jit_resume_in_interpreter(
+    vm, closure, this_val, new_target, super_val,
+    args, argc, vstack, vstack_sp, params, n_params,
+    locals, n_locals, bc_offset
   );
 }
 

--- a/tests/test_jit_osr_large_function.cjs
+++ b/tests/test_jit_osr_large_function.cjs
@@ -112,4 +112,20 @@ console.log('done');
   if (lines.some(line => line.includes('jit: bailout')))
     throw new Error(`long loop: promotion must not count as a bailout:\n${lines.join('\n')}`);
 }
+
+// Repeated calls that are each shorter than the budget must still promote:
+// cold time is banked on the function across activations, so the kernel
+// called four times for ~175 ms each promotes during the second call.
+const repeated = kernel + String.raw`
+for (var k = 0; k < 4; k++)
+  if (benchNbody(300, 120) !== 209399.109) throw new Error('repeated call checksum mismatch');
+console.log('done');
+`;
+{
+  const lines = run(repeated);
+  if (!lines.some(line => line.startsWith('jit: promote func=benchNbody')))
+    throw new Error(`repeated calls: expected a promotion, got:\n${lines.join('\n')}`);
+  if (!lines.some(line => line.startsWith('jit: osr compiled func=benchNbody') && line.includes('tier=hot')))
+    throw new Error(`repeated calls: expected a hot OSR recompile, got:\n${lines.join('\n')}`);
+}
 console.log('jit-osr-large-function: ok');

--- a/tests/test_jit_osr_large_function.cjs
+++ b/tests/test_jit_osr_large_function.cjs
@@ -90,4 +90,26 @@ if (Math.round(compiledDriver() * 1000) / 1000 !== 791187.692) throw new Error('
 console.log('done');
 `;
 expectTierUp(run(compiledCaller), 'compiled caller');
+
+// A single long call: cold code must hand the loop back once this run has
+// spent JIT_COLD_PROMOTE_COMPILE_MULTIPLE estimated hot-compile times on
+// cold code (~240 ms for this kernel), and the OSR recompile that follows
+// must go straight to the hot tier. 800 steps is ~1.05 s cold on an M-series
+// laptop, over four times the budget, so a much faster machine still
+// promotes. (At 1000 steps ant and node diverge in the last digits: the
+// system is chaotic and amplifies a one-ulp libm difference. Every ant tier
+// agrees with itself; the checksum below is agreed by node too.)
+const longLoop = kernel + String.raw`
+if (benchNbody(300, 800) !== 216448.41) throw new Error('long loop checksum mismatch');
+console.log('done');
+`;
+{
+  const lines = run(longLoop);
+  if (!lines.some(line => line.startsWith('jit: promote func=benchNbody')))
+    throw new Error(`long loop: expected an in-loop promotion, got:\n${lines.join('\n')}`);
+  if (!lines.some(line => line.startsWith('jit: osr compiled func=benchNbody') && line.includes('tier=hot')))
+    throw new Error(`long loop: expected a hot OSR recompile, got:\n${lines.join('\n')}`);
+  if (lines.some(line => line.includes('jit: bailout')))
+    throw new Error(`long loop: promotion must not count as a bailout:\n${lines.join('\n')}`);
+}
 console.log('jit-osr-large-function: ok');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Long-running cold-tier code can now be promoted to the hot tier while execution remains inside a loop.
  - Tier promotion uses elapsed execution time and accumulated activity across calls to determine when recompilation should occur.
  - Promotion resumes execution safely and triggers hot-tier OSR compilation.

- **Bug Fixes**
  - Bailouts now correctly clear cold-tier status, ensuring subsequent compilation uses the appropriate tier.

- **Tests**
  - Added coverage for in-loop promotion, repeated-call promotion, hot-tier recompilation, and promotion without bailouts.

- **Documentation**
  - Updated runtime invariants and execution plans to describe tier promotion behavior and validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->