### PR TITLE
keep the banked cold time in the cold module

### DIFF
--- a/docs/exec-plans/active/osr-size-scaled-tiering.md
+++ b/docs/exec-plans/active/osr-size-scaled-tiering.md
@@ -266,9 +266,25 @@ allocated when a deopt-capable op exists, so a cold loop of plain method
 calls segfaulted at the budget (cold tier now forces both); a cold-code
 deopt left `jit_code_cold` set and so bought a hot recompile of the same
 bailout (cleared on deopt, predicate named `sv_jit_promote_pending`).
-Known limits left open: promotion is a pure ~40 ms loss on loops the hot tier cannot
-speed up (helper-bound bodies such as integer `%`); each backward jump
-emits a full spill block, +12% cold compile time at 12 loops.
+Promotion is skipped where it cannot pay. Hot and cold code differ only
+in MIR's optimization level, so the hot tier only speeds up loops whose
+time is in inline code; a loop dominated by calls into C helpers (integer
+`%`, `Math.*`, string and regexp ops) runs at the same speed on both, and
+promoting it cost a 40 ms hot compile for nothing (11% on a 340 ms modulo
+loop). The cold compile now weighs each op inside a loop by its emitted
+MIR: an op with a call before its first unconditional jump is on a helper
+path and counts `JIT_PROMOTE_HELPER_WEIGHT` (16) inline ops; if helper
+weight reaches inline weight the emitted promote checks are removed again
+and the function never promotes (`jit: promote disabled` under op-warn).
+Reading the emitted code rather than an opcode list keeps the estimate
+true as emitters change. Calibration: the modulo loop is 12 inline ops to
+1 helper (disabled), the N-body inner loop ~40 to 1 (promotes); on
+bench-v8 it declines only the regexp blocks and Crypto's string parser.
+The modulo loop now matches the cold-only binary (200 to 214 ms against
+204 to 218). Regression: the helper-bound case in the test.
+
+Known limit left open: each backward jump emits a full spill block, +12%
+cold compile time at 12 loops.
 
 Two pre-existing cliffs surfaced while probing this, neither caused here
 and both left as follow-ups:

--- a/docs/exec-plans/active/osr-size-scaled-tiering.md
+++ b/docs/exec-plans/active/osr-size-scaled-tiering.md
@@ -217,8 +217,8 @@ A once-called function that never leaves its OSR'd cold loop used to stay
 on level-1 code for the whole call. Cold-tier code now reads the monotonic
 clock at entry, counts back-edges in a register (`r_promote`,
 `emit_control.c`), and every 4096 of them calls `jit_helper_promote_due`,
-which banks the cold time since the last check on `sv_func_t.jit_cold_ns`
-(reset at each cold compile) and hands back a fresh `t0`, or 0 once the
+which banks the cold time since the last check in an 8-byte bss item of
+the cold code's own MIR module (zeroed on load, discarded with the code) and hands back a fresh `t0`, or 0 once the
 function has spent `JIT_COLD_PROMOTE_COMPILE_MULTIPLE` (8) estimated
 hot-compile times (`JIT_HOT_COMPILE_NS_PER_BYTE` x `code_len`) on cold
 code across any number of activations. Banking per check rather than per
@@ -227,8 +227,9 @@ the common driver-loop shape: eight 120-step calls went from 1329 ms cold
 to 1195 ms, promoting during the second call, against 1092 ms hot from
 the start. Idle time between calls is never charged. When the budget is
 spent it takes a second resume trampoline into `jit_helper_promote_resume`.
-`sizeof(sv_func_t)` is 216 for the field; a saturating 32-bit variant in
-64 ns units fit the tail padding but was rejected for its truncation. That unpublishes the cold code,
+The counter is state of the cold code, not of the function, so it lives in
+the code's module and `sizeof(sv_func_t)` stays 208; an `int64_t` field
+(216) and a saturating 32-bit tail-padding variant were both tried first. That unpublishes the cold code,
 leaves `jit_code_cold` set as the "next compile is hot" mark, primes
 `back_edge_count` to one below the OSR threshold and resumes the interpreter
 at the jump. The interpreter re-executes the back-edge, `sv_jit_try_osr`

--- a/include/silver/engine.h
+++ b/include/silver/engine.h
@@ -359,7 +359,6 @@ struct sv_func {
   
   sv_call_target_fb_t *call_target_fb;
   uint64_t gc_epoch;
-  int64_t jit_cold_ns;
 
   int code_len;
   int const_count;

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -440,7 +440,6 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
 
   c->func->jit_compiled_tfb_ver = c->func->tfb_version;
   c->func->jit_code_cold = tier == SV_JIT_TIER_COLD;
-  if (tier == SV_JIT_TIER_COLD) c->func->jit_cold_ns = 0;
   
   if (sv_jit_warn_unlikely) fprintf(
     stderr, "jit: compiled func=%s code_len=%d max_stack=%d tier=%s\n",

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -353,6 +353,17 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
         break;
     }
 
+    if (c->loop_ops && c->loop_ops[c->bc_off] && !(sv_op_flags[c->op] & (SV_OPF_JIT_BRANCH32 | SV_OPF_JIT_BRANCH8))) {
+      bool helper = false;
+      
+      for (MIR_insn_t insn = DLIST_NEXT(MIR_insn_t, c->previous_insn); insn; insn = DLIST_NEXT(MIR_insn_t, insn)) {
+        if (insn->code == MIR_JMP) break;
+        if (MIR_call_code_p(insn->code)) { helper = true; break; }
+      }
+      
+      if (helper) c->promote_helper_ops++; else c->promote_inline_ops++;
+    }
+    
     for (MIR_insn_t insn = DLIST_NEXT(MIR_insn_t, c->previous_insn); insn;
          insn = DLIST_NEXT(MIR_insn_t, insn)) {
       if (c->op != OP_GET_ELEM && MIR_call_code_p(insn->code)) c->element_available = false;
@@ -384,6 +395,26 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
     jit_emit_exit_ret(c, MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)));
   }
 
+  if (c->needs_promote &&
+      c->promote_inline_ops <= c->promote_helper_ops * JIT_PROMOTE_HELPER_WEIGHT) {
+    for (int i = 0; i < c->promote_check_count; i++) {
+      MIR_insn_t insn = DLIST_NEXT(MIR_insn_t, c->promote_checks[i].start);
+      MIR_insn_t last = c->promote_checks[i].end;
+      while (insn) {
+        MIR_insn_t next = insn == last ? NULL : DLIST_NEXT(MIR_insn_t, insn);
+        MIR_remove_insn(c->ctx, c->jit_func, insn);
+        insn = next;
+      }
+    }
+    
+    if (sv_jit_warn_unlikely) fprintf(
+      stderr, "jit: promote disabled func=%s inline=%d helper=%d\n",
+      c->func->debug->name ? c->func->debug->name : "<anonymous>",
+      c->promote_inline_ops, c->promote_helper_ops
+    );
+    
+    c->needs_promote = false;
+  }
   if (c->needs_bailout) jit_emit_resume_tramp(c, c->bailout_tramp, c->imp_resume, "resume_res");
   if (c->needs_promote) jit_emit_resume_tramp(c, c->promote_tramp, c->imp_promote_resume, "promote_res");
 
@@ -413,6 +444,8 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
   free(c->captured_params);
   free(c->captured_locals);
   free(c->feat.builder_target_slots);
+  free(c->loop_ops);
+  free(c->promote_checks);
 
   if (!c->ok) {
     if (sv_jit_warn_unlikely) fprintf(

--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -270,6 +270,10 @@ typedef struct jit_compile {
   bool use_jit_upvalue_list;
   jit_bailout_emit_t bailout_ctx;
   jit_bailout_emit_t promote_ctx;
+  uint8_t *loop_ops;
+  int promote_inline_ops, promote_helper_ops;
+  struct { MIR_insn_t start, end; } *promote_checks;
+  int promote_check_count, promote_check_cap;
   jit_label_map_t lm;
   osr_entry_map_t osr_map;
   jit_try_entry_t jit_try_stack[JIT_TRY_MAX];

--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -48,6 +48,7 @@ typedef struct jit_compile {
   MIR_item_t truthy_proto;
   MIR_item_t resume_proto;
   MIR_item_t promote_now_proto;
+  MIR_item_t cold_ns_item;
   MIR_item_t promote_due_proto;
   MIR_item_t closure_proto;
   MIR_item_t close_upval_proto;

--- a/src/jit/emit_control.c
+++ b/src/jit/emit_control.c
@@ -13,12 +13,15 @@ static void jit_emit_promote_check(jit_compile_t *c, MIR_label_t loop) {
                   MIR_new_insn(c->ctx, MIR_BNE, MIR_new_label_op(c->ctx, loop),
                                MIR_new_reg_op(c->ctx, r_due), MIR_new_int_op(c->ctx, 0)));
   MIR_append_insn(c->ctx, c->jit_func,
-                  MIR_new_call_insn(c->ctx, 5,
+                  MIR_new_call_insn(c->ctx, 6,
                                     MIR_new_ref_op(c->ctx, c->promote_due_proto),
                                     MIR_new_ref_op(c->ctx, c->imp_promote_due),
                                     MIR_new_reg_op(c->ctx, r_due),
-                                    MIR_new_uint_op(c->ctx, (uint64_t)(uintptr_t)c->func),
-                                    MIR_new_reg_op(c->ctx, c->r_promote_t0)));
+                                    MIR_new_ref_op(c->ctx, c->cold_ns_item),
+                                    MIR_new_reg_op(c->ctx, c->r_promote_t0),
+                                    MIR_new_int_op(c->ctx, JIT_COLD_PROMOTE_COMPILE_MULTIPLE *
+                                                           JIT_HOT_COMPILE_NS_PER_BYTE *
+                                                           (int64_t)c->func->code_len)));
   MIR_label_t due = MIR_new_label(c->ctx);
   MIR_append_insn(c->ctx, c->jit_func,
                   MIR_new_insn(c->ctx, MIR_BEQ, MIR_new_label_op(c->ctx, due),

--- a/src/jit/emit_control.c
+++ b/src/jit/emit_control.c
@@ -2,6 +2,7 @@
 
 static void jit_emit_promote_check(jit_compile_t *c, MIR_label_t loop) {
   MIR_reg_t r_due = c->r_tmp2;
+  MIR_insn_t start = DLIST_TAIL(MIR_insn_t, c->jit_func->u.func->insns);
   MIR_append_insn(c->ctx, c->jit_func,
                   MIR_new_insn(c->ctx, MIR_ADD, MIR_new_reg_op(c->ctx, c->r_promote),
                                MIR_new_reg_op(c->ctx, c->r_promote), MIR_new_int_op(c->ctx, 1)));
@@ -35,6 +36,14 @@ static void jit_emit_promote_check(jit_compile_t *c, MIR_label_t loop) {
   mir_emit_bailout_jump_typed(c->ctx, c->jit_func, c->bc_off, c->vs.sp, &c->promote_ctx,
                               -1, SLOT_BOXED, -1, SLOT_BOXED);
   c->needs_promote = true;
+  if (c->promote_check_count == c->promote_check_cap) {
+    c->promote_check_cap = c->promote_check_cap ? c->promote_check_cap * 2 : 8;
+    c->promote_checks = realloc(c->promote_checks,
+                                (size_t)c->promote_check_cap * sizeof(*c->promote_checks));
+  }
+  c->promote_checks[c->promote_check_count].start = start;
+  c->promote_checks[c->promote_check_count].end = DLIST_TAIL(MIR_insn_t, c->jit_func->u.func->insns);
+  c->promote_check_count++;
 }
 
 void jit_emit_control(jit_compile_t *c) {

--- a/src/jit/jit_internal.h
+++ b/src/jit/jit_internal.h
@@ -26,6 +26,7 @@
 
 static constexpr int JIT_VSTACK_SLACK = 4;
 static constexpr int JIT_PARAM_HOIST_CAP = 8;
+static constexpr int JIT_PROMOTE_HELPER_WEIGHT = 16;
 static constexpr int JIT_OSR_COLD_COMPILE_MIN_BYTES = 512;
 
 static constexpr int64_t JIT_HOT_COMPILE_NS_PER_BYTE = 50000;

--- a/src/jit/runtime.c
+++ b/src/jit/runtime.c
@@ -12,15 +12,10 @@ int64_t jit_helper_promote_now(void) {
   return (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
 }
 
-int64_t jit_helper_promote_due(sv_func_t *func, int64_t t0) {
-  int64_t budget =
-    JIT_COLD_PROMOTE_COMPILE_MULTIPLE *
-    JIT_HOT_COMPILE_NS_PER_BYTE * (int64_t)func->code_len;
-  
+int64_t jit_helper_promote_due(int64_t *cold_ns, int64_t t0, int64_t budget) {
   int64_t now = jit_helper_promote_now();
-  func->jit_cold_ns += now - t0;
-  
-  return func->jit_cold_ns >= budget ? 0 : now;
+  *cold_ns += now - t0;
+  return *cold_ns >= budget ? 0 : now;
 }
 
 void jit_load_externals_once(sv_jit_ctx_t *jc) {

--- a/src/jit/setup_frame.c
+++ b/src/jit/setup_frame.c
@@ -543,6 +543,22 @@ bool jit_setup_frame(jit_compile_t *c) {
     c->promote_tramp = MIR_new_label(c->ctx);
     c->promote_ctx = c->bailout_ctx;
     c->promote_ctx.tramp = c->promote_tramp;
+    c->loop_ops = calloc((size_t)c->func->code_len, 1);
+    if (c->loop_ops) {
+      uint8_t *code = c->func->code;
+      for (int off = 0; off < c->func->code_len; ) {
+        uint8_t op = code[off];
+        int sz = sv_op_size[op];
+        if (sz == 0) break;
+        uint16_t flags = sv_op_flags[op];
+        int target = -1;
+        if (flags & SV_OPF_JIT_BRANCH32) target = off + sz + sv_get_i32(code + off + 1);
+        else if (flags & SV_OPF_JIT_BRANCH8) target = off + sz + (int8_t)sv_get_i8(code + off + 1);
+        if (target >= 0 && target <= off)
+          memset(c->loop_ops + target, 1, (size_t)(off - target + 1));
+        off += sz;
+      }
+    }
     c->r_promote = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "promote_edges");
     c->r_promote_t0 = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "promote_t0");
     MIR_append_insn(c->ctx, c->jit_func,

--- a/src/jit/setup_prototypes.c
+++ b/src/jit/setup_prototypes.c
@@ -390,9 +390,11 @@ void jit_setup_prototypes(jit_compile_t *c, MIR_type_t ret_type) {
   MIR_type_t i64_ret = MIR_T_I64;
   c->promote_now_proto = MIR_new_proto(c->ctx, "promote_now_proto", 1, &i64_ret, 0);
   c->promote_due_proto = MIR_new_proto(c->ctx, "promote_due_proto",
-                                       1, &i64_ret, 2,
-                                       MIR_T_I64, "func",
-                                       MIR_T_I64, "t0");
+                                       1, &i64_ret, 3,
+                                       MIR_T_I64, "cold_ns",
+                                       MIR_T_I64, "t0",
+                                       MIR_T_I64, "budget");
+  if (c->cold_tier) c->cold_ns_item = MIR_new_bss(c->ctx, "cold_ns", sizeof(int64_t));
 
   MIR_type_t tier_ret = MIR_T_I64;
   c->tier_up_proto = MIR_new_proto(c->ctx, "tier_up_proto",

--- a/tests/test_jit_osr_large_function.cjs
+++ b/tests/test_jit_osr_large_function.cjs
@@ -128,4 +128,26 @@ console.log('done');
   if (!lines.some(line => line.startsWith('jit: osr compiled func=benchNbody') && line.includes('tier=hot')))
     throw new Error(`repeated calls: expected a hot OSR recompile, got:\n${lines.join('\n')}`);
 }
+
+// A loop whose time is in helper calls (integer % has no inline path) gains
+// nothing from the hot tier, so the cold compile must not emit the promote
+// check at all, however long the loop runs. The body is padded past 512
+// bytes so the function takes the cold tier; 40M iterations is ~700 ms,
+// three times the budget.
+const pad = Array.from({ length: 56 }, (_, i) => `var p${i} = s * ${i + 2};`).join(' ') +
+  ' var z = (' + Array.from({ length: 56 }, (_, i) => `p${i}`).join(' + ') + ') * 0;';
+const helperBound = String.raw`
+function modLoop(n) { var s = 0; for (var i = 0; i < n; i++) s = (s + i * 7) % 1000003; ${pad} return s + z; }
+if (modLoop(40000000) !== 50820) throw new Error('mod loop checksum mismatch');
+console.log('done');
+`;
+{
+  const lines = run(helperBound);
+  if (!lines.some(line => line.startsWith('jit: osr compiled func=modLoop') && line.includes('tier=cold')))
+    throw new Error(`helper-bound: expected a cold OSR compile, got:\n${lines.join('\n')}`);
+  if (!lines.some(line => line.startsWith('jit: promote disabled func=modLoop')))
+    throw new Error(`helper-bound: expected promotion to be disabled, got:\n${lines.join('\n')}`);
+  if (lines.some(line => line.startsWith('jit: promote func=modLoop')))
+    throw new Error(`helper-bound: must not promote:\n${lines.join('\n')}`);
+}
 console.log('jit-osr-large-function: ok');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved adaptive promotion between cold and hot execution tiers with a dedicated cold-code time budget.
  * Promotion decisions now account for compiled code size, enabling more consistent behavior across functions of different sizes.
  * Cold-tier timing data is scoped to generated code and reset when that code is loaded or discarded.
  * Disabled promotion when helper-heavy loops are unlikely to benefit from hot execution.

* **Documentation**
  * Updated the tiering design documentation to reflect the revised promotion-budget approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->