### PR TITLE
share the local spill block between bail sites

### DIFF
--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -1,9 +1,9 @@
 #include "compile.h"
 #include <time.h>
 
-static void jit_emit_resume_tramp(jit_compile_t *c, MIR_label_t tramp, MIR_item_t imp,
-                                const char *res_name) {
-  MIR_append_insn(c->ctx, c->jit_func, tramp);
+static void jit_emit_resume_tramp(jit_compile_t *c, const jit_bailout_emit_t *bail, MIR_item_t imp, const char *res_name) {
+  mir_emit_bailout_spill_block(c->ctx, c->jit_func, bail);
+  MIR_append_insn(c->ctx, c->jit_func, bail->tramp);
 
   if (c->r_jit_open_upvalues) {
     MIR_append_insn(c->ctx, c->jit_func,
@@ -387,15 +387,8 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
     jit_emit_exit_ret(c, MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)));
   }
 
-  if (c->needs_bailout) {
-    mir_emit_bailout_spill_block(c->ctx, c->jit_func, &c->bailout_ctx);
-    jit_emit_resume_tramp(c, c->bailout_tramp, c->imp_resume, "resume_res");
-  }
-  
-  if (c->needs_promote) {
-    mir_emit_bailout_spill_block(c->ctx, c->jit_func, &c->promote_ctx);
-    jit_emit_resume_tramp(c, c->promote_tramp, c->imp_promote_resume, "promote_res");
-  }
+  if (c->needs_bailout) jit_emit_resume_tramp(c, &c->bailout_ctx, c->imp_resume, "resume_res");
+  if (c->needs_promote) jit_emit_resume_tramp(c, &c->promote_ctx, c->imp_promote_resume, "promote_res");
 
   MIR_finish_func(c->ctx);
   MIR_finish_module(c->ctx);

--- a/src/jit/compile.c
+++ b/src/jit/compile.c
@@ -387,8 +387,15 @@ sv_jit_func_t sv_jit_compile_tier(ant_t *js, sv_func_t *func, sv_closure_t *hint
     jit_emit_exit_ret(c, MIR_new_uint_op(c->ctx, mkval(kTypeUndefined, 0)));
   }
 
-  if (c->needs_bailout) jit_emit_resume_tramp(c, c->bailout_tramp, c->imp_resume, "resume_res");
-  if (c->needs_promote) jit_emit_resume_tramp(c, c->promote_tramp, c->imp_promote_resume, "promote_res");
+  if (c->needs_bailout) {
+    mir_emit_bailout_spill_block(c->ctx, c->jit_func, &c->bailout_ctx);
+    jit_emit_resume_tramp(c, c->bailout_tramp, c->imp_resume, "resume_res");
+  }
+  
+  if (c->needs_promote) {
+    mir_emit_bailout_spill_block(c->ctx, c->jit_func, &c->promote_ctx);
+    jit_emit_resume_tramp(c, c->promote_tramp, c->imp_promote_resume, "promote_res");
+  }
 
   MIR_finish_func(c->ctx);
   MIR_finish_module(c->ctx);

--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -217,6 +217,7 @@ typedef struct jit_compile {
   MIR_reg_t r_bailout_off;
   MIR_reg_t r_bailout_sp;
   MIR_label_t bailout_tramp;
+  MIR_label_t bailout_spill;
   MIR_label_t promote_tramp;
   MIR_reg_t r_promote;
   MIR_reg_t cached_index_key;

--- a/src/jit/compile.h
+++ b/src/jit/compile.h
@@ -217,7 +217,6 @@ typedef struct jit_compile {
   MIR_reg_t r_bailout_off;
   MIR_reg_t r_bailout_sp;
   MIR_label_t bailout_tramp;
-  MIR_label_t bailout_spill;
   MIR_label_t promote_tramp;
   MIR_reg_t r_promote;
   MIR_reg_t cached_index_key;

--- a/src/jit/emit_arithmetic.c
+++ b/src/jit/emit_arithmetic.c
@@ -25,8 +25,7 @@ void jit_emit_arithmetic(jit_compile_t *c) {
             &c->vs, c->ctx, c->jit_func, l_is_num, r_is_num, c->r_d_slot);
         MIR_label_t slow = MIR_new_label(c->ctx);
         MIR_label_t done = MIR_new_label(c->ctx);
-        mir_emit_string_concat_fastpath(
-            c->ctx, c->jit_func, c->r_js, rl, rr, rd, slow, 0, c->bc_off, false);
+        mir_emit_string_concat_fastpath(c->ctx, c->jit_func, c->r_js, rl, rr, rd, slow, -1, c->bc_off, false);
         MIR_append_insn(c->ctx, c->jit_func,
                         MIR_new_insn(c->ctx, MIR_JMP, MIR_new_label_op(c->ctx, done)));
         MIR_append_insn(c->ctx, c->jit_func, slow);
@@ -596,34 +595,7 @@ void jit_emit_arithmetic(jit_compile_t *c) {
                       MIR_new_insn(c->ctx, MIR_JMP, MIR_new_label_op(c->ctx, done)));
 
       MIR_append_insn(c->ctx, c->jit_func, slow);
-      for (int i = 0; i < c->vs.sp; i++) {
-        mir_emit_slot_boxed(
-            c->ctx, c->jit_func, c->vs.regs[i], c->vs.d_regs[i],
-            c->vs.slot_type ? c->vs.slot_type[i] : SLOT_BOXED, c->r_d_slot);
-        MIR_append_insn(c->ctx, c->jit_func,
-                        MIR_new_insn(c->ctx, MIR_MOV,
-                                     MIR_new_mem_op(c->ctx, MIR_T_I64,
-                                                    (MIR_disp_t)(i * (int)sizeof(ant_value_t)), c->r_args_buf, 0, 1),
-                                     MIR_new_reg_op(c->ctx, c->vs.regs[i])));
-      }
-      mir_emit_dnum_rebox(c->ctx, c->jit_func, &c->bailout_ctx);
-      for (int i = 0; i < c->n_locals; i++)
-        MIR_append_insn(c->ctx, c->jit_func,
-                        MIR_new_insn(c->ctx, MIR_MOV,
-                                     MIR_new_mem_op(c->ctx, MIR_T_I64,
-                                                    (MIR_disp_t)(i * (int)sizeof(ant_value_t)), c->r_lbuf, 0, 1),
-                                     MIR_new_reg_op(c->ctx, c->local_regs[i])));
-      MIR_append_insn(c->ctx, c->jit_func,
-                      MIR_new_insn(c->ctx, MIR_MOV,
-                                   MIR_new_reg_op(c->ctx, c->r_bailout_off),
-                                   MIR_new_int_op(c->ctx, c->bc_off)));
-      MIR_append_insn(c->ctx, c->jit_func,
-                      MIR_new_insn(c->ctx, MIR_MOV,
-                                   MIR_new_reg_op(c->ctx, c->r_bailout_sp),
-                                   MIR_new_int_op(c->ctx, c->vs.sp)));
-      MIR_append_insn(c->ctx, c->jit_func,
-                      MIR_new_insn(c->ctx, MIR_JMP,
-                                   MIR_new_label_op(c->ctx, c->bailout_tramp)));
+      mir_emit_bailout_jump_typed(c->ctx, c->jit_func, c->bc_off, c->vs.sp, &c->bailout_ctx, -1, SLOT_BOXED, -1, SLOT_BOXED);
 
       MIR_append_insn(c->ctx, c->jit_func, done);
       break;

--- a/src/jit/emit_strings.c
+++ b/src/jit/emit_strings.c
@@ -182,8 +182,7 @@ void jit_emit_strings(jit_compile_t *c) {
             (!c->known_type_locals || c->known_type_locals[local_idx] != SV_TI_NUM)) {
           MIR_label_t flat_append_slow = MIR_new_label(c->ctx);
           flat_append_done = MIR_new_label(c->ctx);
-          mir_emit_string_concat_fastpath(c->ctx, c->jit_func, c->r_js, lhs, rhs, c->r_tmp,
-                                          flat_append_slow, 0, c->bc_off, true);
+          mir_emit_string_concat_fastpath(c->ctx, c->jit_func, c->r_js, lhs, rhs, c->r_tmp, flat_append_slow, -1, c->bc_off, true);
           MIR_append_insn(c->ctx, c->jit_func, MIR_new_insn(c->ctx, MIR_MOV, MIR_new_reg_op(c->ctx, c->local_regs[local_idx]), MIR_new_reg_op(c->ctx, c->r_tmp)));
           MIR_append_insn(c->ctx, c->jit_func, MIR_new_insn(c->ctx, MIR_MOV, MIR_new_mem_op(c->ctx, MIR_JSVAL, (MIR_disp_t)((size_t)local_idx * sizeof(ant_value_t)), c->r_lbuf, 0, 1), MIR_new_reg_op(c->ctx, c->r_tmp)));
           mir_load_imm(c->ctx, c->jit_func, c->r_err_tmp, js_mkundef());

--- a/src/jit/guards.c
+++ b/src/jit/guards.c
@@ -7,13 +7,10 @@ static uint8_t jit_bailout_slot_type(jit_vstack_t *vs, int idx,
   return vs->slot_type ? vs->slot_type[idx] : SLOT_BOXED;
 }
 
-void mir_emit_dnum_rebox(MIR_context_t ctx, MIR_item_t fn,
-                         const jit_bailout_emit_t *bail) {
+static void mir_emit_dnum_rebox(MIR_context_t ctx, MIR_item_t fn, const jit_bailout_emit_t *bail) {
   if (!bail->dnum_locals) return;
   for (int i = 0; i < bail->n_locals; i++)
-    if (bail->dnum_locals[i])
-      mir_d_to_i64(ctx, fn, bail->local_regs[i], bail->local_d_regs[i],
-                   bail->d_slot);
+    if (bail->dnum_locals[i]) mir_d_to_i64(ctx, fn, bail->local_regs[i], bail->local_d_regs[i], bail->d_slot);
 }
 
 void mir_emit_bailout_jump_typed(MIR_context_t ctx, MIR_item_t fn,

--- a/src/jit/guards.c
+++ b/src/jit/guards.c
@@ -33,13 +33,6 @@ void mir_emit_bailout_jump_typed(MIR_context_t ctx, MIR_item_t fn,
                                                 (MIR_disp_t)(i * (int)sizeof(ant_value_t)), bail->args_buf, 0, 1),
                                  MIR_new_reg_op(ctx, bail->vstack->regs[i])));
   }
-  mir_emit_dnum_rebox(ctx, fn, bail);
-  for (int i = 0; i < bail->n_locals; i++)
-    MIR_append_insn(ctx, fn,
-                    MIR_new_insn(ctx, MIR_MOV,
-                                 MIR_new_mem_op(ctx, MIR_T_I64,
-                                                (MIR_disp_t)(i * (int)sizeof(ant_value_t)), bail->lbuf, 0, 1),
-                                 MIR_new_reg_op(ctx, bail->local_regs[i])));
   MIR_append_insn(ctx, fn,
                   MIR_new_insn(ctx, MIR_MOV,
                                MIR_new_reg_op(ctx, bail->off),
@@ -50,7 +43,19 @@ void mir_emit_bailout_jump_typed(MIR_context_t ctx, MIR_item_t fn,
                                MIR_new_int_op(ctx, pre_op_sp)));
   MIR_append_insn(ctx, fn,
                   MIR_new_insn(ctx, MIR_JMP,
-                               MIR_new_label_op(ctx, bail->tramp)));
+                               MIR_new_label_op(ctx, bail->spill)));
+}
+
+void mir_emit_bailout_spill_block(MIR_context_t ctx, MIR_item_t fn,
+                                  const jit_bailout_emit_t *bail) {
+  MIR_append_insn(ctx, fn, bail->spill);
+  mir_emit_dnum_rebox(ctx, fn, bail);
+  for (int i = 0; i < bail->n_locals; i++)
+    MIR_append_insn(ctx, fn,
+                    MIR_new_insn(ctx, MIR_MOV,
+                                 MIR_new_mem_op(ctx, MIR_T_I64,
+                                                (MIR_disp_t)(i * (int)sizeof(ant_value_t)), bail->lbuf, 0, 1),
+                                 MIR_new_reg_op(ctx, bail->local_regs[i])));
 }
 
 void mir_emit_bailout_check_typed(MIR_context_t ctx, MIR_item_t fn,

--- a/src/jit/jit_internal.h
+++ b/src/jit/jit_internal.h
@@ -210,8 +210,6 @@ void vstack_rebox_binop_operands(
     jit_vstack_t *vs, MIR_context_t ctx, MIR_item_t fn,
     uint8_t lhs_type, uint8_t rhs_type,
     MIR_reg_t d_slot);
-void mir_emit_dnum_rebox(MIR_context_t ctx, MIR_item_t fn,
-                         const jit_bailout_emit_t *bail);
 void mir_emit_bailout_spill_block(MIR_context_t ctx, MIR_item_t fn,
                                   const jit_bailout_emit_t *bail);
 void mir_emit_bailout_jump_typed(MIR_context_t ctx, MIR_item_t fn,

--- a/src/jit/jit_internal.h
+++ b/src/jit/jit_internal.h
@@ -94,6 +94,7 @@ typedef struct {
 typedef struct {
   MIR_reg_t val, off, sp;
   MIR_label_t tramp;
+  MIR_label_t spill;
   MIR_reg_t args_buf;
   jit_vstack_t *vstack;
   MIR_reg_t *local_regs, *local_d_regs;
@@ -211,6 +212,8 @@ void vstack_rebox_binop_operands(
     MIR_reg_t d_slot);
 void mir_emit_dnum_rebox(MIR_context_t ctx, MIR_item_t fn,
                          const jit_bailout_emit_t *bail);
+void mir_emit_bailout_spill_block(MIR_context_t ctx, MIR_item_t fn,
+                                  const jit_bailout_emit_t *bail);
 void mir_emit_bailout_jump_typed(MIR_context_t ctx, MIR_item_t fn,
                                  int bc_off, int pre_op_sp,
                                  const jit_bailout_emit_t *bail,

--- a/src/jit/setup_frame.c
+++ b/src/jit/setup_frame.c
@@ -371,6 +371,7 @@ bool jit_setup_frame(jit_compile_t *c) {
   c->r_bailout_off = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "bail_off");
   c->r_bailout_sp = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "bail_sp");
   c->bailout_tramp = c->needs_bailout ? MIR_new_label(c->ctx) : NULL;
+  c->bailout_spill = c->needs_bailout ? MIR_new_label(c->ctx) : NULL;
 
   c->param_count = c->func->param_count;
   c->writes_params = func_writes_params(c->func);
@@ -529,6 +530,7 @@ bool jit_setup_frame(jit_compile_t *c) {
     .off = c->r_bailout_off,
     .sp = c->r_bailout_sp,
     .tramp = c->bailout_tramp,
+    .spill = c->bailout_spill,
     .args_buf = c->r_args_buf,
     .vstack = &c->vs,
     .local_regs = c->local_regs,
@@ -543,6 +545,7 @@ bool jit_setup_frame(jit_compile_t *c) {
     c->promote_tramp = MIR_new_label(c->ctx);
     c->promote_ctx = c->bailout_ctx;
     c->promote_ctx.tramp = c->promote_tramp;
+    c->promote_ctx.spill = MIR_new_label(c->ctx);
 
     c->promote_sites = calloc((size_t)c->func->code_len, 1);
     if (c->promote_sites) {

--- a/src/jit/setup_frame.c
+++ b/src/jit/setup_frame.c
@@ -371,7 +371,6 @@ bool jit_setup_frame(jit_compile_t *c) {
   c->r_bailout_off = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "bail_off");
   c->r_bailout_sp = MIR_new_func_reg(c->ctx, c->jit_func->u.func, MIR_T_I64, "bail_sp");
   c->bailout_tramp = c->needs_bailout ? MIR_new_label(c->ctx) : NULL;
-  c->bailout_spill = c->needs_bailout ? MIR_new_label(c->ctx) : NULL;
 
   c->param_count = c->func->param_count;
   c->writes_params = func_writes_params(c->func);
@@ -530,7 +529,7 @@ bool jit_setup_frame(jit_compile_t *c) {
     .off = c->r_bailout_off,
     .sp = c->r_bailout_sp,
     .tramp = c->bailout_tramp,
-    .spill = c->bailout_spill,
+    .spill = c->needs_bailout ? MIR_new_label(c->ctx) : NULL,
     .args_buf = c->r_args_buf,
     .vstack = &c->vs,
     .local_regs = c->local_regs,
@@ -552,7 +551,8 @@ bool jit_setup_frame(jit_compile_t *c) {
       uint8_t *code = c->func->code;
       int n = 0, cap = 16;
       int (*edges)[2] = malloc((size_t)cap * sizeof(*edges));
-      for (int off = 0; edges && off < c->func->code_len; ) {
+      bool edges_ok = edges != NULL;
+      for (int off = 0; edges_ok && off < c->func->code_len; ) {
         uint8_t op = code[off];
         int sz = sv_op_size[op];
         if (sz == 0) break;
@@ -561,19 +561,29 @@ bool jit_setup_frame(jit_compile_t *c) {
         if (flags & SV_OPF_JIT_BRANCH32) target = off + sz + sv_get_i32(code + off + 1);
         else if (flags & SV_OPF_JIT_BRANCH8) target = off + sz + (int8_t)sv_get_i8(code + off + 1);
         if (target >= 0 && target <= off) {
-          if (n == cap) { cap *= 2; edges = realloc(edges, (size_t)cap * sizeof(*edges)); if (!edges) break; }
+          if (n == cap) {
+            int (*grown)[2] = realloc(edges, (size_t)cap * 2 * sizeof(*edges));
+            if (!grown) { edges_ok = false; break; }
+            edges = grown;
+            cap *= 2;
+          }
           edges[n][0] = target; edges[n][1] = off; n++;
         }
         off += sz;
       }
-      for (int i = 0; edges && i < n; i++) {
-        bool nested = false, has_inner = false;
-        for (int j = 0; j < n; j++) {
-          if (j == i) continue;
-          if (edges[j][0] <= edges[i][0] && edges[j][1] >= edges[i][1]) nested = true;
-          if (edges[i][0] <= edges[j][0] && edges[j][1] <= edges[i][1]) has_inner = true;
+      if (edges_ok) {
+        for (int i = 0; i < n; i++) {
+          bool nested = false, has_inner = false;
+          for (int j = 0; j < n; j++) {
+            if (j == i) continue;
+            if (edges[j][0] <= edges[i][0] && edges[j][1] >= edges[i][1]) nested = true;
+            if (edges[i][0] <= edges[j][0] && edges[j][1] <= edges[i][1]) has_inner = true;
+          }
+          c->promote_sites[edges[i][1]] = nested ? 0 : has_inner ? 2 : 1;
         }
-        c->promote_sites[edges[i][1]] = nested ? 0 : has_inner ? 2 : 1;
+      } else {
+        free(c->promote_sites);
+        c->promote_sites = NULL;
       }
       free(edges);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT bailout and resume handling for more reliable execution recovery.
  * Corrected string-concatenation fast paths to use the appropriate argument tracking.
  * Improved unary negation bailout handling, including boxed values and local state.
  * Added safer handling for allocation failures during optimization setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->